### PR TITLE
Re-work fields.Function

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,6 @@ wheel
 twine
 
 # Testing
-mock
 pytest==2.8.0
 tox>=1.5.0
 simplejson

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ wheel
 twine
 
 # Testing
+mock
 pytest==2.8.0
 tox>=1.5.0
 simplejson

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1133,27 +1133,27 @@ class Method(Field):
 class Function(Field):
     """A field that takes the value returned by a function.
 
-    :param callable func: This argument is to be depreciated. It exists for
-        backwards compatiblity. Use serialize instead.
-    :param callable deserialize: A callable from which to retrieve the value.
-        The function must take a single argument ``value`` which is the value
-        to be deserialized. It can also optionally take a ``context`` argument,
-        which is a dictionary of context variables passed to the deserializer.
-        If no callable is provided then ```value``` will be passed through
-        unchanged.
     :param callable serialize: A callable from which to retrieve the value.
         The function must take a single argument ``obj`` which is the object
         to be serialized. It can also optionally take a ``context`` argument,
         which is a dictionary of context variables passed to the serializer.
         If no callable is provided then the ```load_only``` flag will be set
         to True.
+    :param callable deserialize: A callable from which to retrieve the value.
+        The function must take a single argument ``value`` which is the value
+        to be deserialized. It can also optionally take a ``context`` argument,
+        which is a dictionary of context variables passed to the deserializer.
+        If no callable is provided then ```value``` will be passed through
+        unchanged.
+    :param callable func: This argument is to be deprecated. It exists for
+        backwards compatiblity. Use serialize instead.
     """
     _CHECK_ATTRIBUTE = False
 
-    def __init__(self, func=None, deserialize=None, serialize=None, **kwargs):
+    def __init__(self, serialize=None, deserialize=None, func=None, **kwargs):
         if func:
-            warnings.warn('Argument func of fields.Function is being depreciated.'
-                          ' Use the serialize argument instead.')
+            warnings.warn('"func" argument of fields.Function is deprecated. '
+                          'Use the "serialize" argument instead.')
             serialize = func
 
         super(Function, self).__init__(load_only=not serialize, **kwargs)
@@ -1167,7 +1167,7 @@ class Function(Field):
             pass
         return missing_
 
-    def _deserialize(self, value, attr, obj):
+    def _deserialize(self, value, attr, data):
         if self.deserialize_func:
             return self._call_or_raise(self.deserialize_func, value, attr)
         return value

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1135,16 +1135,11 @@ class Function(Field):
 
     :param callable func: This argument is to be depreciated. It exists for
         backwards compatiblity. Use serialize instead.
-
-        A callable from which to retrieve the value.
-        The function must take a single argument ``obj`` which is the object
-        to be serialized. It can also optionally take a ``context`` argument,
-        which is a dictionary of context variables passed to the serializer.
     :param callable deserialize: A callable from which to retrieve the value.
         The function must take a single argument ``value`` which is the value
         to be deserialized. It can also optionally take a ``context`` argument,
         which is a dictionary of context variables passed to the deserializer.
-        If no callable is provided then ```value``` we be passed through
+        If no callable is provided then ```value``` will be passed through
         unchanged.
     :param callable serialize: A callable from which to retrieve the value.
         The function must take a single argument ``obj`` which is the object

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -3,6 +3,7 @@ import datetime as dt
 import uuid
 import decimal
 
+import mock
 import pytest
 
 from marshmallow import fields, utils, Schema, validate
@@ -492,6 +493,15 @@ class TestFieldDeserialization:
         field = fields.Function(lambda x: None,
                                 deserialize=lambda val: val.upper())
         assert field.deserialize('foo') == 'FOO'
+
+    def test_function_field_deserialization_with_context(self):
+        field = fields.Function(
+            lambda x: None,
+            deserialize=lambda val, context: val.upper() + context['key']
+        )
+        field.parent = mock.MagicMock()
+        field.parent.context = {'key': 'BAR'}
+        assert field.deserialize('foo') == 'FOOBAR'
 
     def test_uuid_field_deserialization(self):
         field = fields.UUID()

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -495,12 +495,13 @@ class TestFieldDeserialization:
         assert field.deserialize('foo') == 'FOO'
 
     def test_function_field_deserialization_with_context(self):
+        class Parent(Schema):
+            pass
         field = fields.Function(
             lambda x: None,
             deserialize=lambda val, context: val.upper() + context['key']
         )
-        field.parent = mock.MagicMock()
-        field.parent.context = {'key': 'BAR'}
+        field.parent = Parent(context={'key': 'BAR'})
         assert field.deserialize('foo') == 'FOOBAR'
 
     def test_uuid_field_deserialization(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -69,11 +69,12 @@ class TestFieldSerialization:
         assert field.load_only
 
     def test_function_field_passed_serialize_with_context(self, user, monkeypatch):
+        class Parent(Schema):
+            pass
         field = fields.Function(
             serialize=lambda obj, context: obj.name.upper() + context['key']
         )
-        field.parent = mock.MagicMock()
-        field.parent.context = {'key': 'BAR'}
+        field.parent = Parent(context={'key': 'BAR'})
         assert "FOOBAR" == field.serialize("key", user)
 
     def test_function_field_passed_uncallable_object(self):


### PR DESCRIPTION
Argument func is now optional and deprecated in favor of serialize. The deserialize function can now optionally receive the context.

Note that deserialize is still noop by default to maintain backwards compatibility.

I'm assuming we don't want to mess with the order of arguments which is slightly untidy but I think we have to wear it for now for backwards compatibility.
