### PR TITLE
Option to treat empty strings as null values

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,3 +64,4 @@ Contributors (chronological)
 - `@immerrr <https://github.com/immerrr>`_
 - Mike Yumatov `@yumike <https://github.com/yumike>`_
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
+- Colton Allen `@cmanallen <https://github.com/cmanallen>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -122,13 +122,16 @@ class Field(FieldABC):
         'validator_failed': 'Invalid value.'
     }
 
-    def __init__(self, default=missing_, attribute=None, load_from=None, dump_to=None,
-                 error=None, validate=None, required=False, allow_none=None, load_only=False,
-                 dump_only=False, missing=missing_, error_messages=None, **metadata):
+    def __init__(self, default=missing_, attribute=None, load_from=None,
+                 dump_to=None, error=None, validate=None, required=False,
+                 allow_none=None, load_only=False, dump_only=False,
+                 missing=missing_, error_messages=None, empty_as_none=False,
+                 **metadata):
         self.default = default
         self.attribute = attribute
         self.load_from = load_from  # this flag is used by Unmarshaller
         self.dump_to = dump_to  # this flag is used by Marshaller
+        self.empty_as_none = empty_as_none
         self.validate = validate
         if utils.is_iterable_but_not_string(validate):
             if not utils.is_generator(validate):
@@ -256,8 +259,10 @@ class Field(FieldABC):
         # Validate required fields, deserialize, then validate
         # deserialized value
         self._validate_missing(value)
-        if hasattr(self.root, 'opts'):
-            if self.parent.opts.empty_as_none and value == '':
+        if value == '':
+            if self.empty_as_none:
+                value = None
+            elif hasattr(self.root, 'opts') and self.root.opts.empty_as_none:
                 value = None
         if getattr(self, 'allow_none', False) is True and value is None:
             return None

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -256,6 +256,9 @@ class Field(FieldABC):
         # Validate required fields, deserialize, then validate
         # deserialized value
         self._validate_missing(value)
+        if hasattr(self.root, 'opts'):
+            if self.parent.opts.empty_as_none and value == '':
+                value = None
         if getattr(self, 'allow_none', False) is True and value is None:
             return None
         output = self._deserialize(value, attr, data)

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -203,6 +203,7 @@ class SchemaOpts(object):
         self.include = getattr(meta, 'include', {})
         self.load_only = getattr(meta, 'load_only', ())
         self.dump_only = getattr(meta, 'dump_only', ())
+        self.empty_as_none = getattr(meta, 'empty_as_none', False)
 
 
 class BaseSchema(base.SchemaABC):
@@ -318,6 +319,7 @@ class BaseSchema(base.SchemaABC):
             of invalid items in a collection.
         - ``load_only``: Tuple or list of fields to exclude from serialized results.
         - ``dump_only``: Tuple or list of fields to exclude from deserialization
+        - ``empty_as_none``: If `True`, empty strings will be intrepreted as `None`.
         """
         pass
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -697,6 +697,16 @@ class TestFieldDeserialization:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
 
+    def test_field_deserialization_empty_as_none(self):
+        field = fields.String(empty_as_none=True, allow_none=True)
+        assert field.deserialize('') is None
+
+    def test_field_deserialization_empty_as_none_raises_error(self):
+        field = fields.String(empty_as_none=True)
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize('')
+        assert excinfo
+
 # No custom deserialization behavior, so a dict is returned
 class SimpleUserSchema(Schema):
     name = fields.String()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -224,3 +224,25 @@ class TestIncludeOption:
         assert 'email' in s._declared_fields.keys()
         assert 'from' in s._declared_fields.keys()
         assert isinstance(s._declared_fields['from'], fields.Str)
+
+
+class TestEmptyAsNoneOption(object):
+    """Verify that empty values are transformed to `None` types."""
+
+    class EmptyFieldsSchema(Schema):
+        nullable = fields.String(allow_none=True)
+        not_nullable = fields.String(allow_none=False)
+
+        class Meta:
+            empty_as_none = True
+            strict = False
+
+    def test_empty_nullable_field(self):
+        data = {'nullable': '', 'not_nullable': 'x'}
+        result, errors = self.EmptyFieldsSchema().load(data)
+        assert result['nullable'] is None
+
+    def test_empty_not_nullable_field(self):
+        data = {'not_nullable': '', 'nullable': 'x'}
+        result, errors = self.EmptyFieldsSchema().load(data)
+        assert 'not_nullable' in errors


### PR DESCRIPTION
Empty strings are transformed to `None` during deserialization if the appropriate options are set.

**Changes:**
- Adds a schema option for interpreting ALL empty strings (`""`) as `None`.
- Adds a field option for interpreting field specific empty strings (`""`) as `None`.

**Reasoning:**
Clients will often send `""` when a field value has been deleted by the user or the user has tabbed through the form inputs without entering any information.  These inputs have the intention of being null but not the appropriate type.  Having an `empty_as_none` option allows us to use pre-existing marshmallow validators rather than validating after the fact.
