### PR TITLE
Type error and missing required data error handling for nested fields.

### DIFF
--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -13,7 +13,7 @@ from marshmallow.decorators import (
 from marshmallow.utils import pprint, missing
 from marshmallow.exceptions import MarshallingError, UnmarshallingError, ValidationError
 
-__version__ = '2.0.0b4'
+__version__ = '2.0.0b4.idealist.2'
 __author__ = 'Steven Loria'
 __license__ = 'MIT'
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -379,9 +379,9 @@ class Nested(Field):
         return ret
 
     def _deserialize(self, value):
-        if self.many and not isinstance(value, list):
+        if self.many and not utils.is_collection(value):
             raise ValidationError(
-                'Expected a list, got a {0}.'.format(value.__class__.__name__))
+                'Expected a collection of dicts, got a {0}.'.format(value.__class__.__name__))
 
         data, errors = self.schema.load(value)
         if errors:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -418,7 +418,7 @@ class Nested(Field):
                     try:
                         field._validate_missing(field.missing)
                     except ValidationError as ve:
-                        errors[field_name] = [ve.message]
+                        errors[field_name] = ve.messages
         return errors
 
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -374,6 +374,13 @@ class Nested(Field):
         return ret
 
     def _deserialize(self, value):
+        if self.required is True and not value:
+            raise ValidationError(
+                'Missing data for required field.')
+        if self.many and not isinstance(value, list):
+            raise ValidationError(
+                'Expected a list, got a {}.'.format(value.__class__.__name__))
+
         data, errors = self.schema.load(value)
         if errors:
             raise ValidationError(errors)

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -379,7 +379,7 @@ class Nested(Field):
                 'Missing data for required field.')
         if self.many and not isinstance(value, list):
             raise ValidationError(
-                'Expected a list, got a {}.'.format(value.__class__.__name__))
+                'Expected a list, got a {0}.'.format(value.__class__.__name__))
 
         data, errors = self.schema.load(value)
         if errors:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -412,7 +412,10 @@ class Nested(Field):
                     try:
                         field._validate_missing(field.missing)
                     except ValidationError as ve:
-                        errors[self.name] = {field_name: ve.messages}
+                        if self.name in errors:
+                            errors[self.name][field_name] = ve.messages
+                        else:
+                            errors[self.name] = {field_name: ve.messages}
         return errors
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1716,7 +1716,9 @@ class TestNestedSchema:
 
         class Middle(Schema):
             middle_req = fields.Nested(Inner, required=True)
+            middle_req_2 = fields.Nested(Inner, required=True)
             middle_not_req = fields.Nested(Inner)
+            middle_field = fields.Field(required='middlin')
 
         class Outer(Schema):
             outer_req = fields.Nested(Middle, required=True)
@@ -1725,24 +1727,19 @@ class TestNestedSchema:
             outer_many_not_req = fields.Nested(Middle, many=True)
 
         outer = Outer()
+        expected = {
+            'outer_many_req': {0: {'middle_req': {'inner_bad': ['Int plz'],
+                                                   'inner_req': ['Oops']},
+                                    'middle_req_2': {'inner_bad': ['Int plz'],
+                                                     'inner_req': ['Oops']}},
+                                'middle_field': ['middlin']},
+             'outer_req': {'middle_field': ['middlin'],
+                           'middle_req': {'inner_bad': ['Int plz'],
+                                          'inner_req': ['Oops']},
+                           'middle_req_2': {'inner_bad': ['Int plz'],
+                                            'inner_req': ['Oops']}}}
         data, errors = outer.load({})
-        assert errors == {
-            'outer_req': {
-                'middle_req': {
-                    'inner_req': ['Oops'],
-                    'inner_bad': ['Int plz']
-                }
-            },
-            'outer_many_req': {
-                0: {
-                    'middle_req': {
-                        'inner_req': ['Oops'],
-                        'inner_bad': ['Int plz']
-                    }
-                }
-            }
-        }
-
+        assert errors == expected
 
 class TestSelfReference:
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1699,7 +1699,7 @@ class TestNestedSchema:
 
         result = sch.load({'inner': 'invalid'})
         assert 'inner' in result.errors
-        assert result.errors['inner'] == ['Expected a list, got a str.']
+        assert result.errors['inner'] == ['Expected a collection of dicts, got a str.']
 
         class OuterSchema(Schema):
             inner = fields.Nested(InnerSchema)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1712,6 +1712,7 @@ class TestNestedSchema:
         class Inner(Schema):
             inner_req = fields.Field(required='Oops')
             inner_not_req = fields.Field()
+            inner_bad = fields.Integer(required='Int plz')
 
         class Middle(Schema):
             middle_req = fields.Nested(Inner, required=True)
@@ -1728,13 +1729,15 @@ class TestNestedSchema:
         assert errors == {
             'outer_req': {
                 'middle_req': {
-                    'inner_req': ['Oops']
+                    'inner_req': ['Oops'],
+                    'inner_bad': ['Int plz']
                 }
             },
             'outer_many_req': {
                 0: {
                     'middle_req': {
-                        'inner_req': ['Oops']
+                        'inner_req': ['Oops'],
+                        'inner_bad': ['Int plz']
                     }
                 }
             }


### PR DESCRIPTION
Although partially fixed already in issue #188, it is still possible for nested schemas to incorrectly deserialize wrongly-typed data. Moreover, the changes introduced by the fix for #188 generate an error message that is confusing in the case of a string in the place of a (`many=True`) list of nested schemas: the message claims that a dict (i.e. the nested schema) was expected when what really was expected was a _list_ of dicts. This fixes that, and still ensures test coverage for the `many=False` case when deserializing data with something other than the expected dict.

Also, Marshmallow currently doesn't generate an error when deserializing data with missing nested schema containing required fields (whether or not `many=True`). These changes fix that too.
