### PR TITLE
Remove unnecessary raising of ValidationError in unmarshaller

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -204,12 +204,6 @@ class Unmarshaller(ErrorStore):
                     errors.setdefault(field_name, []).append(err.messages)
                 else:
                     errors.setdefault(field_name, []).append(text_type(err))
-            raise ValidationError(
-                errors,
-                fields=field_objs,
-                field_names=field_names,
-                data=output
-            )
 
     def deserialize(self, data, fields_dict, many=False, partial=False,
             dict_class=dict, index_errors=True, index=None):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -299,6 +299,24 @@ class TestValidatesDecorator:
 
 class TestValidatesSchemaDecorator:
 
+    def test_validator_nested_many(self):
+
+        class NestedSchema(Schema):
+            foo = fields.Int(required=True)
+
+            @validates_schema
+            def validate_schema(self, data):
+                raise ValidationError('This will never work', 'foo')
+
+        class MySchema(Schema):
+            nested = fields.Nested(NestedSchema, required=True, many=True)
+
+        schema = MySchema()
+        errors = schema.validate({'nested': [1]})
+        import pdb; pdb.set_trace()
+
+        assert errors
+
     def test_decorated_validators(self):
 
         class MySchema(Schema):


### PR DESCRIPTION
This is to fix a bug for nested schemas where many is set to True.  While this takes care of the problem, the better fix would be to clean up the the references to self.errors in `class Unmarshaller` and its parent class.
