### PR TITLE
Only run py.test for the tests/ subdir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ TEST_REQUIREMENTS = ['pytest', 'pytz']
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = ['--verbose']
+        self.test_args = ['--verbose', 'tests/']
         self.test_suite = True
 
     def run_tests(self):


### PR DESCRIPTION
This only runs the test subdir which is how it's done in watch() as well.
