### PR TITLE
New method validators

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,3 +16,4 @@ simplejson
 
 # Syntax checking
 flake8==2.4.1
+pep8==1.6.1  # http://stackoverflow.com/a/28531781/1222326

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 from marshmallow import validate, utils, class_registry
 from marshmallow.base import FieldABC, SchemaABC
 from marshmallow.utils import missing as missing_
-from marshmallow.compat import text_type, basestring
+from marshmallow.compat import text_type, basestring, OrderedDict
 from marshmallow.exceptions import ValidationError
 
 __all__ = [
@@ -143,7 +143,7 @@ class Field(FieldABC):
         else:
             raise ValueError("The 'validate' parameter must be a callable "
                              "or a collection of callables.")
-        self._method_validators = []
+        self._method_validators = OrderedDict()
 
         self.required = required
         # If missing=None, None should be considered valid by default
@@ -283,7 +283,7 @@ class Field(FieldABC):
         """
         # Func is an unbound method. We partial it when the field gets bound
         # to the schema in `_add_to_schema`
-        self._method_validators.append(func)
+        self._method_validators[func.__name__] = func
         return func
 
     # Methods for concrete classes to override.
@@ -299,7 +299,7 @@ class Field(FieldABC):
         self.name = self.name or field_name
         # Bind registered method validators so that the `self` argument
         # is the Schema
-        for validator in self._method_validators:
+        for validator in self._method_validators.values():
             self.validators.append(functools.partial(validator, schema))
 
     def _serialize(self, value, attr, obj):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import collections
-import functools
 import datetime as dt
 import uuid
 import warnings
@@ -297,10 +296,11 @@ class Field(FieldABC):
         """
         self.parent = self.parent or schema
         self.name = self.name or field_name
-        # Bind registered method validators so that the `self` argument
-        # is the Schema
-        for validator in self._method_validators.values():
-            self.validators.append(functools.partial(validator, schema))
+        for validator in self._method_validators:
+            try:
+                self.validators.append(getattr(schema, validator))
+            except AttributeError:
+                pass
 
     def _serialize(self, value, attr, obj):
         """Serializes ``value`` to a basic Python datatype. Noop by default.

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -410,7 +410,6 @@ class TestFieldValidatorDecorator:
                 assert value == 42
                 raise ValidationError('from MySchema')
 
-            @BaseSchema.bar.validator
             def validate_bar(self, value):
                 assert value == 24
                 raise ValidationError('overridden')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -217,9 +217,8 @@ def test_dumps_returns_a_marshalresult(user):
     assert type(result.data) == str
     assert type(result.errors) == dict
 
-def test_dumping_single_object_with_collection_schema():
+def test_dumping_single_object_with_collection_schema(user):
     s = UserSchema(many=True)
-    user = UserSchema('Mick')
     result = s.dump(user, many=False)
     assert type(result.data) == dict
     assert result.data == UserSchema().dump(user).data


### PR DESCRIPTION
This patch is a proposed fix for the failing
`test_method_validator_override` in `new-method-validators`. Instead of
storing validators in a list, use an `OrderedDict` keyed by method name,
so that overrides by subclasses clobber parent methods with the same
name.
