### PR TITLE
Optimize cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # C extensions
 *.so
+*.c
 
 # Packages
 *.egg

--- a/marshmallow/base.py
+++ b/marshmallow/base.py
@@ -11,6 +11,7 @@ class FieldABC(object):
     """
     parent = None
     name = None
+    __slots__ = ()
 
     def serialize(self, attr, obj, accessor=None):
         raise NotImplementedError
@@ -31,6 +32,8 @@ class FieldABC(object):
 
 class SchemaABC(object):
     """Abstract base class from which all Schemas inherit."""
+
+    __slots__ = ()
 
     def dump(self, obj):
         raise NotImplementedError

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -5,6 +5,7 @@ from marshmallow.compat import basestring
 
 class MarshmallowError(Exception):
     """Base class for all marshmallow-related errors."""
+    __slots__ = ()
     pass
 
 
@@ -18,6 +19,8 @@ class ValidationError(MarshmallowError):
         If `None`, the error is stored in its default location.
     :param list fields: `Field` objects to which the error applies.
     """
+
+    __slots__ = ("messages", "fields", "field_names", "data", "kwargs")
 
     def __init__(self, message, field_names=None, fields=None, data=None, **kwargs):
         if not isinstance(message, dict) and not isinstance(message, list):
@@ -45,4 +48,5 @@ class RegistryError(NameError):
     """Raised when an invalid operation is performed on the serializer
     class registry.
     """
+    __slots__ = ()
     pass

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -944,7 +944,6 @@ class Time(Field):
         """Deserialize an ISO8601-formatted time to a :class:`datetime.time` object."""
         if not value:   # falsy values are invalid
             self.fail('invalid')
-            raise err
         try:
             return utils.from_iso_time(value)
         except (AttributeError, TypeError, ValueError):

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -26,6 +26,8 @@ FIELD = '_field'
 
 class ErrorStore(object):
 
+    __slots__ = ('errors', 'error_fields', 'error_field_names', '_pending')
+
     def __init__(self):
         #: Dictionary of errors stored during serialization
         self.errors = {}
@@ -85,6 +87,9 @@ class Marshaller(ErrorStore):
     :param str prefix: Optional prefix that will be prepended to all the
         serialized field names.
     """
+
+    __slots__ = ('prefix')
+
     def __init__(self, prefix=''):
         self.prefix = prefix
         ErrorStore.__init__(self)
@@ -167,6 +172,7 @@ class Unmarshaller(ErrorStore):
     .. versionadded:: 1.0.0
     """
 
+    __slots__ = ()
     default_schema_validation_error = 'Invalid data.'
 
     def run_validator(self, validator_func, output,

--- a/marshmallow/ordereddict.py
+++ b/marshmallow/ordereddict.py
@@ -27,6 +27,8 @@ from UserDict import DictMixin
 
 class OrderedDict(dict, DictMixin):
 
+    __slots__ = ("__end")
+
     def __init__(self, *args, **kwds):
         if len(args) > 1:
             raise TypeError('expected at most 1 arguments, got %d' % len(args))

--- a/marshmallow/orderedset.py
+++ b/marshmallow/orderedset.py
@@ -25,6 +25,8 @@ import collections
 
 class OrderedSet(collections.MutableSet):
 
+    __slots__ = ('end', 'map')
+
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]         # sentinel node for doubly linked list

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -43,7 +43,7 @@ def _get_fields(attrs, field_class, pop=False, ordered=False):
     if ordered:
         return sorted(
             fields,
-            key=lambda pair: pair[1]._creation_index,
+            key=lambda pair: pair[1].creation_index,
         )
     else:
         return fields
@@ -865,4 +865,5 @@ class BaseSchema(base.SchemaABC):
 
 
 class Schema(with_metaclass(SchemaMeta, BaseSchema)):
+    __slots__ = ()
     __doc__ = BaseSchema.__doc__

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -26,6 +26,8 @@ except ImportError:
 
 class _Missing(object):
 
+    __slots__ = ()
+
     def __bool__(self):
         return False
 
