### PR TITLE
Avoid use of sys.version for version checks

### DIFF
--- a/marshmallow/compat.py
+++ b/marshmallow/compat.py
@@ -2,7 +2,7 @@
 import sys
 import itertools
 
-PY2 = int(sys.version[0]) == 2
+PY2 = int(sys.version_info[0]) == 2
 PY26 = PY2 and int(sys.version_info[1]) < 7
 
 if PY2:


### PR DESCRIPTION
The string `sys.version` should not be used for version checks so this change updates it to be done using `sys.version_info`.
