### PR TITLE
pytest: don't recurse into virtualenv + other dirs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ universal = 1
 ignore = E127,E128,E265,E302,N803,N804,N806,E266,E731
 max-line-length = 100
 exclude = .git,.ropeproject,.tox,docs,.git,tests/,examples/,marshmallow/compat.py,marshmallow/ordereddict.py,build,setup.py,env,venv
+
+[pytest]
+norecursedirs = .git .ropeproject .tox docs env venv


### PR DESCRIPTION
While developing, `invoke test` failed due to some tests inside virtualenv.

This should prevent pytest to run tests outside marshmallow source code.

https://pytest.org/latest/customize.html#confval-norecursedirs
