### PR TITLE
DateTime uses strptime during deserialization

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Contributors (chronological)
 - Alex Morken `@alexmorken <https://github.com/alexmorken>`_
 - Sergey Polzunov `@traut <https://github.com/traut>`_
 - Kelvin Hammond `@kelvinhammond <https://github.com/kelvinhammond>`_
+- Bart Aelterman `@bartaelterman <https://github.com/bartaelterman>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -777,7 +777,7 @@ class DateTime(Field):
         elif utils.dateutil_available:
             try:
                 return utils.from_datestring(value)
-            except TypeError:
+            except (TypeError, AttributeError):
                 raise err
         else:
             warnings.warn('It is recommended that you install python-dateutil '

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -7,6 +7,7 @@ import datetime as dt
 import uuid
 import warnings
 import decimal
+import time
 from operator import attrgetter
 
 from marshmallow import validate, utils, class_registry
@@ -768,15 +769,11 @@ class DateTime(Field):
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise err
-        elif utils.dateutil_available:
+        else:
             try:
-                return utils.from_datestring(value)
+                return dt.datetime(*time.strptime(value, self.dateformat)[0:6])
             except TypeError:
                 raise err
-        else:
-            warnings.warn('It is recommended that you install python-dateutil '
-                          'for improved datetime deserialization.')
-            raise err
 
 
 class LocalDateTime(DateTime):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -769,7 +769,7 @@ class DateTime(Field):
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise err
-        elif type(value) is str:
+        elif type(value) is str and self.dateformat:
             try:
                 return dt.datetime(*time.strptime(value, self.dateformat)[0:6])
             except TypeError:


### PR DESCRIPTION
Note that this fix will solely rely on the DateTime format given. No deserialization attempt is made using dateutil.
