### PR TITLE
Remove unnecessary raising of ValidationError in unmarshaller

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -204,12 +204,6 @@ class Unmarshaller(ErrorStore):
                     errors.setdefault(field_name, []).append(err.messages)
                 else:
                     errors.setdefault(field_name, []).append(text_type(err))
-            raise ValidationError(
-                errors,
-                fields=field_objs,
-                field_names=field_names,
-                data=output
-            )
 
     def deserialize(self, data, fields_dict, many=False, partial=False,
             dict_class=dict, index_errors=True, index=None):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -299,6 +299,26 @@ class TestValidatesDecorator:
 
 class TestValidatesSchemaDecorator:
 
+    def test_validator_nested_many(self):
+
+        class NestedSchema(Schema):
+            foo = fields.Int(required=True)
+
+            @validates_schema
+            def validate_schema(self, data):
+                raise ValidationError('This will never work', 'foo')
+
+        class MySchema(Schema):
+            nested = fields.Nested(NestedSchema, required=True, many=True)
+
+        schema = MySchema()
+        errors = schema.validate({'nested': [1]})
+        assert errors
+        assert 'nested' in errors
+        assert 0 in errors['nested']
+        assert '_schema' in errors['nested']
+        assert 'foo' not in errors['nested']
+
     def test_decorated_validators(self):
 
         class MySchema(Schema):


### PR DESCRIPTION
The validation error does not need to be thrown because it is already being picked up.  Most of the time the error message was stomping on itself and it was not noticeable bug.  The only time this would come up is if a nested schema had a validation error and an index was being tacked on the beginning of the error - then the error would appear twice, once indexed and the other not indexed.  This is a tricky area that should be cleaned up more.
