### PR TITLE
Nested 'only' parameter

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -364,6 +364,7 @@ class Nested(Field):
     def __init__(self, nested, default=missing_, exclude=tuple(), only=None, **kwargs):
         self.nested = nested
         self.only = only
+        self.only_explicit = None
         self.exclude = exclude
         self.many = kwargs.get('many', False)
         self.__schema = None  # Cached Schema instance
@@ -382,10 +383,11 @@ class Nested(Field):
             only = (self.only, )
         else:
             only = self.only
+        only = self.only_explicit or only
 
         # Inherit context from parent.
         context = getattr(self.parent, 'context', {})
-        if not self.__schema:
+        if not self.__schema or self.__schema.only != only:
             if isinstance(self.nested, SchemaABC):
                 self.__schema = self.nested
                 self.__schema.context.update(context)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -669,6 +669,27 @@ def test_error_raised_if_additional_option_is_not_list():
                 additional = 'email'
 
 
+def test_nested_only():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+    sch = ParentSchema(only=('bla', ('blubb', ('foo', 'bar'))))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
 def test_only_and_exclude():
     class MySchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
This allows to specify a nested `only` parameter both at schema instantiation time and during dump() like so:

``` python
class ChildSchema(Schema):
    foo = fields.Field()
    bar = fields.Field()
    baz = fields.Field()

class ParentSchema(Schema):
    bla = fields.Field()
    bli = fields.Field()
    blubb = fields.Nested(ChildSchema)

data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))

# either when instantiating
sch = ParentSchema(only=('bla', ('blubb', ('foo', 'bar'))))
result = sch.dump(data)

#or when dumping
sch = ParentSchema()
result = sch.dump(data, only=('bla', ('blubb', ('foo', 'bar'))))
```

It is fully backwards compatible. Fixes #402 
