### PR TITLE
Add support for polymorphic fields

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1348,6 +1348,66 @@ class Constant(Field):
         return self.constant
 
 
+class PolyField(Field):
+    """
+    A field that (de)serializes to one of many types. a function
+    is called to disambiguate what schema to use for the (de)serialization
+    Intended to assist in working with fields that can contain any subclass
+    of a base type
+    """
+    def __init__(self, disambiguation_function, many=False, **metadata):
+        """
+        :param disambiguation_function: Function that takes in either
+        an object or a dict representing that object
+        and returns the appropriate schema
+
+        """
+        super(PolyField, self).__init__(**metadata)
+        self.many = many
+        self.disambiguation_function = disambiguation_function
+
+    def _deserialize(self, value, attr, data):
+        if value is None:
+            if hasattr(self, 'required') and self.required:
+                raise ValidationError('Missing data for required field.')
+            return None
+        if not self.many:
+            value = [value]
+
+        results = []
+        for v in value:
+            if not v:
+                results.append(v)
+            else:
+                try:
+                    schema = self.disambiguation_function(v)
+                    data, errors = schema.load(v)
+                except TypeError:
+                    raise ValidationError("Unable to use schema. Did the disambiguation function return one?")
+                if errors:
+                    raise ValidationError(errors)
+                results.append(data)
+
+        if self.many:
+            return results
+        else:
+            # Will be at least one otherwise value would have been None
+            return results[0]
+
+    def _serialize(self, value, key, obj):
+        if value is None:
+            return None
+        try:
+            if self.many:
+                return [self.disambiguation_function(v).dump(v).data for v in value]
+            else:
+                return self.disambiguation_function(value).dump(value).data
+        except Exception as err:
+            raise TypeError(
+                'Failed to serialize object. Error: {}\n'
+                ' Ensure the selection function returns a Schema and that schema'
+                ' can serialize this value {}'.format(err, value))
+
 # Aliases
 URL = Url
 Enum = Select

--- a/tests/shapes.py
+++ b/tests/shapes.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from marshmallow import Schema, fields
+
+
+class Shape(object):
+    def __init__(self, color):
+        self.color = color
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+
+class ShapeSchema(Schema):
+    color = fields.Str(allow_none=True)
+
+
+class Triangle(Shape):
+    def __init__(self, color, base, height):
+        super(Triangle, self).__init__(color)
+        self.base = base
+        self.height = height
+
+
+class TriangleSchema(ShapeSchema):
+    base = fields.Int(required=True)
+    height = fields.Int(required=True)
+
+    def make_object(self, data):
+        return Triangle(
+            color=data['color'],
+            base=data['base'],
+            height=data['height']
+        )
+
+
+class Rectangle(Shape):
+    def __init__(self, color, length, width):
+        super(Rectangle, self).__init__(color)
+        self.length = length
+        self.width = width
+
+
+class RectangleSchema(ShapeSchema):
+    length = fields.Int(required=True)
+    width = fields.Int(required=True)
+
+    def make_object(self, data):
+        return Rectangle(
+            color=data['color'],
+            length=data['length'],
+            width=data['width']
+        )
+
+
+def shape_schema_disambiguation(value):
+    class_to_schema = {
+        Rectangle.__name__: RectangleSchema,
+        Triangle.__name__: TriangleSchema
+    }
+    try:
+        return class_to_schema[value.__class__.__name__]()
+    except KeyError:
+        pass
+
+    try:
+        if value.get("base"):
+            return TriangleSchema()
+        elif value.get("length"):
+            return RectangleSchema()
+    except AttributeError:
+        pass
+
+    raise TypeError("Could not detect type. "
+                    "Did not have a base or a length. "
+                    "Are you sure this is a shape?")


### PR DESCRIPTION
Howdy!

I use marshmallow to communicate with a service using polymorphism. One of the fields is basically "anything that is a subtype of X" I was not sure how to implement this with what was there so I wrote this field.

I thought I would offer it to you in case you wanted it. 

If you want to support the use case but have an idea for a better design (I find the disambiguation function a tad clunky but a better way of disambiguating did not come to me...) I would gladly implement it.

If you like it ill write up some docs for it. Otherwise close and forget :-)

Thanks for this library btw. Really helped me out.
