### PR TITLE
Improve decorator signatures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 2.0.0rc2 (unreleased)
 +++++++++++++++++++++
 
+Changes since 2.0.0rc1:
+
+- The ``raw`` parameter of the ``pre_*``, ``post_*``, ``validates_schema`` decorators was renamed to ``pass_many`` (:issue:`276`).
+- Add ``pass_original`` parameter to ``post_load`` and ``post_dump`` (:issue:`216`).
+- Methods decorated with the ``pre_*``, ``post_*``, and ``validates_*`` decorators must be instance methods. Class methods and instance methods are not supported at this time.
+
 2.0.0rc1 (2015-09-13)
 +++++++++++++++++++++
 

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -87,7 +87,7 @@ def pre_dump(fn=None, pass_many=False):
     return tag_processor(PRE_DUMP, fn, pass_many)
 
 
-def post_dump(fn=None, pass_many=False):
+def post_dump(fn=None, pass_many=False, pass_original=False):
     """Register a method to invoke after serializing an object. The method
     receives the serialized object and returns the processed object.
 
@@ -95,7 +95,7 @@ def post_dump(fn=None, pass_many=False):
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_DUMP, fn, pass_many)
+    return tag_processor(POST_DUMP, fn, pass_many, pass_original=pass_original)
 
 
 def pre_load(fn=None, pass_many=False):
@@ -109,7 +109,7 @@ def pre_load(fn=None, pass_many=False):
     return tag_processor(PRE_LOAD, fn, pass_many)
 
 
-def post_load(fn=None, pass_many=False):
+def post_load(fn=None, pass_many=False, pass_original=False):
     """Register a method to invoke after deserializing an object. The method
     receives the deserialized data and returns the processed data.
 
@@ -117,7 +117,7 @@ def post_load(fn=None, pass_many=False):
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_LOAD, fn, pass_many)
+    return tag_processor(POST_LOAD, fn, pass_many, pass_original=pass_original)
 
 
 class _StaticProcessorMethod(staticmethod):

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -39,6 +39,10 @@ Example: ::
             if data < 14:
                 raise ValidationError('Too young!')
 
+.. note::
+    These decorators only work with instance methods. Class and static
+    methods are not supported.
+
 .. warning::
     The invocation order of decorated methods of the same type is not guaranteed.
     If you need to guarantee order of different processing steps, you should put
@@ -121,7 +125,11 @@ def post_load(fn=None, pass_many=False, pass_original=False):
 
 
 def tag_processor(tag_name, fn, pass_many, **kwargs):
-    """Tags decorated processor function to be picked up later
+    """Tags decorated processor function to be picked up later.
+
+    .. note::
+        Currently ony works with functions and instance methods. Class and
+        static methods are not supported.
 
     :return: Decorated function if supplied, else this decorator with its args
         bound.

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -19,12 +19,12 @@ Example: ::
             item['email'] = item['email'].lower().strip()
             return item
 
-        @pre_load(raw=True)
+        @pre_load(pass_many=True)
         def remove_envelope(self, data, many):
             namespace = 'results' if many else 'result'
             return data[namespace]
 
-        @post_dump(raw=True):
+        @post_dump(pass_many=True):
         def add_envelope(self, data, many):
             namespace = 'results' if many else 'result'
             return {namespace: data}
@@ -63,61 +63,61 @@ def validates(field_name):
     return tag_processor(VALIDATES, None, False, field_name=field_name)
 
 
-def validates_schema(fn=None, raw=False, pass_original=False):
+def validates_schema(fn=None, pass_many=False, pass_original=False):
     """Register a schema-level validates_schema method.
 
     By default, receives a single object at a time, regardless of whether ``many=True``
-    is passed to the `Schema`. If ``raw=True``, the raw data (which may be a collection)
+    is passed to the `Schema`. If ``pass_many=True``, the raw data (which may be a collection)
     and the value for ``many`` is passed.
 
     If ``pass_original=True``, the original data (before unmarshalling) will be passed as
     an additional argument to the method.
     """
