### PR TITLE
Handle unicode output during validation

### DIFF
--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Exception classes for marshmallow-related errors."""
+from marshmallow.compat import text_type
 
 class MarshmallowError(Exception):
     """Base class for all marshmallow-related errors."""
@@ -17,7 +18,9 @@ class _WrappingException(MarshmallowError):
             self.underlying_exception = underlying_exception
         else:
             self.underlying_exception = None
-        super(_WrappingException, self).__init__(str(underlying_exception))
+        super(_WrappingException, self).__init__(
+            text_type(underlying_exception)
+        )
 
 
 class ForcedError(_WrappingException):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -287,7 +287,7 @@ class Field(FieldABC):
                 else:
                     raise ValueError("The 'validate' parameter must be a callable or a collection of callables.")
                 for validator in validators:
-                    msg = 'Validator {0}({1}) is not True'.format(
+                    msg = u'Validator {0}({1}) is not True'.format(
                         validator.__name__, output
                     )
                     if not validator(output):


### PR DESCRIPTION
Hi!

This tiny fix allows to validate non-ASCII output. The problem is in interpolation of `str` with `unicode`.
It can also be `from __future__ import unicode_literals` but I'm not sure about side effects.

A snippet to reproduce the error:

```
from marshmallow.fields import String

def validator(output):
    return True

f = String(validate=validator)
f.deserialize(u'привет')
```
