### PR TITLE
Pass attribute name through to method and function field callables

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -400,8 +400,10 @@ class Method(Raw):
     """A field that takes the value returned by a Serializer method.
 
     :param str method_name: The name of the Serializer method from which
-        to retrieve the value. The method must take a single argument ``obj``
-        (in addition to self) that is the object to be serialized.
+        to retrieve the value. The method must take two arguments, the first is
+        ``key`` identifying the name of the attribute to be serialised and the
+        second is ``obj`` which is the object (in addition to self) that is the
+        object to be serialized.
     """
 
     def __init__(self, method_name):
@@ -410,7 +412,7 @@ class Method(Raw):
 
     def output(self, key, obj):
         try:
-            return getattr(self.parent, self.method_name)(obj)
+            return getattr(self.parent, self.method_name)(key, obj)
         except AttributeError:
             pass
 
@@ -419,8 +421,9 @@ class Function(Raw):
     '''A field that takes the value returned by a function.
 
     :param function func: A callable function from which to retrieve the value.
-        The function must take a single argument ``obj`` which is the object
-        to be serialized.
+        The function must take two arguments, the first is ``key`` identifying
+        the name of the attribute to be serialised and the second is ``obj``
+        which is the object to be serialized.
     '''
 
     def __init__(self, func):
@@ -428,7 +431,7 @@ class Function(Raw):
 
     def output(self, key, obj):
         try:
-            return self.func(obj)
+            return self.func(key, obj)
         except TypeError as te:  # Function is not callable
             raise MarshallingError(te)
         except AttributeError:

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -79,13 +79,13 @@ class UserSerializer(Serializer):
     email = fields.Email()
     balance = fields.Price()
     is_old = fields.Method("get_is_old")
-    lowername = fields.Function(lambda obj: obj.name.lower())
+    lowername = fields.Function(lambda name, obj: obj.name.lower())
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)
     sex_choices = fields.List(fields.Raw)
     finger_count = fields.Integer()
 
-    def get_is_old(self, obj):
+    def get_is_old(self, name, obj):
         try:
             return obj.age > 80
         except TypeError as te:
@@ -96,13 +96,13 @@ class UserMetaSerializer(Serializer):
     uppername = Uppercased(attribute='name')
     balance = fields.Price()
     is_old = fields.Method("get_is_old")
-    lowername = fields.Function(lambda obj: obj.name.lower())
+    lowername = fields.Function(lambda name, obj: obj.name.lower())
     updated_local = fields.LocalDateTime(attribute="updated")
     species = fields.String(attribute="SPECIES")
     homepage = fields.Url()
     email = fields.Email()
 
-    def get_is_old(self, obj):
+    def get_is_old(self, name, obj):
         try:
             return obj.age > 80
         except TypeError as te:
@@ -557,7 +557,7 @@ class TestFields(unittest.TestCase):
         assert_equal(repr(field), "<String Field>")
 
     def test_function_field(self):
-        field = fields.Function(lambda obj: obj.name.upper())
+        field = fields.Function(lambda name, obj: obj.name.upper())
         assert_equal("FOO", field.output("key", self.user))
 
     def test_function_with_uncallable_param(self):


### PR DESCRIPTION
As the branch name says, this is a suggestion. I've been looking into a use case for a serializer that has several `Method` fields that serialise different attributes but basically do the same thing. Unfortunately, within the callables used by the `Method` and `Function` field, I don't know anything about the attribute name of the field. It would be nice to have that, especially since the `key` value is available in the `to_output` methods of the fields and just needs to be passed in. A simple example would be something like this:

```
class CustomSerializer(Serializer):
    first_name = fields.Method('get_lowercase_attribute')
    last_name = fields.Method('get_lowercase_attribute')

    def get_lowercase_attribute(self, key, obj):
        return getattr(obj, key)
```

I've added the argument to both fields in this PR. This will cause problems for existing code that uses these fields so I would be good to get your input on whether you want backwards compatibility or not. What are your thoughts?
