### PR TITLE
Accept dict in messages errors

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -198,7 +198,7 @@ class Range(Validator):
         return 'min={0!r}, max={1!r}'.format(self.min, self.max)
 
     def _format_error(self, value, message):
-        if not isinstance(self.error, dict):or self.error is None:
+        if not isinstance(self.error, dict) or self.error is None:
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max)
         if 'message' in self.error:
@@ -255,7 +255,7 @@ class Length(Range):
         return 'min={0!r}, max={1!r}, equal={2!r}'.format(self.min, self.max, self.equal)
 
     def _format_error(self, value, message):
-        if not isinstance(self.error, dict):or self.error is None:
+        if not isinstance(self.error, dict) or self.error is None:
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
         if 'message' in self.error:

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -38,8 +38,9 @@ class URL(Validator):
     """Validate a URL.
 
     :param bool relative: Whether to allow relative URLs.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}`.
+        Case dict, the content of key `message` can be interpolated with `{input}`.
     :param set schemes: Valid schemes. By default, ``http``, ``https``,
         ``ftp``, and ``ftps`` are allowed.
     """
@@ -79,7 +80,12 @@ class URL(Validator):
         return 'relative={0!r}'.format(self.relative)
 
     def _format_error(self, value):
-        return self.error.format(input=value)
+        if isinstance(self.error, str):
+            return self.error.format(input=value)
+        if 'message' in self.error:
+            message = self.error.get('message').format(input=value)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         message = self._format_error(value)
@@ -103,8 +109,9 @@ class URL(Validator):
 class Email(Validator):
     """Validate an email address.
 
-    :param str error: Error message to raise in case of a validation error. Can be
-        interpolated with `{input}`.
+    :param str/dict error: Error message to raise in case of a validation error. Can be
+        Can be interpolated with `{input}`.
+        Case dict, the content of key `message` can be interpolated with `{input}`.
     """
 
     USER_REGEX = re.compile(
@@ -129,7 +136,12 @@ class Email(Validator):
         self.error = error or self.default_message
 
     def _format_error(self, value):
-        return self.error.format(input=value)
+        if isinstance(self.error, str):
+            return self.error.format(input=value)
+        if 'message' in self.error:
+            message = self.error.get('message').format(input=value)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         message = self._format_error(value)
@@ -167,8 +179,10 @@ class Range(Validator):
         value will not be checked.
     :param max: The maximum value (upper bound). If not provided, maximum
         value will not be checked.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}`, `{min}` and `{max}`.
+        Case dict, the content of key `message`
+            can be interpolated with `{input}`, `{min}` and `{max}`.
     """
 
     message_min = 'Must be at least {min}.'
@@ -184,7 +198,14 @@ class Range(Validator):
         return 'min={0!r}, max={1!r}'.format(self.min, self.max)
 
     def _format_error(self, value, message):
-        return (self.error or message).format(input=value, min=self.min, max=self.max)
+        if isinstance(self.error, str) or self.error is None:
+            return (self.error or message).format(
+                input=value, min=self.min, max=self.max)
+        if 'message' in self.error:
+            m = (self.error.get('message') or message).format(
+                input=value, min=self.min, max=self.max)
+            self.error.update({'message': m})
+        return self.error
 
     def __call__(self, value):
         if self.min is not None and value < self.min:
@@ -209,8 +230,10 @@ class Length(Range):
         will not be checked.
     :param int equal: The exact length. If provided, maximum and minimum
         length will not be checked.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}`, `{min}` and `{max}`.
+        Case dict, the content of key `message`
+            can be interpolated with `{input}`, `{min}` and `{max}`.
     """
 
     message_min = 'Shorter than minimum length {min}.'
@@ -232,8 +255,14 @@ class Length(Range):
         return 'min={0!r}, max={1!r}, equal={2!r}'.format(self.min, self.max, self.equal)
 
     def _format_error(self, value, message):
-        return (self.error or message).format(input=value, min=self.min, max=self.max,
-                                              equal=self.equal)
+        if isinstance(self.error, str) or self.error is None:
+            return (self.error or message).format(
+                input=value, min=self.min, max=self.max, equal=self.equal)
+        if 'message' in self.error:
+            m = self.error.get('message').format(
+                input=value, min=self.min, max=self.max, equal=self.equal)
+            self.error.update({'message': m})
+        return self.error
 
     def __call__(self, value):
         length = len(value)
@@ -259,8 +288,9 @@ class Equal(Validator):
     equal to ``comparable``.
 
     :param comparable: The object to compare to.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}` and `{other}`.
+        Case dict, the content of key `message` can be interpolated with `{input}` and `{other}`.
     """
 
     default_message = 'Must be equal to {other}.'
