### PR TITLE
Fix "many" serialization with custom accessor, skip_missing

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -174,7 +174,8 @@ class Marshaller(object):
         if many and obj is not None:
             self.__pending = True
             ret = [self.serialize(d, fields_dict, many=False, strict=strict,
-                                    dict_class=dict_class, accessor=accessor)
+                                    dict_class=dict_class, accessor=accessor,
+                                    skip_missing=skip_missing)
                     for d in obj]
             self.__pending = False
             return ret

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -174,7 +174,7 @@ class Marshaller(object):
         if many and obj is not None:
             self.__pending = True
             ret = [self.serialize(d, fields_dict, many=False, strict=strict,
-                                    dict_class=dict_class)
+                                    dict_class=dict_class, accessor=accessor)
                     for d in obj]
             self.__pending = False
             return ret

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1846,6 +1846,16 @@ class TestSkipMissingOption:
         assert 'email' not in result.data
         assert 'age' not in result.data
 
+    def test_missing_values_are_skipped_with_many(self):
+        users = [User(name='Joe', email=None, age=None),
+                 User(name='Jane', email=None, age=None)]
+        schema = UserSkipSchema(many=True)
+        results = schema.dump(users)
+        for data in results.data:
+            assert 'name' in data
+            assert 'email' not in data
+            assert 'age' not in data
+
     # Regression test for https://github.com/marshmallow-code/marshmallow/issues/71
     def test_missing_string_values_can_be_skipped(self):
         user = dict(email='foo@bar.com', age=42)


### PR DESCRIPTION
Make sure the 'accessor' parameter is passed on when
the serialize method in Field calls itself recursively.
