### PR TITLE
Pass through exception kwargs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,3 +64,4 @@ Contributors (chronological)
 - `@immerrr <https://github.com/immerrr>`_
 - Mike Yumatov `@yumike <https://github.com/yumike>`_
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
+- Russell Davies `@russelldavies <https://github.com/russelldavies>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Features:
 
 - Make context available to ``Nested`` field's ``on_bind_field`` method (:issue:`408`). Thanks :user:`immerrr` for the PR.
+- Pass through user ``ValidationError`` kwargs (:issue:`418`). Thanks :user:`russelldavies` for helping implement this.
 
 Other changes:
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -189,17 +189,19 @@ class Field(FieldABC):
         does not succeed.
         """
         errors = []
+        kwargs = {}
         for validator in self.validators:
             try:
                 if validator(value) is False:
                     self.fail('validator_failed')
             except ValidationError as err:
+                kwargs.update(err.kwargs)
                 if isinstance(err.messages, dict):
                     errors.append(err.messages)
                 else:
                     errors.extend(err.messages)
         if errors:
-            raise ValidationError(errors)
+            raise ValidationError(errors, **kwargs)
 
     # Hat tip to django-rest-framework.
     def fail(self, key, **kwargs):

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -35,6 +35,8 @@ class ErrorStore(object):
         self.error_field_names = []
         #: True while (de)serializing a collection
         self._pending = False
+        #: Dictionary of extra kwargs from user raised exception
+        self.kwargs = {}
 
     def reset_errors(self):
         self.errors = {}
@@ -181,6 +183,7 @@ class Unmarshaller(ErrorStore):
                 raise ValidationError(self.default_schema_validation_error)
         except ValidationError as err:
             errors = self.get_errors(index=index)
+            self.kwargs = err.kwargs
             # Store or reraise errors
             if err.field_names:
                 field_names = err.field_names

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -36,7 +36,7 @@ class ErrorStore(object):
         #: True while (de)serializing a collection
         self._pending = False
         #: Dictionary of extra kwargs from user raised exception
-        self.kwargs = {}
+        self.error_kwargs = {}
 
     def reset_errors(self):
         self.errors = {}
@@ -66,6 +66,7 @@ class ErrorStore(object):
         try:
             value = getter_func(data)
         except ValidationError as err:  # Store validation errors
+            self.error_kwargs.update(err.kwargs)
             self.error_fields.append(field_obj)
             self.error_field_names.append(field_name)
             errors = self.get_errors(index=index)
@@ -183,7 +184,7 @@ class Unmarshaller(ErrorStore):
                 raise ValidationError(self.default_schema_validation_error)
         except ValidationError as err:
             errors = self.get_errors(index=index)
-            self.kwargs = err.kwargs
+            self.error_kwargs.update(err.kwargs)
             # Store or reraise errors
             if err.field_names:
                 field_names = err.field_names

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -634,7 +634,8 @@ class BaseSchema(base.SchemaABC):
                 errors,
                 field_names=self._unmarshal.error_field_names,
                 fields=self._unmarshal.error_fields,
-                data=data
+                data=data,
+                **self._unmarshal.kwargs
             )
             self.handle_error(exc, data)
             if self.strict:

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -635,7 +635,7 @@ class BaseSchema(base.SchemaABC):
                 field_names=self._unmarshal.error_field_names,
                 fields=self._unmarshal.error_fields,
                 data=data,
-                **self._unmarshal.kwargs
+                **self._unmarshal.error_kwargs
             )
             self.handle_error(exc, data)
             if self.strict:


### PR DESCRIPTION
This contains the changes in #418. It goes on further to pass ValidationError kwargs all the way until the final re-raising by `Schema`.