-    return tag_processor(VALIDATES_SCHEMA, fn, raw, pass_original=pass_original)
+    return tag_processor(VALIDATES_SCHEMA, fn, pass_many, pass_original=pass_original)
 
 
-def pre_dump(fn=None, raw=False):
+def pre_dump(fn=None, pass_many=False):
     """Register a method to invoke before serializing an object. The method
     receives the object to be serialized and returns the processed object.
 
     By default, receives a single object at a time, regardless of whether ``many=True``
-    is passed to the `Schema`. If ``raw=True``, the raw data (which may be a collection)
+    is passed to the `Schema`. If ``pass_many=True``, the raw data (which may be a collection)
     and the value for ``many`` is passed.
     """
-    return tag_processor(PRE_DUMP, fn, raw)
+    return tag_processor(PRE_DUMP, fn, pass_many)
 
 
-def post_dump(fn=None, raw=False):
+def post_dump(fn=None, pass_many=False):
     """Register a method to invoke after serializing an object. The method
     receives the serialized object and returns the processed object.
 
     By default, receives a single object at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``raw=True``, the raw data
+    argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_DUMP, fn, raw)
+    return tag_processor(POST_DUMP, fn, pass_many)
 
 
-def pre_load(fn=None, raw=False):
+def pre_load(fn=None, pass_many=False):
     """Register a method to invoke before deserializing an object. The method
     receives the data to be deserialized and returns the processed data.
 
     By default, receives a single datum at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``raw=True``, the raw data
+    argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(PRE_LOAD, fn, raw)
+    return tag_processor(PRE_LOAD, fn, pass_many)
 
 
-def post_load(fn=None, raw=False):
+def post_load(fn=None, pass_many=False):
     """Register a method to invoke after deserializing an object. The method
     receives the deserialized data and returns the processed data.
 
     By default, receives a single datum at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``raw=True``, the raw data
+    argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_LOAD, fn, raw)
+    return tag_processor(POST_LOAD, fn, pass_many)
 
 
 class _StaticProcessorMethod(staticmethod):
@@ -130,14 +130,14 @@ class _ClassProcessorMethod(classmethod):
     pass
 
 
-def tag_processor(tag_name, fn, raw, **kwargs):
+def tag_processor(tag_name, fn, pass_many, **kwargs):
     """Tags decorated processor function to be picked up later
 
     :return: Decorated function if supplied, else this decorator with its args
         bound.
     """
     if fn is None:  # Allow decorator to be used with no arguments
-        return lambda fn_actual: tag_processor(tag_name, fn_actual, raw, **kwargs)
+        return lambda fn_actual: tag_processor(tag_name, fn_actual, pass_many, **kwargs)
 
     # Special-case rewrapping staticmethod and classmethod, because we can't
     # directly set attributes on those.
@@ -163,12 +163,12 @@ def tag_processor(tag_name, fn, raw, **kwargs):
     except AttributeError:
         fn.__marshmallow_tags__ = marshmallow_tags = set()
     # Also save the kwargs for the tagged function on
-    # __marshmallow_kwargs__, keyed by (<tag_name>, <raw>)
+    # __marshmallow_kwargs__, keyed by (<tag_name>, <pass_many>)
     try:
         marshmallow_kwargs = fn.__marshmallow_kwargs__
     except AttributeError:
         fn.__marshmallow_kwargs__ = marshmallow_kwargs = {}
-    marshmallow_tags.add((tag_name, raw))
-    marshmallow_kwargs[(tag_name, raw)] = kwargs
+    marshmallow_tags.add((tag_name, pass_many))
+    marshmallow_kwargs[(tag_name, pass_many)] = kwargs
 
     return fn

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -120,16 +120,6 @@ def post_load(fn=None, pass_many=False, pass_original=False):
     return tag_processor(POST_LOAD, fn, pass_many, pass_original=pass_original)
 
 
-class _StaticProcessorMethod(staticmethod):
-    """Allows setting attributes on a staticmethod"""
-    pass
-
-
-class _ClassProcessorMethod(classmethod):
-    """Allows setting attributes on a classmethod"""
-    pass
-
-
 def tag_processor(tag_name, fn, pass_many, **kwargs):
     """Tags decorated processor function to be picked up later
 
