### PR TITLE
fix #248

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ Contributors (chronological)
 - Kelvin Hammond `@kelvinhammond <https://github.com/kelvinhammond>`_
 - Matt Stobo `@mwstobo <https://github.com/mwstobo>`_
 - Max Orhai `@max-orhai <https://github.com/max-orhai>`_
+- Praveen `@praveen-p <https://github.com/praveen-p>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -810,6 +810,11 @@ class DateTime(Field):
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise err
+        elif self.dateformat:
+            try:
+                return dt.datetime.strptime(value, self.dateformat)
+            except (TypeError, AttributeError, ValueError):
+                raise err
         elif utils.dateutil_available:
             try:
                 return utils.from_datestring(value)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -288,6 +288,26 @@ class TestFieldDeserialization:
         msg = 'Could not deserialize {0!r} to a datetime object.'.format(in_value)
         assert msg in str(excinfo)
 
+    def test_custom_date_format_datetime_field_deserialization(self):
+
+        dtime = dt.datetime.now()
+        datestring = dtime.strftime('%H:%M:%S %Y-%m-%d')
+
+        field = fields.DateTime(format='%d-%m-%Y %H:%M:%S')
+        #deserialization should fail when datestring is not of same format
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(datestring)
+        msg = 'Could not deserialize {0!r} to a datetime object.'.format(datestring)
+        assert msg in str(excinfo)
+        field = fields.DateTime(format='%H:%M:%S %Y-%m-%d')
+        assert_datetime_equal(field.deserialize(datestring), dtime)
+
+        field = fields.DateTime()
+        if utils.dateutil_available:
+            assert_datetime_equal(field.deserialize(datestring), dtime)
+        else:
+            assert msg in str(excinfo)
+
     @pytest.mark.parametrize('fmt', ['rfc', 'rfc822'])
     def test_rfc_datetime_field_deserialization(self, fmt):
         dtime = dt.datetime.now()


### PR DESCRIPTION
The user specified datetime format will be used to deserialize the datetime string. Raise validationError if the string cannot be deserialized.  
