### PR TITLE
Encapsulate data

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -163,7 +163,8 @@ class UnMarshaller(object):
         #: Dictionary of errors stored during deserialization
         self.errors = {}
 
-    def deserialize(self, data, fields_dict, many=False, postprocess=None):
+    def deserialize(self, data, fields_dict, many=False, postprocess=None,
+                    encapsulate=None):
         """Deserialize ``data`` based on the schema defined by ``fields_dict``.
 
         :param dict data: The data to deserialize.
@@ -172,8 +173,15 @@ class UnMarshaller(object):
             a collection.
         :param callable postprocess: Post-processing function that is passed the
             deserialized dictionary.
+        :param str encapsulate: The singular name of the key if data is
+            encapsulated, if used with many=True is pluralized
         :return: An OrderedDict of the deserialized data.
         """
+        if encapsulate and data:
+            if many:
+                data = data[pluralize(encapsulate)]
+            else:
+                data = data[encapsulate]
         if many and data is not None:
             return [self.deserialize(d, fields_dict, many=False) for d in data]
         items = []

--- a/marshmallow/serializer.py
+++ b/marshmallow/serializer.py
@@ -414,7 +414,7 @@ class BaseSerializer(base.SerializerABC):
         """
         self._unmarshal.strict = self.strict
         result = self._unmarshal(data, self.fields, self.many,
-                                        postprocess=self.make_object)
+                    postprocess=self.make_object, encapsulate=self.encapsulate)
         errors = self._unmarshal.errors
         return result, errors
 

--- a/marshmallow/serializer.py
+++ b/marshmallow/serializer.py
@@ -65,6 +65,7 @@ class SerializerOpts(object):
         self.strict = getattr(meta, 'strict', False)
         self.dateformat = getattr(meta, 'dateformat', None)
         self.json_module = getattr(meta, 'json_module', json)
+        self.encapsulate = getattr(meta, 'encapsulate', None)
 
 
 class BaseSerializer(base.SerializerABC):
@@ -109,6 +110,8 @@ class BaseSerializer(base.SerializerABC):
         instead of failing silently and storing the errors.
     :param bool many: Should be set to ``True`` if ``obj`` is a collection
         so that the object will be serialized to a list.
+    :param str encapsulate: If a name is given, is used to encapsulate
+        the result and pluralize it when used with many=True
     """
     TYPE_MAPPING = {
         text_type: fields.String,
@@ -157,12 +160,14 @@ class BaseSerializer(base.SerializerABC):
             storing them.
         - ``json_module``: JSON module to use. Defaults to the ``json`` module
             in the stdlib.
+        - ``encapsulate``: If a name is given, is used to encapsulate the result
+            and pluralize it when used with many=True
         """
         pass
 
     def __init__(self, obj=None, extra=None, only=None,
                 exclude=None, prefix='', strict=False, many=False,
-                context=None):
+                context=None, encapsulate=None):
         if not many and utils.is_collection(obj) and not utils.is_keyed_tuple(obj):
             warnings.warn('Implicit collection handling is deprecated. Set '
                             'many=True to serialize a collection.',
@@ -179,6 +184,7 @@ class BaseSerializer(base.SerializerABC):
         self.exclude = exclude or ()
         self.prefix = prefix
         self.strict = strict or self.opts.strict
+        self.encapsulate = encapsulate or self.opts.encapsulate
         #: Callable marshalling object
         self._marshal = fields.Marshaller(
             prefix=self.prefix,
@@ -219,7 +225,8 @@ class BaseSerializer(base.SerializerABC):
         return data
 
     def _update_data(self):
-        result = self._marshal(self.obj, self.fields, many=self.many)
+        result = self._marshal(self.obj, self.fields, many=self.many,
+                               encapsulate=self.encapsulate)
         self._data = self._postprocess(result, obj=self.obj)
 
     @classmethod
@@ -390,7 +397,8 @@ class BaseSerializer(base.SerializerABC):
         if obj != self.obj:
             self._update_fields(obj)
         self._marshal.strict = self.strict
-        preresult = self._marshal(obj, self.fields, many=self.many)
+        preresult = self._marshal(obj, self.fields, many=self.many,
+                                  encapsulate=self.encapsulate)
         result = self._postprocess(preresult, obj=obj)
         errors = self._marshal.errors
         return result, errors

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     packages=find_packages(exclude=("test*", )),
     package_dir={'marshmallow': 'marshmallow'},
     include_package_data=True,
+    install_requires=['inflection'],
     tests_require=TEST_REQUIREMENTS,
     license=read("LICENSE"),
     zip_safe=False,

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -264,6 +264,28 @@ class TestSchemaDeserialization:
         user = result[0]
         assert user['age'] == int(users_data[0]['age'])
 
+    def test_deserialize_encapsulate(self):
+        user_data = {
+            'user': {'name': 'Mick', 'age': 18}
+        }
+        serializer = SimpleUserSerializer(encapsulate='user')
+        result, errors = serializer.load(user_data)
+        assert result['name'] == user_data['user']['name']
+        assert result['age'] == user_data['user']['age']
+
+    def test_deserialize_encapsulate_many(self):
+        users_data = {
+            'users': [
+                {'name': 'Mick', 'age': 18},
+                {'name': 'Keith', 'age': 19}
+            ]
+        }
+        serializer = SimpleUserSerializer(many=True, encapsulate='user')
+        result, errors = serializer.load(users_data)
+        for idx, res in enumerate(result):
+            assert res['name'] == users_data['users'][idx]['name']
+            assert res['age'] == users_data['users'][idx]['age']
+
     def test_make_object(self):
         class SimpleUserSerializer2(Serializer):
             name = fields.String()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -862,7 +862,7 @@ def test_encapsulated_many_data(user):
     range_of_users = 10
     serializer = UserSerializer(many=True, encapsulate='user')
     x = serializer.dump([user] * range_of_users)[0]
-    assert x.keys() == ['users']
+    assert list(x.keys()) == ['users']
     for idx in range(0, range_of_users):
         assert x['users'][idx]['name'] == user.name
         assert x['users'][idx]['age'] == user.age
@@ -874,7 +874,7 @@ def test_encapsulated_meta():
             encapsulate = "user"
     user = User("Foo", email="foo.com")
     x = EncapUserSerializer().dump(user)[0]
-    assert x.keys() == ['user']
+    assert list(x.keys()) == ['user']
 
     x = EncapUserSerializer(many=True).dump([user])[0]
-    assert x.keys() == ['users']
+    assert list(x.keys()) == ['users']

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -850,3 +850,31 @@ def test_error_gets_raised_if_many_is_omitted(user):
         BadSerializer().dump(user)
         # Exception includes message about setting many argument
         assert 'many=True' in str(excinfo)
+
+
+def test_encapsulated_data(user):
+    x = UserSerializer(encapsulate='user').dump(user)[0]
+    assert x['user']['name'] == user.name
+    assert x['user']['age'] == user.age
+
+
+def test_encapsulated_many_data(user):
+    range_of_users = 10
+    serializer = UserSerializer(many=True, encapsulate='user')
+    x = serializer.dump([user] * range_of_users)[0]
+    assert x.keys() == ['users']
+    for idx in range(0, range_of_users):
+        assert x['users'][idx]['name'] == user.name
+        assert x['users'][idx]['age'] == user.age
+
+
+def test_encapsulated_meta():
+    class EncapUserSerializer(UserSerializer):
+        class Meta:
+            encapsulate = "user"
+    user = User("Foo", email="foo.com")
+    x = EncapUserSerializer().dump(user)[0]
+    assert x.keys() == ['user']
+
+    x = EncapUserSerializer(many=True).dump([user])[0]
+    assert x.keys() == ['users']


### PR DESCRIPTION
Add a feature for encapsulate data in the JSON and generate a JSON with ember compatibility. The key of encapsulate is pluralized automatically if is used with `many=True`.

``` python
user1 = User(name="Mick", email="mick@stones.com")
user2 = User(name="Keith", email="keith@stones.com")
users = [user1, user2]
serializer = UserSerializer(many=True, encapsulate='user')
results, errors = serializer.dump(users)
# {'users': [
# {'created_at': 'Fri, 08 Nov 2013 17:02:17 -0000',
#   'email': u'mick@stones.com',
#   'name': u'Mick'},
#  {'created_at': 'Fri, 08 Nov 2013 17:02:17 -0000',
#   'email': u'keith@stones.com',
#   'name': u'Keith'}]}
```

I don't know if the name `encapsulate` is right or if you will like this feature. If is accepted then I'll write the documentation.

And the examples can be changed to use this feature.
