### PR TITLE
Fixing issue with PyMongo cursor not being serialized properly

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -696,7 +696,7 @@ class BaseSchema(base.SchemaABC):
                     obj_prototype = obj[0]
                 else:
                     obj_prototype = next(iter(obj))
-            except StopIteration:  # Nothing to serialize
+            except (StopIteration, IndexError):  # Nothing to serialize
                 return self.declared_fields
             obj = obj_prototype
         ret = self.dict_class()


### PR DESCRIPTION
This is our current workaround for getting the PyMongo cursors back on track again. All previous tests pass. Please consider to merge.

And thanks for a great library!
