### PR TITLE
Fix Length validator class inheritance

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -198,7 +198,7 @@ class Range(Validator):
         return value
 
 
-class Length(Range):
+class Length(Validator):
     """Validator which succeeds if the value passed to it has a
     length between a minimum and maximum. Uses len(), so it
     can work for strings, lists, or anything with length.
@@ -225,7 +225,9 @@ class Length(Range):
                 'minimum parameter must not be provided.'
             )
 
-        super(Length, self).__init__(min, max, error)
+        self.min = min
+        self.max = max
+        self.error = error
         self.equal = equal
 
     def _repr_args(self):


### PR DESCRIPTION
Fixes #455.

Extend the `Length` validator directly from `Validator` instead of from the `Range` validator.
#455 suggested using an instance of the `Range` validator in the `Length` class, but it would have broken backwards compatibility with the way the parameters for custom error messages currently behave. `"{input} {min} {max}"` currently evaluates to `"foo 1 9"`, but would be `"3 1 9"` if `Range` formatted the message.

> Note: The class interface did not change, but the inheritance tree changed from
> `Length → Range → Validator → object` to `Length → Validator → object`.