@@ -138,23 +128,6 @@ def tag_processor(tag_name, fn, pass_many, **kwargs):
     """
     if fn is None:  # Allow decorator to be used with no arguments
         return lambda fn_actual: tag_processor(tag_name, fn_actual, pass_many, **kwargs)
-
-    # Special-case rewrapping staticmethod and classmethod, because we can't
-    # directly set attributes on those.
-    if isinstance(fn, staticmethod):
-        try:
-            unwrapped = fn.__func__
-        except AttributeError:
-            # For Python 2.6.
-            unwrapped = fn.__get__(True)
-        fn = _StaticProcessorMethod(unwrapped)
-    elif isinstance(fn, classmethod):
-        try:
-            unwrapped = fn.__func__
-        except AttributeError:
-            # For Python 2.6.
-            unwrapped = fn.__get__(True).im_func
-        fn = _ClassProcessorMethod(unwrapped)
 
     # Set a marshmallow_tags attribute instead of wrapping in some class,
     # because I still want this to end up as a normal (unbound) method.

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -467,10 +467,10 @@ class BaseSchema(base.SchemaABC):
         if update_fields:
             self._update_fields(obj, many=many)
 
-        obj = self._invoke_dump_processors(PRE_DUMP, obj, many)
+        processed_obj = self._invoke_dump_processors(PRE_DUMP, obj, many, original_data=obj)
 
         preresult = self._marshal(
-            obj,
+            processed_obj,
             self.fields,
             many=many,
             strict=self.strict,
@@ -483,7 +483,7 @@ class BaseSchema(base.SchemaABC):
         result = self._postprocess(preresult, many, obj=obj)
         errors = self._marshal.errors
 
-        result = self._invoke_dump_processors(POST_DUMP, result, many)
+        result = self._invoke_dump_processors(POST_DUMP, result, many, original_data=obj)
 
         return MarshalResult(result, errors)
 
@@ -579,10 +579,10 @@ class BaseSchema(base.SchemaABC):
         """
         many = self.many if many is None else bool(many)
 
-        data = self._invoke_load_processors(PRE_LOAD, data, many)
+        processed_data = self._invoke_load_processors(PRE_LOAD, data, many, original_data=data)
 
         result = self._unmarshal(
-            data,
+            processed_data,
             self.fields,
             many=many,
             strict=self.strict,
@@ -600,7 +600,7 @@ class BaseSchema(base.SchemaABC):
             if callable(error_handler):
                 error_handler(errors, data)
 
-        result = self._invoke_load_processors(POST_LOAD, result, many)
+        result = self._invoke_load_processors(POST_LOAD, result, many, original_data=data)
 
         if not errors and postprocess:
             if many:
@@ -702,19 +702,23 @@ class BaseSchema(base.SchemaABC):
                 ret[key] = field_obj
         return ret
 
-    def _invoke_dump_processors(self, tag_name, data, many):
+    def _invoke_dump_processors(self, tag_name, data, many, original_data=None):
         # The pass_many post-dump processors may do things like add an envelope, so
         # invoke those after invoking the non-pass_many processors which will expect
         # to get a list of items.
-        data = self._invoke_processors(tag_name, pass_many=False, data=data, many=many)
-        data = self._invoke_processors(tag_name, pass_many=True, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=False,
+            data=data, many=many, original_data=original_data)
+        data = self._invoke_processors(tag_name, pass_many=True,
+            data=data, many=many, original_data=original_data)
         return data
 
-    def _invoke_load_processors(self, tag_name, data, many):
+    def _invoke_load_processors(self, tag_name, data, many, original_data=None):
         # This has to invert the order of the dump processors, so run the pass_many
         # processors first.
-        data = self._invoke_processors(tag_name, pass_many=True, data=data, many=many)
-        data = self._invoke_processors(tag_name, pass_many=False, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=True,
+            data=data, many=many, original_data=original_data)
+        data = self._invoke_processors(tag_name, pass_many=False,
+            data=data, many=many, original_data=original_data)
         return data
 
     def _invoke_field_validators(self, data, many):
@@ -773,20 +777,30 @@ class BaseSchema(base.SchemaABC):
                     pass_original=pass_original)
         return None
 
-    def _invoke_processors(self, tag_name, pass_many, data, many):
+    def _invoke_processors(self, tag_name, pass_many, data, many, original_data=None):
         for attr_name in self.__processors__[(tag_name, pass_many)]:
             # This will be a bound method.
             processor = getattr(self, attr_name)
 
-            # It's probably not worth the extra LoC to hoist this branch out of
-            # the loop.
-            if pass_many:
-                data = utils.if_none(processor(data, many), data)
-            elif many:
-                data = [utils.if_none(processor(item), item) for item in data]
-            else:
-                data = utils.if_none(processor(data), data)
+            processor_kwargs = processor.__marshmallow_kwargs__[(tag_name, pass_many)]
+            pass_original = processor_kwargs.get('pass_original', False)
 
