### PR TITLE
Validates schema field errors

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -10,8 +10,8 @@ and from primitive types.
 
 from __future__ import unicode_literals
 
-from marshmallow.utils import is_collection, missing
-from marshmallow.compat import text_type, iteritems
+from marshmallow.utils import SCHEMA, is_collection, missing
+from marshmallow.compat import iteritems
 from marshmallow.exceptions import (
     ValidationError,
 )
@@ -160,9 +160,6 @@ class Marshaller(ErrorStore):
 
     # Make an instance callable
     __call__ = serialize
-
-# Key used for schema-level validation errors
-SCHEMA = '_schema'
 
 class Unmarshaller(ErrorStore):
     """Callable class responsible for deserializing data and storing errors.

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -20,7 +20,7 @@ from marshmallow.exceptions import ValidationError
 from marshmallow.orderedset import OrderedSet
 from marshmallow.decorators import (PRE_DUMP, POST_DUMP, PRE_LOAD, POST_LOAD,
                                     VALIDATES, VALIDATES_SCHEMA)
-from marshmallow.utils import missing
+from marshmallow.utils import missing, merge_errors
 
 
 #: Return type of :meth:`Schema.dump` including serialized data and errors
@@ -656,12 +656,12 @@ class BaseSchema(base.SchemaABC):
                 self._invoke_validators(pass_many=True, data=result, original_data=data, many=many,
                                         field_errors=field_errors)
             except ValidationError as err:
-                errors.update(err.messages)
+                errors = merge_errors(errors, err.messages)
             try:
                 self._invoke_validators(pass_many=False, data=result, original_data=data, many=many,
                                         field_errors=field_errors)
             except ValidationError as err:
-                errors.update(err.messages)
+                errors = merge_errors(errors, err.messages)
         # Run post processors
         if not errors and postprocess:
             try:
@@ -906,14 +906,14 @@ class BaseSchema(base.SchemaABC):
                                                   item, original_data, self.fields, many=many,
                                                   index=idx, pass_original=pass_original)
                     except ValidationError as err:
-                        errors.update(err.messages)
+                        errors = merge_errors(errors, err.messages)
             else:
                 try:
                     self._unmarshal.run_validator(validator,
                                               data, original_data, self.fields, many=many,
                                               pass_original=pass_original)
                 except ValidationError as err:
-                    errors.update(err.messages)
+                    errors = merge_errors(errors, err.messages)
         if errors:
             raise ValidationError(errors)
         return None

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -14,7 +14,11 @@ from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
-from marshmallow.compat import OrderedDict, binary_type, text_type
+from marshmallow.compat import OrderedDict, binary_type, iteritems, text_type
+
+
+# Key used for schema-level validation errors
+SCHEMA = '_schema'
 
 
 dateutil_available = False
@@ -348,3 +352,58 @@ def get_func_args(func):
 
 def if_none(value, default):
     return value if value is not None else default
+
+
+def merge_errors(errors1, errors2):
+    """Deeply merges two error messages. Error messages can be
+    string, list of strings or dict of error messages (recursively).
+    Format is the same as accepted by :exc:`ValidationError`.
+    Returns new error messages.
+    """
+    if errors1 is None:
+        return errors2
+    elif errors2 is None:
+        return errors1
+
+    if isinstance(errors1, list):
+        if not errors1:
+            return errors2
+
+        if isinstance(errors2, list):
+            return errors1 + errors2
+        elif isinstance(errors2, dict):
+            return dict(
+                errors2,
+                **{SCHEMA: merge_errors(errors1, errors2.get(SCHEMA))}
+            )
+        else:
+            return errors1 + [errors2]
+    elif isinstance(errors1, dict):
+        if isinstance(errors2, list):
+            return dict(
+                errors1,
+                **{SCHEMA: merge_errors(errors1.get(SCHEMA), errors2)}
+            )
+        elif isinstance(errors2, dict):
+            errors = dict(errors1)
+            for k, v in iteritems(errors2):
+                if k in errors:
+                    errors[k] = merge_errors(errors[k], v)
+                else:
+                    errors[k] = v
+            return errors
+        else:
+            return dict(
+                errors1,
+                **{SCHEMA: merge_errors(errors1.get(SCHEMA), errors2)}
+            )
+    else:
+        if isinstance(errors2, list):
+            return [errors1] + errors2 if errors2 else errors1
+        elif isinstance(errors2, dict):
+            return dict(
+                errors2,
+                **{SCHEMA: merge_errors(errors1, errors2.get(SCHEMA))}
+            )
+        else:
+            return [errors1, errors2]

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -14,7 +14,9 @@ from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
-from marshmallow.compat import OrderedDict, binary_type, iteritems, text_type
+from marshmallow.compat import OrderedDict, binary_type, iteritems, \
+    string_types, text_type
+from marshmallow.exceptions import ValidationError
 
 
 # Key used for schema-level validation errors
@@ -407,3 +409,73 @@ def merge_errors(errors1, errors2):
             )
         else:
             return [errors1, errors2]
+
+
+class ValidationErrorBuilder(object):
+    """Helper class to report multiple errors.
+
+    Example:
+
+        @marshmallow.validates_schema
+        def validate_all(self, data):
+            builder = marshmallow.utils.ValidationErrorBuilder()
+            if data['foo']['bar'] >= data['baz']['bam']:
+                builder.add_error('foo.bar', 'Should be less than bam')
+            if data['foo']['quux'] >= data['baz']['bam']:
+                builder.add_fields('foo.quux', 'Should be less than bam')
+            ...
+            builder.raise_errors()
+    """
+
+    def __init__(self):
+        self.errors = {}
+
+    def _make_error(self, path, error):
+        if isinstance(path, string_types):
+            parts = path.split('.')
+        else:
+            parts = path
+
+        if len(parts) == 1:
+            return {parts[0]: error}
+        else:
+            return {parts[0]: self._make_error(parts[1:], error)}
+
+    def add_error(self, path, error):
+        """Add error message for given field path.
+
+        Example:
+
+            builder = ValidationErrorBuilder()
+            builder.add_error('foo.bar.baz', 'Some error')
+            print builder.errors
+            # => {'foo': {'bar': {'baz': 'Some error'}}}
+
+            builder.add_error(['foo', 'bar', 'baz'], 'Some error')
+            print builder.errors
+            # => {'foo': {'bar': {'baz': 'Some error'}}}
+
+        :param str|list path: '.'-separated list or list of field names
+        :param str error: Error message
+        """
+        self.errors = merge_errors(self.errors, self._make_error(path, error))
+
+    def merge_errors(self, errors):
+        """Add errors in dict format.
+
+        Example:
+
+            builder = ValidationErrorBuilder()
+            builder.add_errors({'foo': {'bar': 'Error 1'}})
+            builder.add_errors({'foo': {'baz': 'Error 2'}, 'bam': 'Error 3'})
+            print builder.errors
+            # => {'foo': {'bar': 'Error 1', 'baz': 'Error 2'}, 'bam': 'Error 3'}
+
+        :param str, list or dict errors: Errors to merge
+        """
+        self.errors = merge_errors(self.errors, errors)
+
+    def raise_errors(self):
+        """Raise ValidationError if errors are not empty; do nothing otherwise."""
+        if self.errors:
+            raise ValidationError(self.errors)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from collections import namedtuple
 
 from marshmallow import (
     Schema,
@@ -432,6 +433,8 @@ class TestValidatesSchemaDecorator:
 
     def test_passing_original_data(self):
 
+        CustomError = namedtuple('CustomError', ['code'])
+
         class MySchema(Schema):
             foo = fields.Int()
             bar = fields.Int()
@@ -447,7 +450,7 @@ class TestValidatesSchemaDecorator:
                 def check(datum):
                     for key, val in datum.items():
                         if key not in self.fields:
-                            raise ValidationError({'code': 'invalid_field'})
+                            raise ValidationError(CustomError(code='invalid_field'))
                 if many:
                     for each in original_data:
                         check(each)
@@ -458,7 +461,7 @@ class TestValidatesSchemaDecorator:
         errors = schema.validate({'foo': 4, 'baz': 42})
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
-        assert errors['_schema'][0] == {'code': 'invalid_field'}
+        assert errors['_schema'][0] == CustomError(code='invalid_field')
 
         errors = schema.validate({'foo': '4'})
         assert '_schema' in errors
@@ -469,7 +472,7 @@ class TestValidatesSchemaDecorator:
         errors = schema.validate([{'foo': 4, 'baz': 42}], many=True)
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
-        assert errors['_schema'][0] == {'code': 'invalid_field'}
+        assert errors['_schema'][0] == CustomError(code='invalid_field')
 
     # https://github.com/marshmallow-code/marshmallow/issues/273
     def test_allow_arbitrary_field_names_in_error(self):
@@ -530,6 +533,37 @@ class TestValidatesSchemaDecorator:
         errors = schema.validate([{'foo': 3, 'bar': 'not an int'}], many=True)
         assert 'bar' in errors[0]
         assert '_schema' not in errors
+
+    def test_allow_reporting_field_errors_in_schema_validator(self):
+
+        class NestedSchema(Schema):
+            baz = fields.Int(required=True)
+
+        class MySchema(Schema):
+            foo = fields.Int(required=True)
+            bar = fields.Nested(NestedSchema, required=True)
+            bam = fields.Int(required=True)
+
+            @validates_schema(skip_on_field_errors=True)
+            def consistency_validation(self, data):
+                errors = {}
+                if data['bar']['baz'] != data['foo']:
+                    errors['bar'] = {'baz': 'Non-matching value'}
+
+                if data['bam'] > data['foo']:
+                    errors['bam'] = 'Value should be less than foo'
+
+                if errors:
+                    raise ValidationError(errors)
+
+        schema = MySchema()
+        errors = schema.validate({'foo': 2, 'bar': {'baz': 5}, 'bam': 6})
+        assert 'bar' in errors
+        assert 'baz' in errors['bar']
+        assert errors['bar']['baz'] == 'Non-matching value'
+        assert 'bam' in errors
+        assert errors['bam'] == 'Value should be less than foo'
+
 
 def test_decorator_error_handling():
     class ExampleSchema(Schema):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,3 +222,122 @@ def test_get_func_args():
 
     for func in [f1, f2, f3]:
         assert utils.get_func_args(func) == ['self', 'foo', 'bar']
+
+
+CustomError = namedtuple('CustomError', ['code', 'message'])
+
+class TestMergeErrors:
+
+    def test_merging_none_and_string(self):
+        assert 'error1' == utils.merge_errors(None, 'error1')
+
+    def test_merging_none_and_custom_error(self):
+        assert CustomError(123, 'error1') == \
+            utils.merge_errors(None, CustomError(123, 'error1'))
+
+    def test_merging_none_and_list(self):
+        assert ['error1', 'error2'] == \
+            utils.merge_errors(None, ['error1', 'error2'])
+
+    def test_merging_none_and_dict(self):
+        assert {'field1': 'error1'} == \
+            utils.merge_errors(None, {'field1': 'error1'})
+
+    def test_merging_string_and_none(self):
+        assert 'error1' == utils.merge_errors('error1', None)
+
+    def test_merging_custom_error_and_none(self):
+        assert CustomError(123, 'error1') == \
+            utils.merge_errors(CustomError(123, 'error1'), None)
+
+    def test_merging_list_and_none(self):
+        assert ['error1', 'error2'] == \
+            utils.merge_errors(['error1', 'error2'], None)
+
+    def test_merging_dict_and_none(self):
+        assert {'field1': 'error1'} == \
+            utils.merge_errors({'field1': 'error1'}, None)
+
+    def test_merging_string_and_string(self):
+        assert ['error1', 'error2'] == utils.merge_errors('error1', 'error2')
+
+    def test_merging_custom_error_and_string(self):
+        assert [CustomError(123, 'error1'), 'error2'] == \
+            utils.merge_errors(CustomError(123, 'error1'), 'error2')
+
+    def test_merging_string_and_custom_error(self):
+        assert ['error1', CustomError(123, 'error2')] == \
+            utils.merge_errors('error1', CustomError(123, 'error2'))
+
+    def test_merging_custom_error_and_custom_error(self):
+        assert [CustomError(123, 'error1'), CustomError(456, 'error2')] == \
+            utils.merge_errors(CustomError(123, 'error1'),
+                               CustomError(456, 'error2'))
+
+    def test_merging_string_and_list(self):
+        assert ['error1', 'error2'] == utils.merge_errors('error1', ['error2'])
+
+    def test_merging_string_and_dict(self):
+        assert {'_schema': 'error1', 'field1': 'error2'} == \
+            utils.merge_errors('error1', {'field1': 'error2'})
+
+    def test_merging_string_and_dict_with_schema_error(self):
+        assert {'_schema': ['error1', 'error2'], 'field1': 'error3'} == \
+            utils.merge_errors('error1', {'_schema': 'error2', 'field1': 'error3'})
+
+    def test_merging_custom_error_and_list(self):
+        assert [CustomError(123, 'error1'), 'error2'] == \
+            utils.merge_errors(CustomError(123, 'error1'), ['error2'])
+
+    def test_merging_custom_error_and_dict(self):
+        assert {'_schema': CustomError(123, 'error1'), 'field1': 'error2'} == \
+            utils.merge_errors(CustomError(123, 'error1'), {'field1': 'error2'})
+
+    def test_merging_custom_error_and_dict_with_schema_error(self):
+        assert {'_schema': [CustomError(123, 'error1'), 'error2'],
+                'field1': 'error3'} == \
+            utils.merge_errors(CustomError(123, 'error1'),
+                               {'_schema': 'error2', 'field1': 'error3'})
+
+    def test_merging_list_and_string(self):
+        assert ['error1', 'error2'] == utils.merge_errors(['error1'], 'error2')
+
+    def test_merging_list_and_custom_error(self):
+        assert ['error1', CustomError(123, 'error2')] == \
+            utils.merge_errors(['error1'], CustomError(123, 'error2'))
+
+    def test_merging_list_and_list(self):
+        assert ['error1', 'error2'] == utils.merge_errors(['error1'], ['error2'])
+
+    def test_merging_list_and_dict(self):
+        assert {'_schema': ['error1'], 'field1': 'error2'} == \
+            utils.merge_errors(['error1'], {'field1': 'error2'})
+
+    def test_merging_list_and_dict_with_schema_error(self):
+        assert {'_schema': ['error1', 'error2'], 'field1': 'error3'} == \
+            utils.merge_errors(['error1'], {'_schema': 'error2',
+                                            'field1': 'error3'})
+
+    def test_merging_dict_and_string(self):
+        assert {'_schema': 'error2', 'field1': 'error1'} == \
+            utils.merge_errors({'field1': 'error1'}, 'error2')
+
+    def test_merging_dict_and_custom_error(self):
+        assert {'_schema': CustomError(123, 'error2'), 'field1': 'error1'} == \
+            utils.merge_errors({'field1': 'error1'}, CustomError(123, 'error2'))
+
+    def test_merging_dict_and_list(self):
+        assert {'_schema': ['error2'], 'field1': 'error1'} == \
+            utils.merge_errors({'field1': 'error1'}, ['error2'])
+
+    def test_merging_dict_and_dict(self):
+        assert {'field1': 'error1',
+                'field2': ['error2', 'error3'],
+                'field3': 'error4'} == \
+            utils.merge_errors({'field1': 'error1', 'field2': 'error2'},
+                               {'field2': 'error3', 'field3': 'error4'})
+
+    def test_deep_merging_dicts(self):
+        assert {'field1': {'field2': ['error1', 'error2']}} == \
+            utils.merge_errors({'field1': {'field2': 'error1'}},
+                               {'field1': {'field2': 'error2'}})


### PR DESCRIPTION
Improves validation error reporting functionality enabling reporting field errors from whole-schema (`validates_schema`) validator.

Introduces new public function marshmallow.utils.merge_errors which allows deep merging of errors. It can be useful to simplify accumulating errors in users' validators.

Updates validation error documentation to clarify error messages format.

Fixes #441 
