### PR TITLE
Updated utils._get_value_for_key return the called attribute if it is callable

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -316,7 +316,8 @@ def _get_value_for_key(key, obj, default):
         return obj[key]
     except (KeyError, AttributeError, IndexError, TypeError):
         try:
-            return getattr(obj, key)
+            attr = getattr(obj, key)
+            return attr() if callable(attr) else attr
         except AttributeError:
             return default
     return default

--- a/tests/base.py
+++ b/tests/base.py
@@ -94,6 +94,9 @@ class User(object):
     def since_created(self):
         return dt.datetime(2013, 11, 24) - self.created
 
+    def call_me(self):
+        return "This was called."
+
     def __repr__(self):
         return "<User {0}>".format(self.name)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -83,6 +83,10 @@ class TestFieldSerialization:
         field = fields.Integer(default=None)
         assert field.serialize('age', user) is None
 
+    def test_callable_field(self, user):
+       field = fields.String()
+       assert field.serialize('call_me', user) == 'This was called.'
+
     def test_decimal_field(self, user):
         user.m1 = 12
         user.m2 = '12.355'


### PR DESCRIPTION
I believe this should be the behavior expected.  While most things can be made an @property, sometimes they aren't and it is great to be able to get the result back.
