### PR TITLE
conda recipe for marshmallow

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: marshmallow
+  version: "2.7.2"
+
+source:
+  path: ../
+#  fn: marshmallow-2.7.2.tar.gz
+#  url: https://pypi.python.org/packages/1c/1d/51ed9afd232691eaace459004cc5a6b7f7e177c0a7f2c1275d6f76e59f19/marshmallow-2.7.2.tar.gz
+#  md5: 6b93167dba628314d66213cdf432af29
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - marshmallow = marshmallow:main
+    #
+    # Would create an entry point called marshmallow that calls marshmallow.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - marshmallow
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/marshmallow-code/marshmallow
+  license: MIT License
+  summary: 'A lightweight library for converting complex datatypes to and from native Python datatypes.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
With a conda recipe it will make it easier for Anaconda users to leverage marshmallow.
But otherwise this provides a conda recipe that can build a conda package.

This was created specifically to support webargs for which marshmallow is a dependency.
