### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     package_dir={'marshmallow': 'marshmallow'},
     include_package_data=True,
     extras_require={'reco': EXTRA_REQUIREMENTS},
-    license=read('LICENSE'),
+    license='LICENSE',
     zip_safe=False,
     keywords=('serialization', 'rest', 'json', 'api', 'marshal',
         'marshalling', 'deserialization', 'validation', 'schema'),


### PR DESCRIPTION
The change fixes the below error,

SCENARIO: Error occurs while generating RPM by executing # python setup.py bdist_rpm
ERROR:
error: line 14: Unknown tag: Permission is hereby granted, free of charge, to any person obtaining a copy
error: query of specfile build/bdist.linux-x86_64/rpm/SPECS/marshmallow.spec failed, can't parse
error: Failed to execute: "rpm -q --qf '%{name}-%{version}-%{release}.src.rpm %{arch}/%{name}-%{version}-%{release}.%{arch}.rpm\n' --specfile 'build/bdist.linux-x86_64/rpm/SPECS/marshmallow.spec'"
