### PR TITLE
Update setup.py to use explicit setuptools options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ EXTRA_REQUIREMENTS = ['python-dateutil', 'simplejson']
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = ['--verbose', 'tests/']
-        self.test_suite = True
+        self.verbose = True
+        self.test_suite = 'tests'
 
     def run_tests(self):
         import pytest


### PR DESCRIPTION
Fixes #300. setuptools 18.4 changed command.test.test_args to a
read-only property. This change uses the existing API to replicate the
same desired CLI args to py.test.
