### PR TITLE
Minor type checking fix

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -301,7 +301,7 @@ def pluck(dictlist, key):
 
 def get_value(key, obj, default=missing):
     """Helper for pulling a keyed value off various types of objects"""
-    if type(key) == int:
+    if isinstance(key, int):
         return _get_value_for_key(key, obj, default)
     else:
         return _get_value_for_keys(key.split('.'), obj, default)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,6 +84,15 @@ def test_get_value_from_dict():
     assert utils.get_value('items', d) == ['foo', 'bar']
     assert utils.get_value('keys', d) == ['baz', 'quux']
 
+def test_get_value():
+    l = [1,2,3]
+    assert utils.get_value(1, l) == 2
+
+    class MyInt(int):
+        pass
+
+    assert utils.get_value(MyInt(1), l) == 2
+
 def test_is_keyed_tuple():
     Point = namedtuple('Point', ['x', 'y'])
     p = Point(24, 42)


### PR DESCRIPTION
Kinda pedantic, but using `isinstance(obj, cls)` is more Pythonic than `type(obj) == cls` and allows for whatever crazy subclass someone comes up with (`bool` because some people use).
