### PR TITLE
Pass through user ValidationError kwargs

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -35,6 +35,8 @@ class ErrorStore(object):
         self.error_field_names = []
         #: True while (de)serializing a collection
         self._pending = False
+        #: Dictionary of extra kwargs from user raised exception
+        self.kwargs = {}
 
     def reset_errors(self):
         self.errors = {}
@@ -181,6 +183,7 @@ class Unmarshaller(ErrorStore):
                 raise ValidationError(self.default_schema_validation_error)
         except ValidationError as err:
             errors = self.get_errors(index=index)
+            self.kwargs.update(err.kwargs)
             # Store or reraise errors
             if err.field_names:
                 field_names = err.field_names

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -634,7 +634,8 @@ class BaseSchema(base.SchemaABC):
                 errors,
                 field_names=self._unmarshal.error_field_names,
                 fields=self._unmarshal.error_fields,
-                data=data
+                data=data,
+                **self._unmarshal.kwargs
             )
             self.handle_error(exc, data)
             if self.strict:


### PR DESCRIPTION
I noticed that in `ValidationError` there is a `kwargs` dictionary, which seems to be for user arguments. I thought I'd use it to add a `status_code` kwarg so that when I catch the exception in my code I could add a bit more semantic information to the response. However, because of how the schema loading works, it is discarded.

This patch fixes this but I'm not sure it's clean enough to get merged. Perhaps a more extensive refactoring is required.
