### PR TITLE
Prevent infinite loop when recursive required field is missing

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -50,6 +50,7 @@ MISSING_ERROR_MESSAGE = (
     'ValidationError raised by `{class_name}`, but error key `{key}` does '
     'not exist in the `error_messages` dictionary.'
 )
+_RECURSIVE_NESTED = 'self'
 
 
 class Field(FieldABC):
@@ -392,7 +393,7 @@ class Nested(Field):
                 self.__schema = self.nested(many=self.many,
                         only=only, exclude=self.exclude)
             elif isinstance(self.nested, basestring):
-                if self.nested == 'self':
+                if self.nested == _RECURSIVE_NESTED:
                     parent_class = self.parent.__class__
                     self.__schema = parent_class(many=self.many, only=only,
                             exclude=self.exclude)
@@ -440,6 +441,8 @@ class Nested(Field):
         `value` should be considered missing.
         """
         if value is missing_ and hasattr(self, 'required'):
+            if self.nested == _RECURSIVE_NESTED:
+                self.fail('required')
             errors = self._check_required()
             if errors:
                 raise ValidationError(errors)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1252,6 +1252,16 @@ class TestSelfReference:
         assert data['employer']['name'] == employer.name
         assert data['employer']['age'] == employer.age
 
+    def test_recursive_missing_required_field(self):
+        class BasicSchema(Schema):
+            sub_basics = fields.Nested("self", required=True)
+
+        data, errors = BasicSchema().load({})
+        assert data == {}
+        assert errors == {
+            'sub_basics': ['Missing data for required field.']
+        }
+
     def test_nested_self_with_only_param(self, user, employer):
         class SelfSchema(Schema):
             employer = fields.Nested('self', only=('name', ))


### PR DESCRIPTION
Got bit by this one when testing my error flows

When trying to get all the errors in infinitely recurses and explodes
