### PR TITLE
added support for fields.List.serialize to correctly process generators (

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
+import types
 import uuid
 import warnings
 import decimal
@@ -408,6 +409,8 @@ class List(Field):
             self.container = cls_or_instance
 
     def _serialize(self, value, attr, obj):
+        if isinstance(value, types.GeneratorType):
+            return [self.container.serialize(0, [entry]) for entry in value]
         if utils.is_indexable_but_not_string(value) and not isinstance(value, dict):
             return [self.container.serialize(idx, value) for idx
                     in range(len(value))]

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -409,13 +409,12 @@ class List(Field):
             self.container = cls_or_instance
 
     def _serialize(self, value, attr, obj):
-        if utils.is_indexable_but_not_string(value) and not isinstance(value, dict):
-            return [self.container.serialize(idx, value) for idx
-                    in range(len(value))]
-        if utils.is_iterable_but_not_string(value) and not isinstance(value, dict):
-            return [self.container.serialize(0, [value]) for value in value]
         if value is None:
             return self.default
+        if utils.is_collection(value):
+            return [self.container._serialize(each, attr, obj) for each in value]
+        if utils.is_indexable_with_length_but_not_a_string(value) and not isinstance(value, dict):
+            return [self.container.serialize(idx, value) for idx in range(len(value))]
         return [self.container.serialize(attr, obj)]
 
     def _deserialize(self, value):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -413,8 +413,6 @@ class List(Field):
             return self.default
         if utils.is_collection(value):
             return [self.container._serialize(each, attr, obj) for each in value]
-        if utils.is_indexable_with_length_but_not_a_string(value) and not isinstance(value, dict):
-            return [self.container.serialize(idx, value) for idx in range(len(value))]
         return [self.container.serialize(attr, obj)]
 
     def _deserialize(self, value):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -409,11 +409,11 @@ class List(Field):
             self.container = cls_or_instance
 
     def _serialize(self, value, attr, obj):
-        if isinstance(value, types.GeneratorType):
-            return [self.container.serialize(0, [entry]) for entry in value]
         if utils.is_indexable_but_not_string(value) and not isinstance(value, dict):
             return [self.container.serialize(idx, value) for idx
                     in range(len(value))]
+        if utils.is_iterable_but_not_string(value) and not isinstance(value, dict):
+            return [self.container.serialize(0, [value]) for value in value]
         if value is None:
             return self.default
         return [self.container.serialize(attr, obj)]

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime as dt
-import types
 import uuid
 import warnings
 import decimal

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -41,6 +41,10 @@ def is_indexable_but_not_string(obj):
     return not hasattr(obj, "strip") and hasattr(obj, "__getitem__")
 
 
+def is_indexable_with_length_but_not_a_string(obj):
+    return is_indexable_but_not_string(obj) and hasattr(obj, "__len__")
+
+
 def is_collection(obj):
     """Return True if ``obj`` is a collection type, e.g list, tuple, queryset."""
     return is_iterable_but_not_string(obj) and not isinstance(obj, dict)

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -41,10 +41,6 @@ def is_indexable_but_not_string(obj):
     return not hasattr(obj, "strip") and hasattr(obj, "__getitem__")
 
 
-def is_indexable_with_length_but_not_a_string(obj):
-    return is_indexable_but_not_string(obj) and hasattr(obj, "__len__")
-
-
 def is_collection(obj):
     """Return True if ``obj`` is a collection type, e.g list, tuple, queryset."""
     return is_iterable_but_not_string(obj) and not isinstance(obj, dict)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -16,6 +16,10 @@ class DateTimeList:
     def __init__(self, dtimes):
         self.dtimes = dtimes
 
+class IntegerList:
+    def __init__(self, ints):
+        self.ints = ints
+
 class TestFieldSerialization:
 
     @pytest.fixture
@@ -381,6 +385,33 @@ class TestFieldSerialization:
         assert len(result) == 2
         assert result[0] is None
         assert result[1] is None
+
+    def test_list_field_work_with_set(self):
+        custom_set = {1, 2, 3}
+        obj = IntegerList(custom_set)
+        field = fields.List(fields.Int)
+        result = field.serialize("ints", obj)
+        assert len(result) == 3
+        assert 1 in result
+        assert 2 in result
+        assert 3 in result
+
+    def test_list_field_work_with_custom_class_with_iterator_protocol(self):
+        class IteratorSupportingClass:
+            def __init__(self, iterable):
+                self.iterable = iterable
+
+            def __iter__(self):
+                return iter(self.iterable)
+
+        ints = IteratorSupportingClass([1, 2, 3])
+        obj = IntegerList(ints)
+        field = fields.List(fields.Int)
+        result = field.serialize("ints", obj)
+        assert len(result) == 3
+        assert result[0] == 1
+        assert result[1] == 2
+        assert result[2] == 3
 
     def test_bad_list_field(self):
         class ASchema(Schema):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -387,7 +387,7 @@ class TestFieldSerialization:
         assert result[1] is None
 
     def test_list_field_work_with_set(self):
-        custom_set = {1, 2, 3}
+        custom_set = set([1, 2, 3])
         obj = IntegerList(custom_set)
         field = fields.List(fields.Int)
         result = field.serialize("ints", obj)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -413,6 +413,23 @@ class TestFieldSerialization:
         assert result[1] == 2
         assert result[2] == 3
 
+    def test_list_field_work_with_custom_class_indexable_but_no_length(self):
+        class IndexableWithLengthClass:
+            def __init__(self, iterable):
+                self.indexable = iterable
+
+            def __getitem__(self, index):
+                return self.indexable[index]
+
+            def __len__(self):
+                return len(self.indexable)
+        ints = IndexableWithLengthClass([1, 2, 3])
+        obj = IntegerList(ints)
+        field = fields.List(fields.Int)
+        result = field.serialize("ints", obj)
+        assert len(result) == 3
+        assert result == [1, 2, 3]
+
     def test_bad_list_field(self):
         class ASchema(Schema):
             id = fields.Int()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -413,23 +413,6 @@ class TestFieldSerialization:
         assert result[1] == 2
         assert result[2] == 3
 
-    def test_list_field_work_with_custom_class_indexable_but_no_length(self):
-        class IndexableWithLengthClass:
-            def __init__(self, iterable):
-                self.indexable = iterable
-
-            def __getitem__(self, index):
-                return self.indexable[index]
-
-            def __len__(self):
-                return len(self.indexable)
-        ints = IndexableWithLengthClass([1, 2, 3])
-        obj = IntegerList(ints)
-        field = fields.List(fields.Int)
-        result = field.serialize("ints", obj)
-        assert len(result) == 3
-        assert result == [1, 2, 3]
-
     def test_bad_list_field(self):
         class ASchema(Schema):
             id = fields.Int()


### PR DESCRIPTION
following our discussion on #185 I've made small workaround changes to the fields.List.serialize method to support generators.

additional test cases were added and successfully passed, as well as the rest of the test suite

while my workaround is simple, it does not support the generator protocol in full (we create dummy one entry list every time we go through generator, and no "exception chaining", no "send()", etc is provided), but I don't think this is that important at the moment.
