### PR TITLE
setuptools extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 
 install:
   - pip install -U -r dev-requirements.txt
-  - pip install -U .
+  - pip install -U .[reco]
 
 before_script:
   - flake8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ python:
   - "2.6"
   - "pypy"
 
+before_install:
+  - pip install -U pip
+
 install:
   - pip install -U -r dev-requirements.txt
   - pip install -U .[reco]

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand  # noqa
 
 TEST_REQUIREMENTS = ['pytest', 'pytz']
+EXTRA_REQUIREMENTS = ['python-dateutil', 'simplejson']
 
 
 class PyTest(TestCommand):
@@ -57,6 +58,7 @@ setup(
     package_dir={'marshmallow': 'marshmallow'},
     include_package_data=True,
     tests_require=TEST_REQUIREMENTS,
+    extras_require={'reco': EXTRA_REQUIREMENTS},
     license=read('LICENSE'),
     zip_safe=False,
     keywords=('serialization', 'rest', 'json', 'api', 'marshal',


### PR DESCRIPTION
1. recommended dependencies are now listed in a single standard place
2. users can easily install marshmallow + recommended dependencies: `pip install marshmallow[reco]`
3. you can remove the "soft dependencies" from dev-requirements.txt
4. 100% backward compatible
5. if properly documented can help to prevent problems like this #240

Refs:
- http://packages.python.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
- https://pip.pypa.io/en/latest/reference/pip_install.html
