### PR TITLE
Add `equal` parameter in validate.Length

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -59,3 +59,4 @@ Contributors (chronological)
 - Jeff Widman `@jeffwidman <https://github.com/jeffwidman>`_
 - Simeon Visser `@svisser <https://github.com/svisser>`_
 - Taylan Develioglu `@tdevelioglu <https://github.com/tdevelioglu>`_
+- Danilo Akamine `@daniloakamine <https://github.com/daniloakamine>`_

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -219,6 +219,12 @@ class Length(Range):
     message_equal = 'Length must be {equal}.'
 
     def __init__(self, min=None, max=None, error=None, equal=None):
+        if equal is not None and any([min, max]):
+            raise ValueError(
+                'The `equal` parameter was provided, maximum or '
+                'minimum parameter must not be provided.'
+            )
+
         super(Length, self).__init__(min, max, error)
         self.equal = equal
 

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -207,6 +207,8 @@ class Length(Range):
         will not be checked.
     :param int max: The maximum length. If not provided, maximum length
         will not be checked.
+    :param int equal: The exact length. If provided, maximum and minimum
+        length will not be checked.
     :param str error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}`, `{min}` and `{max}`.
     """
@@ -214,9 +216,26 @@ class Length(Range):
     message_min = 'Shorter than minimum length {min}.'
     message_max = 'Longer than maximum length {max}.'
     message_all = 'Length must be between {min} and {max}.'
+    message_equal = 'Length must be {equal}.'
+
+    def __init__(self, min=None, max=None, error=None, equal=None):
+        super(Length, self).__init__(min, max, error)
+        self.equal = equal
+
+    def _repr_args(self):
+        return 'min={0!r}, max={1!r}, equal={2!r}'.format(self.min, self.max, self.equal)
+
+    def _format_error(self, value, message):
+        return (self.error or message).format(input=value, min=self.min, max=self.max,
+                                              equal=self.equal)
 
     def __call__(self, value):
         length = len(value)
+
+        if self.equal is not None:
+            if length != self.equal:
+                raise ValidationError(self._format_error(value, self.message_equal))
+            return value
 
         if self.min is not None and length < self.min:
             message = self.message_min if self.max is None else self.message_all

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -264,6 +264,35 @@ def test_length_max():
     with pytest.raises(ValidationError):
         validate.Length(None, 2)([1, 2, 3])
 
+def test_length_equal():
+    assert validate.Length(equal=3)('foo') == 'foo'
+    assert validate.Length(equal=3)([1, 2, 3]) == [1, 2, 3]
+    assert validate.Length(None, 1, equal=2)('ab') == 'ab'
+    assert validate.Length(None, 1, equal=2)([1, 2]) == [1, 2]
+    assert validate.Length(3, None, equal=2)('ab') == 'ab'
+    assert validate.Length(3, None, equal=2)([1, 2]) == [1, 2]
+    assert validate.Length(equal=None)('') == ''
+    assert validate.Length(equal=None)([]) == []
+    assert validate.Length(2, 2, equal=3)('foo') == 'foo'
+    assert validate.Length(2, 2, equal=3)([1, 2, 3]) == [1, 2, 3]
+
+    with pytest.raises(ValidationError):
+        validate.Length(equal=2)('foo')
+    with pytest.raises(ValidationError):
+        validate.Length(equal=2)([1, 2, 3])
+    with pytest.raises(ValidationError):
+        validate.Length(None, 3, equal=5)('foo')
+    with pytest.raises(ValidationError):
+        validate.Length(None, 3, equal=5)([1, 2, 3])
+    with pytest.raises(ValidationError):
+        validate.Length(3, None, equal=5)('foo')
+    with pytest.raises(ValidationError):
+        validate.Length(3, None, equal=5)([1, 2, 3])
+    with pytest.raises(ValidationError):
+        validate.Length(1, 3, equal=5)('foo')
+    with pytest.raises(ValidationError):
+        validate.Length(1, 3, equal=5)([1, 2, 3])
+
 def test_length_custom_message():
     v = validate.Length(5, 6, error='{input} is not between {min} and {max}')
     with pytest.raises(ValidationError) as excinfo:
@@ -280,14 +309,19 @@ def test_length_custom_message():
         v('foo')
     assert 'foo is longer than 2' in str(excinfo)
 
+    v = validate.Length(None, None, equal=4, error='{input} does not have {equal}')
+    with pytest.raises(ValidationError) as excinfo:
+        v('foo')
+    assert 'foo does not have 4' in str(excinfo)
+
 def test_length_repr():
     assert (
-        repr(validate.Length(min=None, max=None, error=None)) ==
-        '<Length(min=None, max=None, error=None)>'
+        repr(validate.Length(min=None, max=None, error=None, equal=None)) ==
+        '<Length(min=None, max=None, equal=None, error=None)>'
     )
     assert (
-        repr(validate.Length(min=1, max=3, error='foo')) ==
-        '<Length(min=1, max=3, error={0!r})>'
+        repr(validate.Length(min=1, max=3, error='foo', equal=5)) ==
+        '<Length(min=1, max=3, equal=5, error={0!r})>'
         .format('foo')
     )
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -267,31 +267,20 @@ def test_length_max():
 def test_length_equal():
     assert validate.Length(equal=3)('foo') == 'foo'
     assert validate.Length(equal=3)([1, 2, 3]) == [1, 2, 3]
-    assert validate.Length(None, 1, equal=2)('ab') == 'ab'
-    assert validate.Length(None, 1, equal=2)([1, 2]) == [1, 2]
-    assert validate.Length(3, None, equal=2)('ab') == 'ab'
-    assert validate.Length(3, None, equal=2)([1, 2]) == [1, 2]
     assert validate.Length(equal=None)('') == ''
     assert validate.Length(equal=None)([]) == []
-    assert validate.Length(2, 2, equal=3)('foo') == 'foo'
-    assert validate.Length(2, 2, equal=3)([1, 2, 3]) == [1, 2, 3]
 
     with pytest.raises(ValidationError):
         validate.Length(equal=2)('foo')
     with pytest.raises(ValidationError):
         validate.Length(equal=2)([1, 2, 3])
-    with pytest.raises(ValidationError):
-        validate.Length(None, 3, equal=5)('foo')
-    with pytest.raises(ValidationError):
-        validate.Length(None, 3, equal=5)([1, 2, 3])
-    with pytest.raises(ValidationError):
-        validate.Length(3, None, equal=5)('foo')
-    with pytest.raises(ValidationError):
-        validate.Length(3, None, equal=5)([1, 2, 3])
-    with pytest.raises(ValidationError):
-        validate.Length(1, 3, equal=5)('foo')
-    with pytest.raises(ValidationError):
-        validate.Length(1, 3, equal=5)([1, 2, 3])
+
+    with pytest.raises(ValueError):
+        validate.Length(1, None, equal=3)('foo')
+    with pytest.raises(ValueError):
+        validate.Length(None, 5, equal=3)('foo')
+    with pytest.raises(ValueError):
+        validate.Length(1, 5, equal=3)('foo')
 
 def test_length_custom_message():
     v = validate.Length(5, 6, error='{input} is not between {min} and {max}')
@@ -320,8 +309,13 @@ def test_length_repr():
         '<Length(min=None, max=None, equal=None, error=None)>'
     )
     assert (
-        repr(validate.Length(min=1, max=3, error='foo', equal=5)) ==
-        '<Length(min=1, max=3, equal=5, error={0!r})>'
+        repr(validate.Length(min=1, max=3, error='foo', equal=None)) ==
+        '<Length(min=1, max=3, equal=None, error={0!r})>'
+        .format('foo')
+    )
+    assert (
+        repr(validate.Length(min=None, max=None, error='foo', equal=5)) ==
+        '<Length(min=None, max=None, equal=5, error={0!r})>'
         .format('foo')
     )
 


### PR DESCRIPTION
I have a String field and I need to validate if it contains exactly 6 characters.
Instead of use **validate.Regexp**, I'd like to use the proper way **validate.Length**.

``` python
name = fields.Str(required=True,
                          validate=[validate.Length(min=6, max=6)])
```

It works, but I need to repeat the same value in two different parameters.
In addition, I receive a weird error message _"Length must be between 6 and 6"_. 
This message don't make sense for my case.

I'm suggesting to create a new optional parameter.

``` python
name = fields.Str(required=True,
                          validate=[validate.Length(equal=6)])
```

In that case, I will receive the message _"Length must be 6"_.
What do you think about this?
