### PR TITLE
Eagerly evaluate list-like iterators with `many`.

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -8,7 +8,6 @@ import datetime as dt
 import decimal
 import inspect
 import json
-import types
 import uuid
 import warnings
 from collections import namedtuple
@@ -472,7 +471,7 @@ class BaseSchema(base.SchemaABC):
                             'many=True to serialize a collection.',
                             category=DeprecationWarning)
 
-        if isinstance(obj, types.GeneratorType):
+        if many and utils.is_iterable_but_not_string(obj):
             obj = list(obj)
 
         processed_obj = self._invoke_dump_processors(PRE_DUMP, obj, many, original_data=obj)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@
 """Tests for field serialization."""
 from collections import namedtuple
 import datetime as dt
+import itertools
 import decimal
 
 import pytest
@@ -11,7 +12,7 @@ from marshmallow.exceptions import ValidationError
 from marshmallow.compat import basestring, OrderedDict
 from marshmallow.utils import missing as missing_
 
-from tests.base import User, DummyModel, ALL_FIELDS
+from tests.base import User, ALL_FIELDS
 
 class DateTimeList:
     def __init__(self, dtimes):
@@ -712,3 +713,14 @@ def test_serializing_named_tuple_with_meta():
     serialized = PointSerializer().dump(p)
     assert serialized.data['x'] == 4
     assert serialized.data['y'] == 2
+
+
+def test_serializing_slice():
+    values = [{'value': value} for value in range(5)]
+    slice = itertools.islice(values, None)
+
+    class ValueSchema(Schema):
+        value = fields.Int()
+
+    serialized = ValueSchema(many=True).dump(slice).data
+    assert serialized == values


### PR DESCRIPTION
Eagerly evaluate non-string iterators on `dump` when `many` is passed.
This ensures that serializing many values doesn't advance an iterator
and drop the first item. Values are only evaluated eagerly when `many`
is set so that we don't inappropriately cast other iterables (dicts,
namedtuples, etc) to lists.

[Resolves #353]

Note: it could be argued that this would be a breaking change--it's possible that users _wanted_ generators to be cast to lists even when `many` is `False`, although I kind of doubt it. Either way, I think it's desirable for the added test to pass, which it didn't before the proposed change to `Schema`.
