### PR TITLE
Fix errors on non-ASCII local email part

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -66,10 +66,10 @@ class Email(object):
         Error message to raise in case of a validation error.
     """
     USER_REGEX = re.compile(
-        r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*$"  # dot-atom
+        r"(^[-!#$%&'*+/=?^_`{}|~0-9\w]+(\.[-!#$%&'*+/=?^_`{}|~0-9\w]+)*$"  # dot-atom
         # quoted-string
         r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]'
-        r'|\\[\001-\011\013\014\016-\177])*"$)', re.IGNORECASE)
+        r'|\\[\001-\011\013\014\016-\177])*"$)', re.IGNORECASE | re.UNICODE)
 
     DOMAIN_REGEX = re.compile(
         # domain
@@ -77,7 +77,7 @@ class Email(object):
         r'(?:[A-Z]{2,6}|[A-Z0-9-]{2,})$'
         # literal form, ipv4 address (SMTP 4.1.3)
         r'|^\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)'
-        r'(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE)
+        r'(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE | re.UNICODE)
 
     DOMAIN_WHITELIST = ('localhost',)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -88,6 +88,8 @@ def test_url_relative_invalid(invalid_url):
     "!#$%&'*+-/=?^_`{}|~@example.org",
     'niceandsimple@[64.233.160.0]',
     'niceandsimple@localhost',
+    u'josé@blah.com',
+    u'δοκ.ιμή@παράδειγμα.δοκιμή',
 ])
 def test_email_valid(valid_email):
     validator = validate.Email()


### PR DESCRIPTION
Add the `re.UNICODE` flag and allow for all word characters as opposed to `A-Z`

Fixes https://github.com/marshmallow-code/marshmallow/issues/221
