### PR TITLE
Fix integer default

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -377,6 +377,10 @@ class Integer(Number):
 
     num_type = int
 
+    def __init__(self, default=0, attribute=None, as_string=False, error=None, **kwargs):
+        self.as_string = as_string
+        super(Number, self).__init__(default=default, attribute=attribute,
+            error=error, **kwargs)
 
 class Boolean(Raw):
     '''A boolean field.'''

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -329,6 +329,12 @@ class TestSerializer(unittest.TestCase):
         assert_equal(type(serialized.data['age']), int)
         assert_equal(serialized.data['age'], 42)
 
+    def test_integer_default(self):
+        user = User("John", age=None)
+        serialized = UserIntSerializer(user)
+        assert_equal(type(serialized.data['age']), int)
+        assert_equal(serialized.data['age'], 0)
+
     def test_fixed_field(self):
         u = User("John", age=42.3)
         serialized = UserFixedSerializer(u)

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -10,7 +10,7 @@ import warnings
 from nose.tools import *  # PEP8 asserts
 import pytz
 
-from marshmallow import Serializer, fields, validate, pprint, utils
+from marshmallow import Serializer, fields, validate, utils
 from marshmallow.exceptions import MarshallingError
 from marshmallow.compat import unicode, PY26, binary_type, total_seconds
 


### PR DESCRIPTION
This pull requests fixes the bug where serializing `None` on integer fields without a default yielded a `0.0` float instead of a 0 integer.
