### PR TITLE
Set field attrs

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -239,6 +239,16 @@ class Field(FieldABC):
 
     # Methods for concrete classes to override.
 
+    def _add_to_schema(self, field_name, schema):
+        """Update field with values from its parent schema. Called by
+            :meth:`__set_field_attrs <marshmallow.Schema.__set_field_attrs>`.
+
+        :param str field_name: Field name set in schema
+        :param Schema schema: Parent schema
+        """
+        self.parent = self.parent or schema
+        self.name = self.name or field_name
+
     def _serialize(self, value, attr, obj):
         """Serializes ``value`` to a basic Python datatype. Noop by default.
         Concrete :class:`Field` classes should implement this method.
@@ -411,6 +421,10 @@ class List(Field):
                 ]
             return self.container.get_value(self.container.attribute, value)
         return value
+
+    def _add_to_schema(self, field_name, schema):
+        super(List, self)._add_to_schema(field_name, schema)
+        self.container._add_to_schema(field_name, schema)
 
     def _serialize(self, value, attr, obj):
         if value is None:
@@ -722,6 +736,10 @@ class DateTime(Field):
         # or ``_desrialize`` methods This allows a Schema to dynamically set the
         # dateformat, e.g. from a Meta option
         self.dateformat = format
+
+    def _add_to_schema(self, field_name, schema):
+        super(DateTime, self)._add_to_schema(field_name, schema)
+        self.dateformat = self.dateformat or schema.opts.dateformat
 
     def _serialize(self, value, attr, obj):
         if value is None:

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -10,7 +10,7 @@ and from primitive types.
 
 from __future__ import unicode_literals
 
-from marshmallow import base, utils
+from marshmallow import utils
 from marshmallow.utils import missing
 from marshmallow.compat import text_type, iteritems
 from marshmallow.exceptions import (
@@ -72,16 +72,6 @@ class ErrorStore(object):
             else:
                 errors.setdefault(field_name, []).extend(err.messages)
             value = missing
-        except TypeError:
-            # field declared as a class, not an instance
-            if (isinstance(field_obj, type) and
-                    issubclass(field_obj, base.FieldABC)):
-                msg = ('Field for "{0}" must be declared as a '
-                                'Field instance, not a class. '
-                                'Did you mean "fields.{1}()"?'
-                                .format(field_name, field_obj.__name__))
-                raise TypeError(msg)
-            raise
         return value
 
 class Marshaller(ErrorStore):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,7 +6,7 @@ import random
 
 import pytest
 
-from marshmallow import Schema, fields, utils, MarshalResult, UnmarshalResult, validate
+from marshmallow import Schema, fields, utils, MarshalResult, UnmarshalResult
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import unicode, OrderedDict
 
@@ -1588,6 +1588,13 @@ class TestNestedSchema:
     def test_list_field(self, blog):
         serialized = BlogSchema().dump(blog)[0]
         assert serialized['categories'] == ["humor", "violence"]
+
+    def test_list_field_parent(self):
+        schema = BlogSchema()
+        assert schema.fields['categories'].parent == schema
+        assert schema.fields['categories'].name == 'categories'
+        assert type(schema.fields['categories'].container.parent) is BlogSchema
+        assert schema.fields['categories'].container.name == 'categories'
 
     def test_nested_load_many(self):
         in_data = {'title': 'Shine A Light', 'collaborators': [


### PR DESCRIPTION
Move logic from `Schema#__set_field_attrs` to `Field#_add_to_schema`. Allows different field types to add logic from Schemas differently; adds schema information to list container fields.
