### PR TITLE
Optional skip_on_field_errors arg for validates_schema

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,3 +55,4 @@ Contributors (chronological)
 - Eugene Prikazchikov `@eprikazc <https://github.com/eprikazc>`_
 - Damian Heard `@DamianHeard <https://github.com/DamianHeard>`_
 - Alec Reiter `@justanr <https://github.com/justanr>`_
+- Dan Sutherland `@d-sutherland <https://github.com/d-sutherland>`_

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -69,7 +69,7 @@ def validates(field_name):
     return tag_processor(VALIDATES, None, False, field_name=field_name)
 
 
-def validates_schema(fn=None, pass_many=False, pass_original=False):
+def validates_schema(fn=None, pass_many=False, pass_original=False, skip_on_field_errors=False):
     """Register a schema-level validator.
 
     By default, receives a single object at a time, regardless of whether ``many=True``
@@ -78,8 +78,12 @@ def validates_schema(fn=None, pass_many=False, pass_original=False):
 
     If ``pass_original=True``, the original data (before unmarshalling) will be passed as
     an additional argument to the method.
+
+    If ``skip_on_field_errors=True``, this validation method will be skipped whenever
+    validation errors have been detected when validating fields.
     """
-    return tag_processor(VALIDATES_SCHEMA, fn, pass_many, pass_original=pass_original)
+    return tag_processor(VALIDATES_SCHEMA, fn, pass_many, pass_original=pass_original,
+                         skip_on_field_errors=skip_on_field_errors)
 
 
 def pre_dump(fn=None, pass_many=False):

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -800,7 +800,7 @@ class BaseSchema(base.SchemaABC):
                         field_obj=field_obj
                     )
 
-    def _invoke_validators(self, pass_many, data, original_data, many, field_errors):
+    def _invoke_validators(self, pass_many, data, original_data, many, field_errors=False):
         errors = {}
         for attr_name in self.__processors__[(VALIDATES_SCHEMA, pass_many)]:
             validator = getattr(self, attr_name)

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -609,13 +609,16 @@ class BaseSchema(base.SchemaABC):
             errors = {}
         self._invoke_field_validators(data=result, many=many)
         errors = self._unmarshal.errors
+        field_errors = bool(errors)
         # Run schema-level migration
         try:
-            self._invoke_validators(pass_many=True, data=result, original_data=data, many=many)
+            self._invoke_validators(pass_many=True, data=result, original_data=data, many=many,
+                                    field_errors=field_errors)
         except ValidationError as err:
             errors.update(err.messages)
         try:
-            self._invoke_validators(pass_many=False, data=result, original_data=data, many=many)
+            self._invoke_validators(pass_many=False, data=result, original_data=data, many=many,
+                                    field_errors=field_errors)
         except ValidationError as err:
             errors.update(err.messages)
         if errors:
@@ -797,12 +800,17 @@ class BaseSchema(base.SchemaABC):
                         field_obj=field_obj
                     )
 
-    def _invoke_validators(self, pass_many, data, original_data, many):
+    def _invoke_validators(self, pass_many, data, original_data, many, field_errors):
         errors = {}
         for attr_name in self.__processors__[(VALIDATES_SCHEMA, pass_many)]:
             validator = getattr(self, attr_name)
             validator_kwargs = validator.__marshmallow_kwargs__[(VALIDATES_SCHEMA, pass_many)]
             pass_original = validator_kwargs.get('pass_original', False)
+
+            skip_on_field_errors = validator_kwargs['skip_on_field_errors']
+            if skip_on_field_errors and field_errors:
+                continue
+
             if pass_many:
                 validator = functools.partial(validator, many=many)
             if many and not pass_many:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -433,7 +433,7 @@ class TestValidatesSchemaDecorator:
     def test_skip_on_field_errors(self):
 
         class MySchema(Schema):
-            foo = fields.Int(required=True)
+            foo = fields.Int(required=True, validate=lambda n: n == 3)
             bar = fields.Int(required=True)
 
             @validates_schema(skip_on_field_errors=True)
@@ -461,6 +461,10 @@ class TestValidatesSchemaDecorator:
         # check that schema errors don't occur when field errors do
         errors = schema.validate({'foo': 3, 'bar': 'not an int'})
         assert 'bar' in errors
+        assert '_schema' not in errors
+
+        errors = schema.validate({'foo': 2, 'bar': 2})
+        assert 'foo' in errors
         assert '_schema' not in errors
 
         errors = schema.validate([{'foo': 3, 'bar': 'not an int'}], many=True)


### PR DESCRIPTION
Add 'skip_on_field_errors' parameter to validates_schema.
'skip_on_field_errors' allows schema level validation to be skipped
when errors are detected in field validation removing the need for
the user to check.
Address issue #323
Suggested that to further address issue #323 the next major release
should change the default value for this parameter from False to True.
