### PR TITLE
Optional serialization parameter for fields.Method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,3 +54,4 @@ Contributors (chronological)
 - Eric Wang `@ewang <https://github.com/ewang>`_
 - Eugene Prikazchikov `@eprikazc <https://github.com/eprikazc>`_
 - Damian Heard `@DamianHeard <https://github.com/DamianHeard>`_
+- Alec Reiter `@justanr <https://github.com/justanr>`_

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -23,8 +23,27 @@ The ``func`` parameter of `fields.Function <marshmallow.fields.Function>` was re
     # NO
     lowername = fields.Function(func=lambda obj: obj.name.lower())
 
+Similiarly, the ``method_name`` of `fields.Method <marshmallow.fields.Method>` was also renamed to ``serialize``.
+
+.. code-block:: python
+
+    # YES
+    lowername = fields.Method(serialize='lowercase')
+    # or
+    lowername = fields.Method('lowercase')
+
+    # NO
+    lowername = fields.Method(method_name='lowercase')
 
 The ``func`` parameter is still available for backwards-compatibility. It will be removed in marshmallow 3.0.
+
+Both `fields.Function <marshmallow.fields.Function>` and `fields.Method <marshmallow.fields.Method>` will allow the serialize parameter to not be passed, in this case use the ``deserialize`` parameter by name.
+
+.. code-block:: python
+
+    lowername = fields.Function(deserialize=lambda name: name.lower())
+    # or
+    lowername = fields.Method(deserialize='lowername')
 
 Upgrading to 2.0
 ++++++++++++++++

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -559,6 +559,16 @@ class TestFieldDeserialization:
         with pytest.raises(ValueError):
             s.fields['uppername'].deserialize('STEVE')
 
+    def test_method_field_deserialize_only(self):
+        class MethodDeserializeOnly(Schema):
+            def lowercase_name(self, value):
+                return value.lower()
+
+        m = fields.Method(deserialize='lowercase_name')
+        m.parent = MethodDeserializeOnly()
+
+        assert m.deserialize('ALEC') == 'alec'
+
     def test_datetime_list_field_deserialization(self):
         dtimes = dt.datetime.now(), dt.datetime.now(), dt.datetime.utcnow()
         dstrings = [each.isoformat() for each in dtimes]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -9,6 +9,7 @@ import pytest
 from marshmallow import Schema, fields, utils
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import basestring, OrderedDict
+from marshmallow.utils import missing as missing_
 
 from tests.base import User, DummyModel, ALL_FIELDS
 
@@ -337,6 +338,16 @@ class TestFieldSerialization:
         u = User('Foo')
         with pytest.raises(ValueError):
             BadSerializer().dump(u)
+
+    def test_method_prefers_serialize_over_method_name(self):
+        m = fields.Method(serialize='serialize', method_name='method')
+        assert m.serialize_method_name == 'serialize'
+
+    def test_method_with_no_serialize_is_missing(self):
+        m = fields.Method()
+        m.parent = Schema()
+
+        assert m.serialize('', '', '') is missing_
 
     def test_serialize_with_dump_to_param(self):
         class DumpToSchema(Schema):


### PR DESCRIPTION
'method_name' parameter of fields.Method is deprecated in favor of the
new 'serialize` method and is now optional. Serializing without a
provided method name returns the utils.missing value.

Implements and closes #329
