### PR TITLE
Support passing specific fields to `partial`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,3 +58,4 @@ Contributors (chronological)
 - Dan Sutherland `@d-sutherland <https://github.com/d-sutherland>`_
 - Jeff Widman `@jeffwidman <https://github.com/jeffwidman>`_
 - Simeon Visser `@svisser <https://github.com/svisser>`_
+- Taylan Develioglu `@tdevelioglu <https://github.com/tdevelioglu>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -306,7 +306,20 @@ Dictionaries or lists are also accepted as the custom error message, in case you
 Partial Loading
 +++++++++++++++
 
-When using the same schema in multiple places, you may only want to check required fields some of the time when deserializing. You can ignore missing fields entirely by setting ``partial=True``.
+When using the same schema in multiple places, you may only want to check required fields some of the time when deserializing by specifying them in ``partial``.
+
+.. code-block:: python
+    :emphasize-lines: 5,6
+
+    class UserSchema(Schema):
+        name = fields.String(required=True)
+        age = fields.Integer(required=True)
+
+    data, errors = UserSchema().load({'age': 42}, partial=('name',))
+    # OR UserSchema(partial=('name',)).load({'age': 42})
+    data, errors  # => ({'age': 42}, {})
+
+Or you can ignore missing fields entirely by setting ``partial=True``.
 
 .. code-block:: python
     :emphasize-lines: 5,6

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -10,7 +10,7 @@ and from primitive types.
 
 from __future__ import unicode_literals
 
-from marshmallow.utils import missing
+from marshmallow.utils import is_collection, missing
 from marshmallow.compat import text_type, iteritems
 from marshmallow.exceptions import (
     ValidationError,
@@ -213,7 +213,9 @@ class Unmarshaller(ErrorStore):
         :param dict fields_dict: Mapping of field names to :class:`Field` objects.
         :param bool many: Set to `True` if ``data`` should be deserialized as
             a collection.
-        :param bool partial: If `True`, ignore missing fields.
+        :param bool|tuple partial: Whether to ignore missing fields. If its
+            value is an iterable, only missing fields listed in that iterable
+            will be ignored.
         :param type dict_class: Dictionary class used to construct the output.
         :param bool index_errors: Whether to store the index of invalid items in
             ``self.errors`` when ``many=True``.
@@ -242,6 +244,7 @@ class Unmarshaller(ErrorStore):
             return ret
         if data is not None:
             items = []
+            partial_is_collection = is_collection(partial)
             for attr_name, field_obj in iteritems(fields_dict):
                 if field_obj.dump_only:
                     continue
@@ -263,7 +266,9 @@ class Unmarshaller(ErrorStore):
                     field_name = field_obj.load_from
                     raw_value = data.get(field_obj.load_from, missing)
                 if raw_value is missing:
-                    if partial:
+                    # Ignore missing field if we're allowed to.
+                    if partial is True or\
+                            partial_is_collection and attr_name in partial:
                         continue
                     _miss = field_obj.missing
                     raw_value = _miss() if callable(_miss) else _miss

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -250,7 +250,9 @@ class BaseSchema(base.SchemaABC):
     :param tuple load_only: A list or tuple of fields to skip during serialization
     :param tuple dump_only: A list or tuple of fields to skip during
         deserialization, read-only fields
-    :param bool partial: If `True`, ignore missing fields when deserializing.
+    :param bool|tuple partial: Whether to ignore missing fields. If its value
+        is an iterable, only missing fields listed in that iterable will be
+        ignored.
 
     .. versionchanged:: 2.0.0
         `__validators__`, `__preprocessors__`, and `__data_handlers__` are removed in favor of
@@ -528,8 +530,9 @@ class BaseSchema(base.SchemaABC):
         :param dict data: The data to deserialize.
         :param bool many: Whether to deserialize `data` as a collection. If `None`, the
             value for `self.many` is used.
-        :param bool partial: Whether to ignore missing fields. If `None`, the
-            value for `self.partial` is used.
+        :param bool|tuple partial: Whether to ignore missing fields. If `None`,
+            the value for `self.partial` is used. If its value is an iterable,
+            only missing fields listed in that iterable will be ignored.
         :return: A tuple of the form (``data``, ``errors``)
         :rtype: `UnmarshalResult`, a `collections.namedtuple`
 
@@ -544,8 +547,8 @@ class BaseSchema(base.SchemaABC):
         :param str json_data: A JSON string of the data to deserialize.
         :param bool many: Whether to deserialize `obj` as a collection. If `None`, the
             value for `self.many` is used.
-        :param bool partial: Whether to ignore missing fields. If `None`, the
-            value for `self.partial` is used.
+        :param bool|tuple partial: Whether to ignore missing fields. If `None`,
+            the value for `self.partial` is used. If its value is an iterable,
         :return: A tuple of the form (``data``, ``errors``)
         :rtype: `UnmarshalResult`, a `collections.namedtuple`
 
@@ -583,13 +586,15 @@ class BaseSchema(base.SchemaABC):
         :param data: The data to deserialize.
         :param bool many: Whether to deserialize `data` as a collection. If `None`, the
             value for `self.many` is used.
-        :param bool partial: Whether to ignore missing fields. If `None`, the
-            value for `self.partial` is used.
+        :param bool|tuple partial: Whether to ignore missing fields. If `None`,
+            the value for `self.partial` is used. If its value is an iterable,
+            only missing fields listed in that iterable will be ignored.
         :param bool postprocess: Whether to run post_load methods..
         :return: A tuple of the form (`data`, `errors`)
         """
         many = self.many if many is None else bool(many)
-        partial = self.partial if partial is None else bool(partial)
+        if partial is None:
+            partial = self.partial
 
         processed_data = self._invoke_load_processors(PRE_LOAD, data, many, original_data=data)
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1067,6 +1067,31 @@ class TestSchemaDeserialization:
         assert 'bar' not in data
         assert not errors
 
+    def test_partial_fields_deserialization(self):
+        class MySchema(Schema):
+            foo = fields.Field(required=True)
+            bar = fields.Field(required=True)
+            baz = fields.Field(required=True)
+
+        data, errors = MySchema().load({'foo': 3}, partial=tuple())
+        assert data['foo'] == 3
+        assert 'bar' in errors
+        assert 'baz' in errors
+
+        data, errors = MySchema().load({'foo': 3}, partial=('bar', 'baz'))
+        assert data['foo'] == 3
+        assert 'bar' not in data
+        assert 'baz' not in data
+        assert not errors
+
+        data, errors = MySchema(partial=True).load({'foo': 3}, partial=('bar', 'baz'))
+        assert data['foo'] == 3
+        assert 'bar' not in data
+        assert 'baz' not in data
+        assert not errors
+
+
+
 validators_gen = (func for func in [lambda x: x <= 24, lambda x: 18 <= x])
 
 validators_gen_float = (func for func in


### PR DESCRIPTION
Support passing specific fields to `partial`. This restricts the fields
allowed to be missing during partial deserialization to those specified
in the value of `partial`.
This is particularly useful in api's when dealing with non client-generated
primary key fields (at creation), where only a specific field is allowed
to be missing, and you'd still like to use the same schema.
