### PR TITLE
loads should use the schema's many value by default

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -483,7 +483,7 @@ class BaseSchema(base.SchemaABC):
             self.__error_handler__(self._unmarshal.errors, data)
         return UnmarshalResult(data=result, errors=errors)
 
-    def loads(self, json_data, many=False, *args, **kwargs):
+    def loads(self, json_data, many=None, *args, **kwargs):
         """Same as :meth:`load`, except it takes a JSON string as input.
 
         :param str json_data: A JSON string of the data to deserialize.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -154,6 +154,16 @@ def test_serializing_none():
     assert s.data['name'] == ''
     assert s.data['age'] == 0
 
+def test_default_many_symmetry():
+    """The dump/load(s) methods should all default to the many value of the schema."""
+    s_many = UserSchema(many=True, only=('name',))
+    s_single = UserSchema(only=('name',))
+    u1, u2 = User('King Arthur'), User('Sir Lancelot')
+    s_single.load(s_single.dump(u1).data)
+    s_single.loads(s_single.dumps(u1).data)
+    s_many.load(s_many.dump([u1, u2]).data)
+    s_many.loads(s_many.dumps([u1, u2]).data)
+
 
 class TestValidate:
 


### PR DESCRIPTION
When a schema is initialized with `many=True`, `dump`, `load`, and `dumps` will use that value by default, but `loads` defaults to `False`.  The user must explicitly pass `True` in order to use the same schema instance for dumping and loading.  All the methods should present the same default behavior to avoid confusion.

No tests failed by making this change, but I added a simple test anyway.  There are no asserts because simply trying to call `loads` on data dumped by the same schema instance will cause an exception.