@@ -273,7 +303,13 @@ class Equal(Validator):
         return 'comparable={0!r}'.format(self.comparable)
 
     def _format_error(self, value):
-        return self.error.format(input=value, other=self.comparable)
+        if isinstance(self.error, str):
+            return self.error.format(input=value, other=self.comparable)
+        if 'message' in self.error:
+            message = self.error.get('message').format(
+                input=value, other=self.comparable)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         if value != self.comparable:
@@ -288,8 +324,9 @@ class Regexp(Validator):
         regular expression pattern.
     :param flags: The regexp flags to use, for example re.IGNORECASE. Ignored
         if ``regex`` is not a string.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}` and `{regex}`.
+        Case dict, the content of key `message` can be interpolated with `{input}` and `{regex}`.
     """
 
     default_message = 'String does not match expected pattern.'
@@ -302,7 +339,13 @@ class Regexp(Validator):
         return 'regex={0!r}'.format(self.regex)
 
     def _format_error(self, value):
-        return self.error.format(input=value, regex=self.regex.pattern)
+        if isinstance(self.error, str):
+            return self.error.format(input=value, regex=self.regex.pattern)
+        if 'message' in self.error:
+            message = self.error.get('message').format(
+                input=value, regex=self.regex.pattern)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         if self.regex.match(value) is None:
@@ -318,8 +361,9 @@ class Predicate(Validator):
     argument will be passed to the method.
 
     :param str method: The name of the method to invoke.
-    :param str error: Error message to raise in case of a validation error.
+    :param str/dict error: Error message to raise in case of a validation error.
         Can be interpolated with `{input}` and `{method}`.
+        Case dict, the content of key `message` can be interpolated with `{input}` and `{method}`.
     :param kwargs: Additional keyword arguments to pass to the method.
     """
 
@@ -334,7 +378,13 @@ class Predicate(Validator):
         return 'method={0!r}, kwargs={1!r}'.format(self.method, self.kwargs)
 
     def _format_error(self, value):
-        return self.error.format(input=value, method=self.method)
+        if isinstance(self.error, str):
+            return self.error.format(input=value, method=self.method)
+        if 'message' in self.error:
+            message = self.error.get('message').format(
+                input=value, method=self.method)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         method = getattr(value, self.method)
@@ -349,8 +399,9 @@ class NoneOf(Validator):
     """Validator which fails if ``value`` is a member of ``iterable``.
 
     :param iterable iterable: A sequence of invalid values.
-    :param str error: Error message to raise in case of a validation error. Can be
+    :param str/dict error: Error message to raise in case of a validation error. Can be
         interpolated using `{input}` and `{values}`.
+        Case dict, the content of key `message` can be interpolated with `{input}` and `{values}`.
     """
 
     default_message = 'Invalid input.'
@@ -364,10 +415,13 @@ class NoneOf(Validator):
         return 'iterable={0!r}'.format(self.iterable)
 
     def _format_error(self, value):
-        return self.error.format(
-            input=value,
-            values=self.values_text,
-        )
+        if isinstance(self.error, str):
+            return self.error.format(input=value, values=self.values_text)
+        if 'message' in self.error:
+            message = self.error.get('message').format(
+                input=value, values=self.values_text)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         try:
@@ -384,8 +438,10 @@ class OneOf(Validator):
 
     :param iterable choices: A sequence of valid values.
     :param iterable labels: Optional sequence of labels to pair with the choices.
-    :param str error: Error message to raise in case of a validation error. Can be
-        interpolated with `{input}`, `{choices}` and `{labels}`.
+    :param str error: Error message to raise in case of a validation error.
+        Can be interpolated with `{input}`, `{choices}` and `{labels}`.
+        Case dict, the content of key `message`
+            can be interpolated with `{input}`, `{choices}` and `{labels}`.
     """
 
     default_message = 'Not a valid choice.'
@@ -401,11 +457,15 @@ class OneOf(Validator):
         return 'choices={0!r}, labels={1!r}'.format(self.choices, self.labels)
 
     def _format_error(self, value):
-        return self.error.format(
-            input=value,
-            choices=self.choices_text,
-            labels=self.labels_text,
-        )
+        if isinstance(self.error, str):
+            return self.error.format(
+                input=value, choices=self.choices_text, labels=self.labels_text)
+        if 'message' in self.error:
+            message = self.error.get('message').format(
+                input=value, choices=self.choices_text,
+                labels=self.labels_text)
+            self.error.update({'message': message})
+        return self.error
 
     def __call__(self, value):
         try:
@@ -439,14 +499,18 @@ class ContainsOnly(OneOf):
 
     :param iterable choices: Same as :class:`OneOf`.
     :param iterable labels: Same as :class:`OneOf`.
-    :param str error: Same as :class:`OneOf`.
+    :param str/dict error: Same as :class:`OneOf`.
     """
 
     default_message = 'One or more of the choices you made was not acceptable.'
 
     def _format_error(self, value):
         value_text = ', '.join(text_type(val) for val in value)
-        return super(ContainsOnly, self)._format_error(value_text)
+        if isinstance(self.error, str):
+            return super(ContainsOnly, self)._format_error(value_text)
+        if 'message' in self.error:
+            self.error.update({'message': value_text})
+        return super(ContainsOnly, self)._format_error(self.error)
 
     def __call__(self, value):
         choices = list(self.choices)

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -259,7 +259,7 @@ class Length(Range):
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
         if 'message' in self.error:
-            m = (message or self.error.get('message')).format(
+            m = (self.error.get('message') or message).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
             self.error.update({'message': m})
         return self.error

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -80,7 +80,7 @@ class URL(Validator):
         return 'relative={0!r}'.format(self.relative)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value)
         if 'message' in self.error:
             message = self.error.get('message').format(input=value)
@@ -136,7 +136,7 @@ class Email(Validator):
         self.error = error or self.default_message
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value)
         if 'message' in self.error:
             message = self.error.get('message').format(input=value)
@@ -198,7 +198,7 @@ class Range(Validator):
         return 'min={0!r}, max={1!r}'.format(self.min, self.max)
 
     def _format_error(self, value, message):
-        if isinstance(self.error, str) or self.error is None:
+        if not isinstance(self.error, dict):or self.error is None:
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max)
         if 'message' in self.error:
@@ -255,7 +255,7 @@ class Length(Range):
         return 'min={0!r}, max={1!r}, equal={2!r}'.format(self.min, self.max, self.equal)
 
     def _format_error(self, value, message):
-        if isinstance(self.error, str) or self.error is None:
+        if not isinstance(self.error, dict):or self.error is None:
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
         if 'message' in self.error:
@@ -303,7 +303,7 @@ class Equal(Validator):
         return 'comparable={0!r}'.format(self.comparable)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value, other=self.comparable)
         if 'message' in self.error:
             message = self.error.get('message').format(
@@ -339,7 +339,7 @@ class Regexp(Validator):
         return 'regex={0!r}'.format(self.regex)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value, regex=self.regex.pattern)
         if 'message' in self.error:
             message = self.error.get('message').format(
@@ -378,7 +378,7 @@ class Predicate(Validator):
         return 'method={0!r}, kwargs={1!r}'.format(self.method, self.kwargs)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value, method=self.method)
         if 'message' in self.error:
             message = self.error.get('message').format(
@@ -415,7 +415,7 @@ class NoneOf(Validator):
         return 'iterable={0!r}'.format(self.iterable)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(input=value, values=self.values_text)
         if 'message' in self.error:
             message = self.error.get('message').format(
@@ -457,7 +457,7 @@ class OneOf(Validator):
         return 'choices={0!r}, labels={1!r}'.format(self.choices, self.labels)
 
     def _format_error(self, value):
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return self.error.format(
                 input=value, choices=self.choices_text, labels=self.labels_text)
         if 'message' in self.error:
@@ -506,7 +506,7 @@ class ContainsOnly(OneOf):
 
     def _format_error(self, value):
         value_text = ', '.join(text_type(val) for val in value)
-        if isinstance(self.error, str):
+        if not isinstance(self.error, dict):
             return super(ContainsOnly, self)._format_error(value_text)
         if 'message' in self.error:
             self.error.update({'message': value_text})

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -259,7 +259,7 @@ class Length(Range):
             return (self.error or message).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
         if 'message' in self.error:
-            m = self.error.get('message').format(
+            m = (message or self.error.get('message')).format(
                 input=value, min=self.min, max=self.max, equal=self.equal)
             self.error.update({'message': m})
         return self.error

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -107,6 +107,15 @@ def test_url_custom_message():
         validator('invalid')
     assert "invalid ain't an URL" in str(excinfo)
 
+def test_url_custom_message_dict():
+    error = {'message': "{input} ain't an URL",
+             'code': 200}
+    validator = validate.URL(error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        validator('invalid')
+    error = excinfo.value.messages
+    assert error.get('code') == 200
+
 def test_url_repr():
     assert (
         repr(validate.URL(relative=False, error=None)) ==
@@ -163,6 +172,15 @@ def test_email_custom_message():
         validator('invalid')
     assert 'invalid is not an email addy.' in str(excinfo)
 
+def test_email_custom_message_dict():
+    error = {'message': "{input} is not an email addy.",
+             'code': 200}
+    validator = validate.URL(error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        validator('invalid')
+    error = excinfo.value.messages
+    assert error.get('code') == 200
+
 def test_email_repr():
     assert (
         repr(validate.Email(error=None)) ==
@@ -213,6 +231,16 @@ def test_range_custom_message():
     with pytest.raises(ValidationError) as excinfo:
         v(4)
     assert '4 is greater than 3' in str(excinfo)
+
+def test_range_custom_message_dict():
+    error = {'message': "{input} is not between {min} and {max}",
+             'code': 200}
+    v = validate.Range(2, 3, error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        v(1)
+
+    error = excinfo.value.messages
+    assert error.get('code') == 200
 
 def test_range_repr():
     assert (
@@ -303,6 +331,15 @@ def test_length_custom_message():
         v('foo')
     assert 'foo does not have 4' in str(excinfo)
 
+def test_length_custom_message_dict():
+    error = {'message': "{input} is not between {min} and {max}",
+             'code': 200}
+    v = validate.Length(5, 6, error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        v('foo')
+    error = excinfo.value.messages
+    assert error.get('code') == 200
+
 def test_length_repr():
     assert (
         repr(validate.Length(min=None, max=None, error=None, equal=None)) ==
@@ -337,6 +374,15 @@ def test_equal_custom_message():
     with pytest.raises(ValidationError) as excinfo:
         v('b')
     assert 'b is not equal to a.' in str(excinfo)
+
+def test_equal_custom_message_dict():
+    error = {'message': "{input} is not equal to {other}.",
+             'code': 200}
+    v = validate.Equal('a', error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        v('b')
+    error = excinfo.value.messages
+    assert error.get('code') == 200
 
 def test_equal_repr():
     assert (
@@ -390,6 +436,16 @@ def test_regexp_custom_message():
     with pytest.raises(ValidationError) as excinfo:
         v('a')
     assert 'a does not match [0-9]+' in str(excinfo)
+
+def test_regexp_custom_message_dict():
+    error = {'message': "{input} does not match {regex}.",
+             'code': 200}
+    rex = r'[0-9]+'
+    v = validate.Regexp(rex, error=error)
+    with pytest.raises(ValidationError) as excinfo:
+        v('a')
+    error = excinfo.value.messages
+    assert error.get('code') == 200
 
 def test_regexp_repr():
     assert (
@@ -453,6 +509,21 @@ def test_predicate_custom_message():
         validate.Predicate('_false', error='{input}.{method} is invalid!')(d)
     assert 'Dummy._false is invalid!' in str(excinfo)
 
+def test_predicate_custom_message_dict():
+    class Dummy(object):
+        def _false(self):
+            return False
+
+        def __str__(self):
+            return 'Dummy'
+    d = Dummy()
+    error = {'message': "{input}.{method} is invalid!",
+             'code': 200}
+    with pytest.raises(ValidationError) as excinfo:
+        validate.Predicate('_false', error=error)(d)
+    error = excinfo.value.messages
+    assert error.get('code') == 200
+
 def test_predicate_repr():
     assert (
         repr(validate.Predicate(method='foo', error=None)) ==
@@ -496,6 +567,12 @@ def test_noneof_custom_message():
     with pytest.raises(ValidationError) as excinfo:
         none_of(1)
     assert '1 cannot be one of 1, 2' in str(excinfo)
+
+def test_noneof_custom_message_dict():
+    error = {'message': 'error', 'code': 200}
+    with pytest.raises(ValidationError) as excinfo:
+        validate.NoneOf([1, 2], error=error)(1)
+    assert excinfo.value.messages.get('code') == 200
 
 def test_noneof_repr():
     assert (


### PR DESCRIPTION
Hi,
I had a problem for return the fields with errors. My api should follow:

`field_name = [{"code": 4001, "message": "error desc" }]`

I like solution for required fields http://marshmallow.readthedocs.org/en/latest/quickstart.html,
 `city = fields.String(required={'message': 'City required', 'code': 400})`, but not working to validate :(.

My solution to problem is this PR, but accept suggestions.

Thanks :)