+            if pass_many:
+                if pass_original:
+                    data = utils.if_none(processor(data, many, original_data), data)
+                else:
+                    data = utils.if_none(processor(data, many), data)
+            elif many:
+                if pass_original:
+                    data = [utils.if_none(processor(item, original_data), item)
+                            for item in data]
+                else:
+                    data = [utils.if_none(processor(item), item) for item in data]
+            else:
+                if pass_original:
+                    data = utils.if_none(processor(data, original_data), data)
+                else:
+                    data = utils.if_none(processor(data), data)
         return data
 
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -591,8 +591,8 @@ class BaseSchema(base.SchemaABC):
         )
         self._invoke_field_validators(data=result, many=many)
         # Run schema-level migration
-        self._invoke_validators(raw=True, data=result, original_data=data, many=many)
-        self._invoke_validators(raw=False, data=result, original_data=data, many=many)
+        self._invoke_validators(pass_many=True, data=result, original_data=data, many=many)
+        self._invoke_validators(pass_many=False, data=result, original_data=data, many=many)
         errors = self._unmarshal.errors
         if errors:
             # TODO: Remove self.__error_handler__ in a later release
@@ -703,18 +703,18 @@ class BaseSchema(base.SchemaABC):
         return ret
 
     def _invoke_dump_processors(self, tag_name, data, many):
-        # The raw post-dump processors may do things like add an envelope, so
-        # invoke those after invoking the non-raw processors which will expect
+        # The pass_many post-dump processors may do things like add an envelope, so
+        # invoke those after invoking the non-pass_many processors which will expect
         # to get a list of items.
-        data = self._invoke_processors(tag_name, raw=False, data=data, many=many)
-        data = self._invoke_processors(tag_name, raw=True, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=False, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=True, data=data, many=many)
         return data
 
     def _invoke_load_processors(self, tag_name, data, many):
-        # This has to invert the order of the dump processors, so run the raw
+        # This has to invert the order of the dump processors, so run the pass_many
         # processors first.
-        data = self._invoke_processors(tag_name, raw=True, data=data, many=many)
-        data = self._invoke_processors(tag_name, raw=False, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=True, data=data, many=many)
+        data = self._invoke_processors(tag_name, pass_many=False, data=data, many=many)
         return data
 
     def _invoke_field_validators(self, data, many):
@@ -755,12 +755,12 @@ class BaseSchema(base.SchemaABC):
                         field_obj=field_obj
                     )
 
-    def _invoke_validators(self, raw, data, original_data, many):
-        for attr_name in self.__processors__[(VALIDATES_SCHEMA, raw)]:
+    def _invoke_validators(self, pass_many, data, original_data, many):
+        for attr_name in self.__processors__[(VALIDATES_SCHEMA, pass_many)]:
             validator = getattr(self, attr_name)
-            validator_kwargs = validator.__marshmallow_kwargs__[(VALIDATES_SCHEMA, raw)]
+            validator_kwargs = validator.__marshmallow_kwargs__[(VALIDATES_SCHEMA, pass_many)]
             pass_original = validator_kwargs.get('pass_original', False)
-            if raw:
+            if pass_many:
                 validator = partial(validator, many=many)
             if many:
                 for idx, item in enumerate(data):
@@ -773,14 +773,14 @@ class BaseSchema(base.SchemaABC):
                     pass_original=pass_original)
         return None
 
-    def _invoke_processors(self, tag_name, raw, data, many):
-        for attr_name in self.__processors__[(tag_name, raw)]:
+    def _invoke_processors(self, tag_name, pass_many, data, many):
+        for attr_name in self.__processors__[(tag_name, pass_many)]:
             # This will be a bound method.
             processor = getattr(self, attr_name)
 
             # It's probably not worth the extra LoC to hoist this branch out of
             # the loop.
-            if raw:
+            if pass_many:
                 data = utils.if_none(processor(data, many), data)
             elif many:
                 data = [utils.if_none(processor(item), item) for item in data]

--- a/tests/base.py
+++ b/tests/base.py
@@ -125,7 +125,6 @@ class DummyModel(object):
 
 ###### Schemas #####
 
-
 class Uppercased(fields.Field):
     """Custom field formatting example."""
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -13,6 +13,7 @@ from marshmallow import (
     ValidationError,
 )
 
