### PR TITLE
_deserialize receives attr and input data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 2.0.0x (unreleased)
 +++++++++++++++++++
 
+Features:
+
+- *Backwards-incompatible*: ``fields.Field._deserialize`` now takes ``attr`` and ``data`` as arguments (:issue:`172`). Thanks :user:`alexmic` for the suggestion.
+
 2.0.0b5 (2015-08-23)
 ++++++++++++++++++++
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -143,7 +143,7 @@ Similar to pre-processing and post-processing methods, schema validators are now
         if data['field_a'] < data['field_b']:
             raise ValidationError('field_a must be greater than field_b')
 
-    # 2.0 Deprecated API
+    # 2.0 API
     from marshmallow import Schema, fields, validator, ValidationError
 
     class MySchema(Schema):
@@ -194,33 +194,6 @@ Use ``ValidationError`` instead of ``MarshallingError`` and ``UnmarshallingError
 
 The :exc:`MarshallingError` and :exc:`UnmarshallingError` exceptions are deprecated in favor of a single :exc:`ValidationError <marshmallow.exceptions.ValidationError>`. Users who have written custom fields or are using ``strict`` mode will need to change their code accordingly.
 
-Custom Fields
--------------
-
-Custom fields should raise :exc:`ValidationError <marshmallow.exceptions.ValidationError>` in their `_deserialize` and `_serialize` methods when a validation error occurs.
-
-.. code-block:: python
-    :emphasize-lines: 17
-
-    from marshmallow import fields, ValidationError
-    from marshmallow.exceptions import UnmarshallingError
-
-    # In 1.0, an UnmarshallingError was raised
-    class PasswordField(fields.Field):
-
-        def _deserialize(self, val):
-            if not len(val) >= 6:
-                raise UnmarshallingError('Password too short.')
-            return val
-
-    # In 2.0, an ValidationError is raised
-    class PasswordField(fields.Field):
-
-        def _deserialize(self, val):
-            if not len(val) >= 6:
-                raise ValidationError('Password too short.')
-            return val
-
 Handle ``ValidationError`` in strict mode
 -----------------------------------------
 
@@ -265,6 +238,37 @@ In 2.0, `strict` mode was improved so that you can access all error messages for
     #     'name': ['Missing data for required field.']
     # }
 
+
+
+Custom Fields
+*************
+
+Two changes must be made to make your custom fields compatible with version 2.0.
+
+- The `_deserialize <marshmallow.fields.Field._deserialize>` method of custom fields now receives ``attr`` (the key corresponding to the value to be deserialized) and the raw input ``data`` as arguments.
+- Custom fields should raise :exc:`ValidationError <marshmallow.exceptions.ValidationError>` in their `_deserialize` and `_serialize` methods when a validation error occurs.
+
+.. code-block:: python
+
+    from marshmallow import fields, ValidationError
+    from marshmallow.exceptions import UnmarshallingError
+
+    # In 1.0, an UnmarshallingError was raised
+    class PasswordField(fields.Field):
+
+        def _deserialize(self, val):
+            if not len(val) >= 6:
+                raise UnmarshallingError('Password too short.')
+            return val
+
+    # In 2.0, _deserialize receives attr and data,
+    # and a ValidationError is raised
+    class PasswordField(fields.Field):
+
+        def _deserialize(self, val, attr, data):
+            if not len(val) >= 6:
+                raise ValidationError('Password too short.')
+            return val
 
 
 Use ``OneOf`` instead of ``fields.Select``

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -271,8 +271,14 @@ class Unmarshaller(ErrorStore):
                     raw_value = _miss() if callable(_miss) else _miss
                 if raw_value is missing and not field_obj.required:
                     continue
+
+                getter = lambda val: field_obj.deserialize(
+                    val,
+                    field_obj.load_from or attr_name,
+                    data
+                )
                 value = self.call_and_store(
-                    getter_func=field_obj.deserialize,
+                    getter_func=getter,
                     data=raw_value,
                     field_name=field_name,
                     field_obj=field_obj,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from marshmallow import fields
+from marshmallow import fields, Schema
 from marshmallow.marshalling import missing
 
-from tests.base import ALL_FIELDS
+from tests.base import ALL_FIELDS, User
 
 class TestFieldAliases:
 
@@ -39,6 +39,32 @@ class TestField:
     def test_error_raised_if_uncallable_validator_passed(self):
         with pytest.raises(ValueError):
             fields.Field(validate='notcallable')
+
+    def test_custom_field_receives_attr_and_obj(self, user):
+        class MyField(fields.Field):
+            def _deserialize(self, val, attr, data):
+                assert attr == 'name'
+                assert data['foo'] == 42
+                return val
+
+        class MySchema(Schema):
+            name = MyField()
+
+        result = MySchema().load({'name': 'Monty', 'foo': 42})
+        assert result.data == {'name': 'Monty'}
+
+    def test_custom_field_receives_load_from_if_set(self, user):
+        class MyField(fields.Field):
+            def _deserialize(self, val, attr, data):
+                assert attr == 'name'
+                assert data['foo'] == 42
+                return val
+
+        class MySchema(Schema):
+            Name = MyField(load_from='name')
+
+        result = MySchema().load({'name': 'Monty', 'foo': 42})
+        assert result.data == {'Name': 'Monty'}
 
 
 class TestMetadata:


### PR DESCRIPTION
Passing `attr` and `data` allows custom fields to deserialize values based on other values in the input data.

see #172
