### PR TITLE
Fix pep8 dev dependency for flake8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,5 +14,5 @@ tox>=1.5.0
 
 
 # Syntax checking
-pep8==1.6.1
-flake8>=2.2.2
+pep8>=1.5.7,<1.6
+flake8>=2.4.0


### PR DESCRIPTION
flake8 2.4.0 explicitly requires pep8<1.6
