### PR TITLE
Always coerce values to string in Decimal object's deserialization method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -65,3 +65,4 @@ Contributors (chronological)
 - Mike Yumatov `@yumike <https://github.com/yumike>`_
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
 - Russell Davies `@russelldavies <https://github.com/russelldavies>`_
+- David Thornton `@davidthornton <https://github.com/davidthornton>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -659,6 +659,16 @@ class Decimal(Number):
         a JSON library that can handle decimals, such as `simplejson`, or serialize
         to a string by passing ``as_string=True``.
 
+    .. warning::
+
+        If a JSON `float` value is passed to this field for deserialization it will
+        first be cast to its corresponding `string` value before being deserialized
+        to a `decimal.Decimal` object. The default `__str__` implementation of the
+        built-in Python `float` type may apply a destructive transformation upon
+        its input data and therefore cannot be relied upon to preserve precision.
+        To avoid this, you can instead pass a JSON `string` to be deserialized
+        directly.
+
     :param int places: How many decimal places to quantize the value. If `None`, does
         not quantize the value.
     :param rounding: How to round the value during quantize, for example

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -690,7 +690,7 @@ class Decimal(Number):
         if value is None:
             return None
 
-        num = decimal.Decimal(value)
+        num = decimal.Decimal(str(value))
 
         if self.allow_nan:
             if num.is_nan():

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -88,8 +88,9 @@ class TestFieldDeserialization:
         m1 = 12
         m2 = '12.355'
         m3 = decimal.Decimal(1)
-        m4 = 'abc'
-        m5 = [1, 2]
+        m4 = 3.14
+        m5 = 'abc'
+        m6 = [1, 2]
 
         field = fields.Decimal()
         assert isinstance(field.deserialize(m1), decimal.Decimal)
@@ -98,11 +99,13 @@ class TestFieldDeserialization:
         assert field.deserialize(m2) == decimal.Decimal('12.355')
         assert isinstance(field.deserialize(m3), decimal.Decimal)
         assert field.deserialize(m3) == decimal.Decimal(1)
-        with pytest.raises(ValidationError) as excinfo:
-            field.deserialize(m4)
-        assert excinfo.value.args[0] == 'Not a valid number.'
+        assert isinstance(field.deserialize(m4), decimal.Decimal)
+        assert field.deserialize(m4).as_tuple() == (0, (3, 1, 4), -2)
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize(m5)
+        assert excinfo.value.args[0] == 'Not a valid number.'
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(m6)
         assert excinfo.value.args[0] == 'Not a valid number.'
 
     def test_decimal_field_with_places(self):


### PR DESCRIPTION
When `as_string` is set to true, the `_deserialize` method will implicitly cast the value to a string before passing to `decimal.Decimal()`.

This preserves legacy behaviour when `as_string` is false, and prevents unexpected `float` to `decimal.Decimal()` conversions when it is true. 
