### PR TITLE
added support for dot notation only fields in dump method

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -485,7 +485,7 @@ class BaseSchema(base.SchemaABC):
         errors = self._marshal.errors
         return MarshalResult(result, errors)
 
-    def dumps(self, obj, many=None, update_fields=True, *args, **kwargs):
+    def dumps(self, obj, many=None, update_fields=True, only={}, *args, **kwargs):
         """Same as :meth:`dump`, except return a JSON-encoded string.
 
         :param obj: The object to serialize.
@@ -499,7 +499,10 @@ class BaseSchema(base.SchemaABC):
 
         .. versionadded:: 1.0.0
         """
-        deserialized, errors = self.dump(obj, many=many, update_fields=update_fields)
+        deserialized, errors = self.dump(obj,
+                                         many=many,
+                                         update_fields=update_fields,
+                                         only=only)
         ret = self.opts.json_module.dumps(deserialized, *args, **kwargs)
         return MarshalResult(ret, errors)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -125,7 +125,7 @@ class DummyModel(object):
 class Uppercased(fields.Field):
     """Custom field formatting example."""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if value:
             return value.upper()
 

--- a/tests/test_serialize_only.py
+++ b/tests/test_serialize_only.py
@@ -1,0 +1,52 @@
+import pytest
+from tests.base import BlogSchema
+
+def create_keys(only):
+        d = {}
+        for vals in only:
+            l = d
+            for k in vals.split("."):
+                if not k in l: l[k] = {}  #if the key isn't there yet add it to d
+                l = l[k]
+        return d
+
+
+def validate_fields(only_dict, result):
+    assert only_dict.keys() == result.keys()
+    for k, v in only_dict.iteritems():
+        if v and not isinstance(result[k], list):
+            validate_fields(v, result[k])
+
+
+def test_serialize_with_only(blog):
+    blog_schema = BlogSchema()
+    only = ("title", "user")
+
+    res, _ = blog_schema.dump(blog)
+    assert set(only) != set(res.keys())
+
+    res, _ = blog_schema.dump(blog, only=only)
+    assert set(only) == set(res.keys())
+
+    only = ("title", "user.name")
+    res, _ = blog_schema.dump(blog, only=only)
+    only_dict = create_keys(only)
+    validate_fields(only_dict, res)
+
+
+def test_serialize_with_only2(blog):
+    blog_schema = BlogSchema()
+    only = ("title", "user", "collaborators")
+
+    res, _ = blog_schema.dump(blog)
+    assert set(only) != set(res.keys())
+
+    res, _ = blog_schema.dump(blog, only=only)
+    assert set(only) == set(res.keys())
+
+    only = ("title", "user.name", "collaborators.name")
+    res, _ = blog_schema.dump(blog, only=only)
+
+    print res
+    only_dict = create_keys(only)
+    validate_fields(only_dict, res)


### PR DESCRIPTION
1. Added only to dump (dumps) 
2. "only" support for dot notation syntax to control nested schema 
   fields 

@sloria This is not the final commit, I am pushing this in to get your first impression
all tests are passing.
My next step is to add more tests and fix documentation.

Thanks