+
 def test_decorated_processors():
     class ExampleSchema(Schema):
         """Includes different ways to invoke decorators and set up methods"""
@@ -23,16 +24,14 @@ def test_decorated_processors():
 
         # Implicit default raw, pre dump, static method, return modified item.
         @pre_dump
-        @staticmethod
-        def increment_value(item):
+        def increment_value(self, item):
             item['value'] += 1
             return item
 
         # Implicit default raw, post dump, class method, modify in place.
         @post_dump
-        @classmethod
-        def add_tag(cls, item):
-            item['value'] = cls.TAG + item['value']
+        def add_tag(self, item):
+            item['value'] = self.TAG + item['value']
 
         # Explicitly raw, post dump, instance method, return modified item.
         @post_dump(pass_many=True)
@@ -76,31 +75,123 @@ def test_decorated_processors():
     items_loaded = schema.load(items_dumped, many=True).data
     assert items_loaded == make_items()
 
+class TestPassOriginal:
+
+    def test_pass_original_single_no_mutation(self):
+        class MySchema(Schema):
+            foo = fields.Field()
+
+            @post_load(pass_original=True)
+            def post_load(self, data, input_data):
+                ret = data.copy()
+                ret['_post_load'] = input_data['sentinel']
+                return ret
+
+            @post_dump(pass_original=True)
+            def post_dump(self, data, obj):
+                ret = data.copy()
+                ret['_post_dump'] = obj['sentinel']
+                return ret
+
+        schema = MySchema()
+        datum = {'foo': 42, 'sentinel': 24}
+        item_loaded = schema.load(datum).data
+        assert item_loaded['foo'] == 42
+        assert item_loaded['_post_load'] == 24
+
+        item_dumped = schema.dump(datum).data
+
+        assert item_dumped['foo'] == 42
+        assert item_dumped['_post_dump'] == 24
+
+    def test_pass_original_single_with_mutation(self):
+        class MySchema(Schema):
+            foo = fields.Field()
+
+            @post_load(pass_original=True)
+            def post_load(self, data, input_data):
+                data['_post_load'] = input_data['post_load']
+
+        schema = MySchema()
+        item_loaded = schema.load({'foo': 42, 'post_load': 24}).data
+        assert item_loaded['foo'] == 42
+        assert item_loaded['_post_load'] == 24
+
+    def test_pass_original_many(self):
+        class MySchema(Schema):
+            foo = fields.Field()
+
+            @post_load(pass_many=True, pass_original=True)
+            def post_load(self, data, many, original):
+                if many:
+                    ret = []
+                    for item, orig_item in zip(data, original):
+                        item['_post_load'] = orig_item['sentinel']
+                        ret.append(item)
+                else:
+                    ret = data.copy()
+                    ret['_post_load'] = original['sentinel']
+                return ret
+
+            @post_dump(pass_many=True, pass_original=True)
+            def post_dump(self, data, many, original):
+                if many:
+                    ret = []
+                    for item, orig_item in zip(data, original):
+                        item['_post_dump'] = orig_item['sentinel']
+                        ret.append(item)
+                else:
+                    ret = data.copy()
+                    ret['_post_dump'] = original['sentinel']
+                return ret
+
+        schema = MySchema()
+        data = [{'foo': 42, 'sentinel': 24}, {'foo': 424, 'sentinel': 242}]
+        items_loaded = schema.load(data, many=True).data
+        assert items_loaded == [
+            {'foo': 42, '_post_load': 24},
+            {'foo': 424, '_post_load': 242},
+        ]
+        test_values = [e['_post_load'] for e in items_loaded]
+        assert test_values == [24, 242]
+
+        items_dumped = schema.dump(data, many=True).data
+        assert items_dumped == [
+            {'foo': 42, '_post_dump': 24},
+            {'foo': 424, '_post_dump': 242},
+        ]
+
+        # Also check load/dump of single item
+
+        datum = {'foo': 42, 'sentinel': 24}
+        item_loaded = schema.load(datum, many=False).data
+        assert item_loaded == {'foo': 42, '_post_load': 24}
+
+        item_dumped = schema.dump(datum, many=False).data
+        assert item_dumped == {'foo': 42, '_post_dump': 24}
 
 def test_decorated_processor_inheritance():
     class ParentSchema(Schema):
+
         @post_dump