@@ -147,6 +149,7 @@ class UTC(datetime.tzinfo):
     _utcoffset = ZERO
     _dst = ZERO
     _tzname = zone
+    __slots__ = ()
 
     def fromutc(self, dt):
         if dt.tzinfo is None:

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -17,6 +17,7 @@ class Validator(object):
         This class does not provide any behavior. It is only used to
         add a useful `__repr__` implementation for validators.
     """
+    __slots__ = ()
 
     def __repr__(self):
         args = self._repr_args()
@@ -44,6 +45,7 @@ class URL(Validator):
         ``ftp``, and ``ftps`` are allowed.
     """
 
+    __slots__ = ('relative', 'error', 'schemes')
     URL_REGEX = re.compile(
         r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
         r'(?:[^:@]+?:[^:@]*?@|)'  # basic auth
@@ -107,6 +109,7 @@ class Email(Validator):
         interpolated with `{input}`.
     """
 
+    __slots__ = ('error')
     USER_REGEX = re.compile(
         r"(^[-!#$%&'*+/=?^`{}|~\w]+(\.[-!#$%&'*+/=?^`{}|~\w]+)*$"  # dot-atom
         # quoted-string
@@ -171,6 +174,7 @@ class Range(Validator):
         Can be interpolated with `{input}`, `{min}` and `{max}`.
     """
 
+    __slots__ = ('min', 'max', 'error')
     message_min = 'Must be at least {min}.'
     message_max = 'Must be at most {max}.'
     message_all = 'Must be between {min} and {max}.'
@@ -213,6 +217,7 @@ class Length(Range):
         Can be interpolated with `{input}`, `{min}` and `{max}`.
     """
 
+    __slots__ = ('equal')
     message_min = 'Shorter than minimum length {min}.'
     message_max = 'Longer than maximum length {max}.'
     message_all = 'Length must be between {min} and {max}.'
@@ -263,6 +268,7 @@ class Equal(Validator):
         Can be interpolated with `{input}` and `{other}`.
     """
 
+    __slots__ = ('comparable', 'error')
     default_message = 'Must be equal to {other}.'
 
     def __init__(self, comparable, error=None):
@@ -292,6 +298,7 @@ class Regexp(Validator):
         Can be interpolated with `{input}` and `{regex}`.
     """
 
+    __slots__ = ('regex', 'error')
     default_message = 'String does not match expected pattern.'
 
     def __init__(self, regex, flags=0, error=None):
@@ -323,6 +330,7 @@ class Predicate(Validator):
     :param kwargs: Additional keyword arguments to pass to the method.
     """
 
+    __slots__ = ('method', 'error', 'kwargs')
     default_message = 'Invalid input.'
 
     def __init__(self, method, error=None, **kwargs):
@@ -353,6 +361,7 @@ class NoneOf(Validator):
         interpolated using `{input}` and `{values}`.
     """
 
+    __slots__ = ('iterable', 'values_text', 'error')
     default_message = 'Invalid input.'
 
     def __init__(self, iterable, error=None):
@@ -388,6 +397,7 @@ class OneOf(Validator):
         interpolated with `{input}`, `{choices}` and `{labels}`.
     """
 
+    __slots__ = ('choices', 'choices_text', 'labels', 'labels_text', 'error')
     default_message = 'Not a valid choice.'
 
     def __init__(self, choices, labels=None, error=None):
@@ -442,6 +452,7 @@ class ContainsOnly(OneOf):
     :param str error: Same as :class:`OneOf`.
     """
 
+    __slots__ = ()
     default_message = 'One or more of the choices you made was not acceptable.'
 
     def _format_error(self, value):


### PR DESCRIPTION
added slots to classes and made changes that will compile for cython. There were a few things that had to change worth noteing:

1) _creation_index was being used as both a class level and instance level variable which cause problems when adding slots. For this reason I just changed the instance level _creation_index to just be creation_index and switched the places referring to it to now refer to the new variable.

2) There was some code that said 'raise err' but there was no err defined. It appears like it would never get hit which was why it was not causing problems before. However with the cython compilation change this line made the code not compile. So that was removed. 

everything else was just required for the slots changes or compilation.
