### PR TITLE
Respect `attribute` of container in `List` field.

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -400,12 +400,24 @@ class List(Field):
                                            'marshmallow.base.FieldABC')
             self.container = cls_or_instance
 
+    def get_value(self, attr, obj, accessor=None):
+        """Return the value for a given key from an object."""
+        value = super(List, self).get_value(attr, obj, accessor=accessor)
+        if self.container.attribute:
+            if utils.is_collection(value):
+                return [
+                    self.container.get_value(self.container.attribute, each)
+                    for each in value
+                ]
+            return self.container.get_value(self.container.attribute, value)
+        return value
+
     def _serialize(self, value, attr, obj):
         if value is None:
             return None
         if utils.is_collection(value):
             return [self.container._serialize(each, attr, obj) for each in value]
-        return [self.container.serialize(attr, obj)]
+        return [self.container._serialize(value, attr, obj)]
 
     def _deserialize(self, value):
         if utils.is_indexable_but_not_string(value) and not isinstance(value, dict):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -632,7 +632,6 @@ def test_load_errors_with_many():
     assert 'anotherbademail' in errors[2]['email'][0]
 
 def test_error_raised_if_fields_option_is_not_list():
-    u = User('Joe')
     with pytest.raises(ValueError):
         class BadSchema(Schema):
             name = fields.String()
@@ -642,7 +641,6 @@ def test_error_raised_if_fields_option_is_not_list():
 
 
 def test_error_raised_if_additional_option_is_not_list():
-    u = User('Joe')
     with pytest.raises(ValueError):
         class BadSchema(Schema):
             name = fields.String()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -425,6 +425,18 @@ class TestFieldSerialization:
         field = fields.List(fields.DateTime)
         assert field.serialize('dtimes', obj) is None
 
+    def test_list_field_respect_inner_attribute(self):
+        now = dt.datetime.now()
+        obj = DateTimeList([now])
+        field = fields.List(fields.Int(attribute='day'))
+        assert field.serialize('dtimes', obj) == [now.day]
+
+    def test_list_field_respect_inner_attribute_single_value(self):
+        now = dt.datetime.now()
+        obj = DateTimeList(now)
+        field = fields.List(fields.Int(attribute='day'))
+        assert field.serialize('dtimes', obj) == [now.day]
+
     def test_list_field_work_with_generator_single_value(self):
         def custom_generator():
             yield dt.datetime.utcnow()


### PR DESCRIPTION
For a `List` field whose nested field sets `attribute`, the value of
`attribute` is ignored. For example, consider a field that extracts the
year from each date on a `dates` list from the original object:

``` python
dates = List(Integer(attribute='year'))
```

This patch adds support for `attribute` values set on fields inside a
`List`.
