### PR TITLE
Implements #302: Allow callable in fields.Nested

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,4 @@ Contributors (chronological)
 - `@Mise <https://github.com/Mise>`_
 - Taylor Edmiston `@tedmiston <https://github.com/tedmiston>`_
 - Francisco Demartino `@franciscod <https://github.com/franciscod>`_
+- Alec Reiter `@justanr <https://github.com/justanr>`_

--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -214,6 +214,42 @@ If the object to be marshalled has a relationship to an object of the same type,
     #     }
     # }
 
+Using A Callable To Nest
+------------------------
+
+It's also possible to use a callable to nest a `Schema`. The callable must accept
+the many, exclude, only, parent and context keywords and it must return an instance
+of `Schema` as well. The passed callable may be a function, method or object that 
+defines `__call__`.
+
+.. code-block:: python
+    :emphasize-lines: 1,6
+
+    def make_schema(many, exclude, only, **kwargs):
+        return UserSchema(many=many, exclude=exclude, only=only)
+
+    class BlogSchema(Schema):
+        title = fields.String()
+        author = fields.Nested(make_schema)
+
+    user = User(name="Monty", email="monty@python.com")
+    blog = Blog(title="The Architects", author=user)
+    result, errors = BlogSchema().dump(blog)
+    pprint(result)
+    #{'title': u'The Architects',
+    #{'author': {'name': u'Monty',
+    #            'email': u'monty@python.com',
+    #            'created_at': '2014-08-17T14:58:57.600623+00:00'}}
+
+Alternatively, the function could examine it's parameters and dynamically determine
+which schema to return, or provide extra configuration to it.
+
+.. note::
+    Once a schema has been instantiated and used, the `Nested` field holds a reference
+    to it, meaning the callable will only be invoked once for each instance of the
+    schema that holds reference to the `Nested` field.
+
+
 Next Steps
 ----------
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -339,8 +339,9 @@ class Nested(Field):
         collaborators = fields.Nested(UserSchema, many=True, only='id')
         parent = fields.Nested('self')
 
-    :param Schema nested: The Schema class or class name (string)
-        to nest, or ``"self"`` to nest the :class:`Schema` within itself.
+    :param Schema nested: The Schema class, class name (string)
+        to nest, ``"self"`` to nest the :class:`Schema` within itself or a callable
+        that returns a :class:`Schema` instance.
     :param default: Default value to if attribute is missing or None
     :param tuple exclude: A list or tuple of fields to exclude.
     :param required: Raise an :exc:`ValidationError` during deserialization
@@ -376,6 +377,9 @@ class Nested(Field):
 
         .. versionchanged:: 1.0.0
             Renamed from `serializer` to `schema`
+
+        .. versionchanged:: 2.3.0
+            Allow callable to be provided in addition to string, instance and class
         """
         # Ensure that only parameter is a tuple
         if isinstance(self.only, basestring):
@@ -399,8 +403,9 @@ class Nested(Field):
                     self.__schema = schema_class(many=self.many,
                             only=only, exclude=self.exclude)
             elif callable(self.nested):
+                context = getattr(self.parent, 'context', {})
                 schema = self.nested(many=self.many, exclude=self.exclude,
-                                     only=only)
+                                     only=only, parent=self.parent, context=context)
                 if not isinstance(schema, SchemaABC):
                     raise ValueError('Nested callable must return a Schema'
                                      ' not {0}.'.format(self.nested.__class__))

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -398,6 +398,13 @@ class Nested(Field):
                     schema_class = class_registry.get_class(self.nested)
                     self.__schema = schema_class(many=self.many,
                             only=only, exclude=self.exclude)
+            elif callable(self.nested):
+                schema = self.nested(many=self.many, exclude=self.exclude,
+                                     only=only)
+                if not isinstance(schema, SchemaABC):
+                    raise ValueError('Nested callable must return a Schema'
+                                     ' not {0}.'.format(self.nested.__class__))
+                self.__schema = schema
             else:
                 raise ValueError('Nested fields must be passed a '
                                  'Schema, not {0}.'.format(self.nested.__class__))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1424,7 +1424,7 @@ class TestPassCallableForSchema:
 
         assert isinstance(NestedCallable._declared_fields['user'].schema, UserSchema)
 
-    def test_raise_error_on_non_schema_return(self, blog):
+    def test_nested_raises_error_on_non_schema_return(self, blog):
         def make_schema(**kwargs):
             return None
 
@@ -1434,7 +1434,7 @@ class TestPassCallableForSchema:
         with pytest.raises(ValueError):
             BustedCallableSchema._declared_fields['user'].schema
 
-    def test_pass_args_to_callable(self):
+    def test_nested_passes_args_to_callable(self):
         def make_schema(many, only, exclude):
             return UserSchema(many=many, exclude=exclude, only=only)
 
@@ -1444,6 +1444,8 @@ class TestPassCallableForSchema:
         nested = NestedCallable._declared_fields['user'].schema
 
         assert nested.many and nested.exclude == ('homepage', 'id')
+
+
 
 
 class RequiredUserSchema(Schema):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1424,7 +1424,7 @@ class TestPassCallableForSchema:
 
         assert isinstance(NestedCallable._declared_fields['user'].schema, UserSchema)
 
-    def test_nested_raises_error_on_non_schema_return(self, blog):
+    def test_nested_raises_error_on_non_schema_return(self):
         def make_schema(**kwargs):
             return None
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1415,11 +1415,6 @@ class TestSelfReference:
 
 
 class TestPassCallableForSchema:
-    @pytest.fixture
-    def user(self):
-        return User(name="Monty", age=81)
-
-
     def test_pass_callable_to_nested(self):
         def make_schema(**kwargs):
             return UserSchema()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1435,7 +1435,7 @@ class TestPassCallableForSchema:
             BustedCallableSchema._declared_fields['user'].schema
 
     def test_nested_passes_args_to_callable(self):
-        def make_schema(many, only, exclude):
+        def make_schema(many, only, exclude, **kwargs):
             return UserSchema(many=many, exclude=exclude, only=only)
 
         class NestedCallable(Schema):
@@ -1445,8 +1445,23 @@ class TestPassCallableForSchema:
 
         assert nested.many and nested.exclude == ('homepage', 'id')
 
+    def test_nested_passes_context_and_parent(self, user):
+        check = {'parent': None, 'context': None}
 
+        def make_schema(many, exclude, only, parent, context):
+            check['parent'] = parent
+            check['context'] = context
+            return UserSchema()
 
+        thing = namedtuple('thing', ['user'])
+
+        class NestedCallable(Schema):
+            user = fields.Nested(make_schema)
+
+        NestedCallable().dump(thing(user))
+
+        assert check['parent'] is not None
+        assert check['context'] is not None
 
 class RequiredUserSchema(Schema):
     name = fields.Field(required=True)


### PR DESCRIPTION
This only implements allowing a callable to `fields.Nested`. I'm happy to squash commits into one if desired.
