### PR TITLE
Set child's parent before on_bind_field

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -692,8 +692,8 @@ class BaseSchema(base.SchemaABC):
                     field_obj.load_only = True
                 if field_name in self.dump_only:
                     field_obj.dump_only = True
-                self.on_bind_field(field_name, field_obj)
                 field_obj._add_to_schema(field_name, self)
+                self.on_bind_field(field_name, field_obj)
             except TypeError:
                 # field declared as a class, not an instance
                 if (isinstance(field_obj, type) and

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -303,6 +303,7 @@ def test_on_bind_field_hook():
         foo = fields.Str()
 
         def on_bind_field(self, field_name, field_obj):
+            assert field_obj.parent is self
             field_obj.metadata['fname'] = field_name
 
     schema = MySchema()


### PR DESCRIPTION
This PR ensures that `field_obj.parent` and `field_obj.name` are set before `on_bind_field` hook is invoked.

Got bitten by this when trying to access `nested.schema` inside `on_bind_field` of the parent which triggered an early instantiation of the schema with parent still unset which meant it did not inherit the parent context (as implemented in #408).
