### PR TITLE
Ignore popular virtualenv names to fix issues like #99

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ Vagrantfile
 .konchrc
 _sandbox
 pylintrc
+
+# Virtualenvs
+env
+venv

--- a/tasks.py
+++ b/tasks.py
@@ -9,12 +9,12 @@ build_dir = os.path.join(docs_dir, '_build')
 @task
 def test():
     """Run the tests."""
-    flake()
     run('python setup.py test', echo=True, pty=True)
 
 @task
 def flake():
-    run('flake8 .', echo=True)
+    """Run flake8 on codebase."""
+    run('flake8 --exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,env,venv .', echo=True)
 
 @task
 def watch():
@@ -61,6 +61,7 @@ def docs(clean=False, browse=False, watch=False):
 
 @task
 def watch_docs():
+    """Run build the docs when a file changes."""
     try:
         import sphinx_autobuild  # noqa
     except ImportError:


### PR DESCRIPTION
The reasoning here is that it's fairly common practice to create virtualenvs that are named either 'env' or 'venv' in the project root.
