### PR TITLE
Fixed boolean field serialization.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,4 @@ Contributors (chronological)
 - Matt Stobo `@mwstobo <https://github.com/mwstobo>`_
 - Max Orhai `@max-orhai <https://github.com/max-orhai>`_
 - Praveen `@praveen-p <https://github.com/praveen-p>`_
+- Stas Sușcov `@stas <https://github.com/stas>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -648,15 +648,20 @@ class Boolean(Field):
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
-    #: Values that will deserialize to `True`. If an empty set, any non-falsy
+    #: Values that will (de)serialize to `True`. If an empty set, any non-falsy
     #  value will deserialize to `True`.
     truthy = set()
-    #: Values that will deserialize to `False`.
+    #: Values that will (de)serialize to `False`.
     falsy = set(['False', 'false', '0', 'null', 'None'])
 
     def _serialize(self, value, attr, obj):
         if value is None:
             return None
+        elif value in self.truthy:
+            return True
+        elif value in self.falsy:
+            return False
+
         return bool(value)
 
     def _deserialize(self, value, attr, data):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -248,6 +248,17 @@ class TestFieldSerialization:
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero() and m7s.is_signed()
 
+    def test_boolean_field_serialization(self, user):
+        field = fields.Boolean()
+
+        user.truthy = 'non-falsy-ish'
+        user.falsy = 'false'
+        user.none = None
+
+        assert field.serialize('truthy', user) == True
+        assert field.serialize('falsy', user) == False
+        assert field.serialize('none', user) == None
+
     def test_function_with_uncallable_param(self):
         with pytest.raises(ValueError):
             fields.Function("uncallable")


### PR DESCRIPTION
I updated the Boolean field behavior to be as similar as possible with the de-serialization of the same field.

This breaks a test that verifies the field serialization of `None` to a `None`. I'm not sure what is the purpose of that, but it doesn't really make sense in the context of a boolean field.

Please help me understand if there's some backwards-compatibility or something with it, I will be happy to revert it back or fix the relevant test.

Thanks in advance for reviewing this.
