### PR TITLE
Support specifying envelope for fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,3 +58,4 @@ Contributors (chronological)
 - Dan Sutherland `@d-sutherland <https://github.com/d-sutherland>`_
 - Jeff Widman `@jeffwidman <https://github.com/jeffwidman>`_
 - Simeon Visser `@svisser <https://github.com/svisser>`_
+- Taylan Develioglu `@tdevelioglu <https://github.com/tdevelioglu>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -398,6 +398,30 @@ If you want to marshal a field to a different key than the field name you can us
     # 'CamelCasedEmail': 'foo@bar.com'}
 
 
+Enveloping Keys
+-------------------------------
+
+If you want to marshal or unmarshal fields that are enveloped, you can use `envelope` to specify a tuple of keys that a field is nested in.
+
+.. code-block:: python
+    :emphasize-lines: 2,3,4,14
+
+    class UserSchema(Schema):
+        id = fields.String(envelope=('data',))
+        name = fields.String(envelope=('data', 'attributes'))
+        email = fields.Email(envelope=('data', 'attributes'))
+
+    data = {
+        'id': '5',
+        'name': 'Mike',
+        'email': 'foo@bar.com',
+    }
+    s = UserSchema()
+    result, errors = s.dump(data)
+    #{'data': {'attributes': {'email': 'foo@bar.com', 'name': 'Mike'}, 'id': '5'}}
+    result, errors = s.load(result)
+    #{'email': 'foo@bar.com', 'id': '5', 'name': 'Mike'}
+
 Refactoring: Implicit Field Creation
 ------------------------------------
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -85,6 +85,8 @@ class Field(FieldABC):
     :param missing: Default deserialization value for the field if the field is not
         found in the input data. May be a value or a callable.
     :param dict error_messages: Overrides for `Field.default_error_messages`.
+    :param tuple envelope: tuple with keys of the dictionaries that the field
+        is nested under and will subsequently be loaded from and dumped to.
     :param metadata: Extra arguments to be stored as metadata.
 
     .. versionchanged:: 2.0.0
@@ -124,11 +126,12 @@ class Field(FieldABC):
 
     def __init__(self, default=missing_, attribute=None, load_from=None, dump_to=None,
                  error=None, validate=None, required=False, allow_none=None, load_only=False,
-                 dump_only=False, missing=missing_, error_messages=None, **metadata):
+                 dump_only=False, missing=missing_, error_messages=None, envelope=tuple(), **metadata):
         self.default = default
         self.attribute = attribute
         self.load_from = load_from  # this flag is used by Unmarshaller
         self.dump_to = dump_to  # this flag is used by Marshaller
+        self.envelope = envelope  # this flag is used by (Un)Marshaller
         self.validate = validate
         if utils.is_iterable_but_not_string(validate):
             if not utils.is_generator(validate):
@@ -173,7 +176,8 @@ class Field(FieldABC):
                 'validate={self.validate}, required={self.required}, '
                 'load_only={self.load_only}, dump_only={self.dump_only}, '
                 'missing={self.missing}, allow_none={self.allow_none}, '
-                'error_messages={self.error_messages})>'
+                'error_messages={self.error_messages}, '
+                'envelope={self.envelope})>'
                 .format(ClassName=self.__class__.__name__, self=self))
 
     def get_value(self, attr, obj, accessor=None, default=missing_):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -685,6 +685,23 @@ class TestFieldDeserialization:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
 
+    def test_deserialize_enveloped(self):
+        class MySchema(Schema):
+            foo = fields.Field(envelope=('one',))
+            bar = fields.Field(envelope=('one', 'two'))
+            baz = fields.Field(envelope=('one',))
+            qux = fields.Field(envelope=('two', 'three'), load_from='quack')
+            quux = fields.Field()
+
+        input_data = {
+            'one': {'foo': 'oof', 'two': {'bar': 'rab'}, 'baz': 'zab'},
+            'two': {'three': {'quack': 'xuq'}},
+            'quux': 'xuuq'
+        }
+        data, errors = MySchema().load(input_data)
+        assert data == {'foo': 'oof', 'bar': 'rab', 'baz': 'zab', 'qux': 'xuq',
+                        'quux': 'xuuq'}
+
 # No custom deserialization behavior, so a dict is returned
 class SimpleUserSchema(Schema):
     name = fields.String()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -29,7 +29,8 @@ class TestField:
                                 'validate=None, required=False, '
                                 'load_only=False, dump_only=False, '
                                 'missing={missing}, allow_none=False, '
-                                'error_messages={error_messages})>'
+                                'error_messages={error_messages}, '
+                                'envelope=())>'
                                 .format(default, missing=missing,
                                         error_messages=field.error_messages))
         int_field = fields.Integer(validate=lambda x: True)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -691,6 +691,23 @@ class TestFieldSerialization:
         else:
             assert res is None
 
+    def test_serialize_enveloped(self):
+        class MySchema(Schema):
+            foo = fields.Field(envelope=('one',))
+            bar = fields.Field(envelope=('one', 'two'))
+            baz = fields.Field(envelope=('one',))
+            qux = fields.Field(envelope=('two', 'three'), dump_to='quack')
+            quux = fields.Field()
+
+        data, errors = MySchema().dump(
+            {'foo': 'oof', 'bar': 'rab', 'baz': 'zab', 'qux': 'xuq', 'quux': 'xuuq'})
+
+        assert data == {
+            'one': {'foo': 'oof', 'two': {'bar': 'rab'}, 'baz': 'zab'},
+            'two': {'three': {'quack': 'xuq'}},
+            'quux': 'xuuq'
+        }
+
 
 def test_serializing_named_tuple():
     Point = namedtuple('Point', ['x', 'y'])


### PR DESCRIPTION
This adds support for marshalling/unmarshalling fields that are enveloped, making it simpler to deal with fields that require nesting. (relevant: http://jsonapi.org/format/)