-        @staticmethod
-        def inherited(item):
+        def inherited(self, item):
             item['inherited'] = 'inherited'
             return item
 
         @post_dump
-        @staticmethod
-        def overridden(item):
+        def overridden(self, item):
             item['overridden'] = 'base'
             return item
 
         @post_dump
-        @staticmethod
-        def deleted(item):
+        def deleted(self, item):
             item['deleted'] = 'retained'
             return item
 
     class ChildSchema(ParentSchema):
+
         @post_dump
-        @staticmethod
-        def overridden(item):
+        def overridden(self, item):
             item['overridden'] = 'overridden'
             return item
 
@@ -119,19 +210,18 @@ def test_decorated_processor_inheritance():
         'overridden': 'overridden'
     }
 
+class ValidatesSchema(Schema):
+    foo = fields.Int()
+
+    @validates('foo')
+    def validate_foo(self, value):
+        if value != 42:
+            raise ValidationError('The answer to life the universe and everything.')
 
 class TestValidatesDecorator:
 
-    class MySchema(Schema):
-        foo = fields.Int()
-
-        @validates('foo')
-        def validate_foo(self, value):
-            if value != 42:
-                raise ValidationError('The answer to life the universe and everything.')
-
-    def test_decorator(self):
-        schema = self.MySchema()
+    def test_validates_decorator(self):
+        schema = ValidatesSchema()
 
         errors = schema.validate({'foo': 41})
         assert 'foo' in errors
@@ -152,7 +242,7 @@ class TestValidatesDecorator:
         assert errors == {}
 
     def test_field_not_present(self):
-        class BadSchema(self.MySchema):
+        class BadSchema(ValidatesSchema):
             @validates('bar')
             def validate_bar(self, value):
                 raise ValidationError('Never raised.')
@@ -160,11 +250,11 @@ class TestValidatesDecorator:
         schema = BadSchema()
 
         with pytest.raises(ValueError) as excinfo:
-            errors = schema.validate({'foo': 42})
+            schema.validate({'foo': 42})
         assert '"bar" field does not exist.' in str(excinfo)
 
     def test_precedence(self):
-        class Schema2(self.MySchema):
+        class Schema2(ValidatesSchema):
             foo = fields.Int(validate=lambda n: n != 42)
             bar = fields.Int(validate=lambda n: n == 1)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -35,13 +35,13 @@ def test_decorated_processors():
             item['value'] = cls.TAG + item['value']
 
         # Explicitly raw, post dump, instance method, return modified item.
-        @post_dump(raw=True)
+        @post_dump(pass_many=True)
         def add_envelope(self, data, many):
             key = self.get_envelope_key(many)
             return {key: data}
 
         # Explicitly raw, pre load, instance method, return modified item.
-        @pre_load(raw=True)
+        @pre_load(pass_many=True)
         def remove_envelope(self, data, many):
             key = self.get_envelope_key(many)
             return data[key]
@@ -51,7 +51,7 @@ def test_decorated_processors():
             return 'data' if many else 'datum'
 
         # Explicitly not raw, pre load, instance method, modify in place.
-        @pre_load(raw=False)
+        @pre_load(pass_many=False)
         def remove_tag(self, item):
             item['value'] = item['value'][len(self.TAG):]
 
@@ -204,7 +204,7 @@ class TestValidatesSchemaDecorator:
                 if data['foo'] <= 3:
                     raise ValidationError('Must be greater than 3')
 
-            @validates_schema(raw=True)
+            @validates_schema(pass_many=True)
             def validate_raw(self, data, many):
                 if many:
                     if len(data) < 2:
@@ -242,7 +242,7 @@ class TestValidatesSchemaDecorator:
                     raise ValidationError('foo cannot be a string')
 
             # See https://github.com/marshmallow-code/marshmallow/issues/127
-            @validates_schema(raw=True, pass_original=True)
+            @validates_schema(pass_many=True, pass_original=True)
             def check_unknown_fields(self, data, original_data, many):
                 def check(datum):
                     for key, val in datum.items():


### PR DESCRIPTION
See #276 .
- [x] Rename `raw` -> `pass_many`
- [x] Add `pass_original` to `post_load` and `post_dump`
- [x] Remove dead code for supporting class/static methods
- [x] Update "Upgrading docs" and changelog

Note: This drops support for `classmethods` and `staticmethods`. See message in bcb4cc6.
