### PR TITLE
Add support for heterogeneous schemas

### DIFF
--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from marshmallow.schema import (
     Schema,
     SchemaOpts,
+    OneOfSchema,
     MarshalResult,
     UnmarshalResult,
 )
@@ -19,6 +20,7 @@ __author__ = 'Steven Loria'
 __all__ = [
     'Schema',
     'SchemaOpts',
+    'OneOfSchema',
     'validates',
     'validates_schema',
     'pre_dump',

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -866,3 +866,135 @@ class BaseSchema(base.SchemaABC):
 
 class Schema(with_metaclass(SchemaMeta, BaseSchema)):
     __doc__ = BaseSchema.__doc__
+
+
+class OneOfSchema(Schema):
+    """
+    This is a special kind of schema that actually multiplexes other schemas
+    based on object type. When serializing values, it uses get_obj_type() method
+    to get object type name. Then it uses `type_schemas` name-to-Schema mapping
+    to get schema for that particular object type, serializes object using that
+    schema and adds an extra "type" field with name of object type.
+    Deserialization is reverse.
+
+    Example:
+        class Foo(object):
+            def __init__(self, foo):
+                self.foo = foo
+
+        class Bar(object):
+            def __init__(self, bar):
+                self.bar = bar
+
+        class FooSchema(marshmallow.Schema):
+            foo = marshmallow.fields.String(required=True)
+
+            @marshmallow.post_load
+            def make_foo(self, data):
+                return Foo(**data)
+
+        class BarSchema(marshmallow.Schema):
+            bar = marshmallow.fields.Integer(required=True)
+
+            @marshmallow.post_load
+            def make_bar(self, data):
+                return Bar(**data)
+
+        class MyUberSchema(marshmallow.OneOfSchema):
+            type_schemas = {
+                'foo': FooSchema,
+                'bar': BarSchema,
+            }
+
+            def get_obj_type(self, obj):
+                if isinstance(obj, Foo):
+                    return 'foo'
+                elif isinstance(obj, Bar):
+                    return 'bar'
+                else:
+                    raise Exception('Unknown object type: %s' % repr(obj))
+
+        MyUberSchema().dump([Foo(foo='hello'), Bar(bar=123)], many=True).data
+        # => [{'type': 'foo', 'foo': 'hello'}, {'type': 'bar', 'bar': 123}]
+
+    You can control type field name added to serialized object representation by
+    setting `type_field` class property.
+    """
+    type_field = 'type'
+    type_schemas = []
+
+    def get_obj_type(self, obj):
+        """Returns name of object schema"""
+        return obj.__class__.__name__
+
+    def dump(self, obj, many=None, update_fields=True, **kwargs):
+        if not many:
+            return self._dump(obj, update_fields, **kwargs)
+
+        result_data = []
+        result_errors = {}
+
+        for idx, o in enumerate(obj):
+            result = self._dump(o, update_fields, **kwargs)
+            result_data.append(result.data)
+            if result.errors:
+                result_errors[idx] = result.errors
+
+        return MarshalResult(result_data, result_errors)
+
+    def _dump(self, obj, update_fields=True, **kwargs):
+        obj_type = self.get_obj_type(obj)
+        if not obj_type:
+            return MarshalResult(None, {
+                '_schema': 'Unknown object class: %s' % obj.__class__.__name__
+            })
+
+        type_schema = self.type_schemas.get(obj_type)
+        if not type_schema:
+            return MarshalResult(None, {
+                '_schema': 'Unsupported object type: %s' % obj_type
+            })
+
+        schema = (type_schema if isinstance(type_schema, Schema)
+                  else type_schema())
+        result = schema.dump(
+            obj, many=False, update_fields=update_fields, **kwargs
+        )
+        if result.data:
+            result.data[self.type_field] = obj_type
+        return result
+
+    def load(self, data, many=None, partial=None):
+        if not many:
+            return self._load(data, partial=partial)
+
+        result_data = []
+        result_errors = {}
+
+        for idx, item in enumerate(data):
+            result = self._load(item, partial=partial)
+            result_data.append(result.data)
+            if result.errors:
+                result_errors[idx] = result.errors
+
+        return UnmarshalResult(result_data, result_errors)
+
+    def _load(self, data, partial=None):
+        data_type = data.get(self.type_field)
+        if not data_type:
+            return UnmarshalResult({}, {
+                self.type_field: [u'Missing data for required field.']
+            })
+
+        type_schema = self.type_schemas.get(data_type)
+        if not type_schema:
+            return UnmarshalResult({}, {
+                self.type_field: ['Unsupported value: %s' % data_type],
+            })
+
+        schema = (type_schema if isinstance(type_schema, Schema)
+                  else type_schema())
+        return schema.load(data, many=False, partial=partial)
+
+    def validate(self, data, many=None, partial=None):
+        return self.load(data, many=many, partial=partial).errors

--- a/tests/test_one_of_schema.py
+++ b/tests/test_one_of_schema.py
@@ -1,0 +1,172 @@
+import marshmallow as m
+import marshmallow.fields as f
+import unittest
+
+
+REQUIRED_ERROR = u'Missing data for required field.'
+
+
+class Foo(object):
+    def __init__(self, value=None):
+        self.value = value
+
+    def __repr__(self):
+        return '<Foo value=%s>' % self.value
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.value == other.value
+
+
+class FooSchema(m.Schema):
+    value = f.String(required=True)
+
+    @m.post_load
+    def make_foo(self, data):
+        return Foo(**data)
+
+
+class Bar(object):
+    def __init__(self, value=None):
+        self.value = value
+
+    def __repr__(self):
+        return '<Bar value=%s>' % self.value
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.value == other.value
+
+
+class BarSchema(m.Schema):
+    value = f.Integer(required=True)
+
+    @m.post_load
+    def make_bar(self, data):
+        return Bar(**data)
+
+
+class MySchema(m.OneOfSchema):
+    type_schemas = {
+        'Foo': FooSchema,
+        'Bar': BarSchema,
+    }
+
+
+class TestOneOfSchema:
+    def test_dump(self):
+        foo_result = MySchema().dump(Foo('hello'))
+        assert {'type': 'Foo', 'value': 'hello'} == foo_result.data
+        assert {} == foo_result.errors
+
+        bar_result = MySchema().dump(Bar(123))
+        assert {'type': 'Bar', 'value': 123} == bar_result.data
+        assert {} == bar_result.errors
+
+    def test_dump_many(self):
+        result = MySchema().dump([Foo('hello'), Bar(123)], many=True)
+        assert [{'type': 'Foo', 'value': 'hello'},
+                {'type': 'Bar', 'value': 123}] == result.data
+        assert {} == result.errors
+
+    def test_load(self):
+        foo_result = MySchema().load({'type': 'Foo', 'value': 'world'})
+        assert Foo('world') == foo_result.data
+        assert {} == foo_result.errors
+
+        bar_result = MySchema().load({'type': 'Bar', 'value': 456})
+        assert Bar(456) == bar_result.data
+        assert {} == bar_result.errors
+
+    def test_load_many(self):
+        result = MySchema().load([
+            {'type': 'Foo', 'value': 'hello world!'},
+            {'type': 'Bar', 'value': 123},
+        ], many=True)
+        assert [Foo('hello world!'), Bar(123)] == result.data
+        assert {} == result.errors
+
+    def test_load_errors_no_type(self):
+        result = MySchema().load({'value': 'Foo'})
+        assert {'type': [REQUIRED_ERROR]} == result.errors
+
+    def test_load_errors_field_error(self):
+        result = MySchema().load({'type': 'Foo'})
+        assert {'value': [REQUIRED_ERROR]} == result.errors
+
+    def test_load_many_errors_are_indexed_by_object_position(self):
+        result = MySchema().load([
+            {'type': 'Foo'},
+            {'type': 'Bar', 'value': 123},
+        ], many=True)
+        assert {0: {'value': [REQUIRED_ERROR]}} == result.errors
+
+    def test_validate(self):
+        assert {} == MySchema().validate({'type': 'Foo', 'value': '123'})
+        assert {'value': [REQUIRED_ERROR]} == MySchema().validate({'type': 'Bar'})
+
+    def test_validate_many(self):
+        errors = MySchema().validate([
+            {'type': 'Foo', 'value': '123'},
+            {'type': 'Bar', 'value': 123},
+        ], many=True)
+        assert {} == errors
+
+        errors = MySchema().validate([
+            {'value': '123'},
+            {'type': 'Bar'},
+        ], many=True)
+        assert {0: {'type': [REQUIRED_ERROR]},
+                1: {'value': [REQUIRED_ERROR]}} == errors
+
+    def test_using_as_nested_schema(self):
+        class SchemaWithList(m.Schema):
+            items = f.List(f.Nested(MySchema))
+
+        schema = SchemaWithList()
+        result = schema.load({'items': [
+            {'type': 'Foo', 'value': 'hello world!'},
+            {'type': 'Bar', 'value': 123},
+        ]})
+        assert {'items': [Foo('hello world!'), Bar(123)]} == result.data
+        assert {} == result.errors
+
+        result = schema.load({'items': [
+            {'type': 'Foo', 'value': 'hello world!'},
+            {'value': 123},
+        ]})
+        assert {'items': {1: {'type': [REQUIRED_ERROR]}}} == result.errors
+
+    def test_using_custom_type_names(self):
+        class MyCustomTypeNameSchema(m.OneOfSchema):
+            type_schemas = {
+                'baz': FooSchema,
+                'bam': BarSchema,
+            }
+
+            def get_obj_type(self, obj):
+                return {'Foo': 'baz', 'Bar': 'bam'}.get(obj.__class__.__name__)
+
+        schema = MyCustomTypeNameSchema()
+        data = [Foo('hello'), Bar(111)]
+        marshalled = schema.dump(data, many=True)
+        assert [{'type': 'baz', 'value': 'hello'},
+                {'type': 'bam', 'value': 111}] == marshalled.data
+        assert {} == marshalled.errors
+
+        unmarshalled = schema.load(marshalled.data, many=True)
+        assert data == unmarshalled.data
+        assert {} == unmarshalled.errors
+
+    def test_using_custom_type_field(self):
+        class MyCustomTypeFieldSchema(MySchema):
+            type_field = 'object_type'
+
+        schema = MyCustomTypeFieldSchema()
+        data = [Foo('hello'), Bar(111)]
+        marshalled = schema.dump(data, many=True)
+        assert [{'object_type': 'Foo', 'value': 'hello'},
+                {'object_type': 'Bar', 'value': 111}] == marshalled.data
+        assert {} == marshalled.errors
+
+        unmarshalled = schema.load(marshalled.data, many=True)
+        assert data == unmarshalled.data
+        assert {} == unmarshalled.errors


### PR DESCRIPTION
Adds OneOfSchema class which is a special
schema that can multiplex between several
other schemas allowing to work with
heterogeneous collections (collections of
objects of different types).
