### PR TITLE
Represent nested only and exclude options using dot delimiters

### DIFF
--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -82,6 +82,23 @@ You can explicitly specify which attributes of the nested objects you want to se
     #     'author': {'email': u'monty@python.org'}
     # }
 
+You can represent the attributes of deeply nested objects using dot delimiters.
+
+.. code-block:: python
+    :emphasize-lines: 5
+
+    class SiteSchema(Schema):
+        blog = fields.Nested(BlogSchema2)
+
+    schema = SiteSchema(only=['blog.author.email'])
+    result, errors = schema.dump(site)
+    pprint(result)
+    # {
+    #     'blog': {
+    #         'author': {'email': u'monty@python.org'}
+    #     }
+    # }
+
 .. note::
 
     If you pass in a string field name to ``only``, only a single value (or flat list of values if ``many=True``) will be returned.
@@ -103,7 +120,7 @@ You can explicitly specify which attributes of the nested objects you want to se
         # }
 
 
-You can also exclude fields by passing in an ``exclude`` list.
+You can also exclude fields by passing in an ``exclude`` list. This argument also allows representing the attributes of deeply nested objects using dot delimiters.
 
 .. _two-way-nesting:
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -237,9 +237,9 @@ class BaseSchema(base.SchemaABC):
 
     :param dict extra: A dict of extra attributes to bind to the serialized result.
     :param tuple only: A list or tuple of fields to serialize. If `None`, all
-        fields will be serialized.
+        fields will be serialized. Nested fields can be represented with dot delimiters.
     :param tuple exclude: A list or tuple of fields to exclude from the
-        serialized result.
+        serialized result. Nested fields can be represented with dot delimiters.
     :param str prefix: Optional prefix that will be prepended to all the
         serialized field names.
     :param bool strict: If `True`, raise errors if invalid data are passed in
@@ -306,6 +306,7 @@ class BaseSchema(base.SchemaABC):
             use this option, e.g., if your fields are Python keywords. May be an
             `OrderedDict`.
         - ``exclude``: Tuple or list of fields to exclude in the serialized result.
+            Nested fields can be represented with dot delimiters.
         - ``dateformat``: Date format for all DateTime fields that do not have their
             date format explicitly specified.
         - ``strict``: If `True`, raise errors during marshalling rather than

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -670,6 +670,157 @@ def test_error_raised_if_additional_option_is_not_list():
                 additional = 'email'
 
 
+def test_nested_only():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+    sch = ParentSchema(only=('bla', 'blubb.foo', 'blubb.bar'))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_nested_exclude():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+    sch = ParentSchema(exclude=('bli', 'blubb.baz'))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_nested_only_and_exclude():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+    sch = ParentSchema(only=('bla', 'blubb.foo', 'blubb.bar'), exclude=('blubb.foo',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_meta_nested_exclude():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+        class Meta:
+            exclude = ('blubb.foo',)
+    sch = ParentSchema()
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' in child
+    assert 'baz' in child
+
+
+def test_deeply_nested_only_and_exclude():
+    class GrandChildSchema(Schema):
+        goo = fields.Field()
+        gah = fields.Field()
+        bah = fields.Field()
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        flubb = fields.Nested(GrandChildSchema)
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema)
+    sch = ParentSchema(
+        only=('bla', 'blubb.foo', 'blubb.flubb.goo', 'blubb.flubb.gah'),
+        exclude=('blubb.flubb.goo',)
+    )
+    data = dict(bla=1, bli=2, blubb=dict(foo=3, bar=4, flubb=dict(goo=5, gah=6, bah=7)))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'flubb' in child
+    assert 'bar' not in child
+    grand_child = child['flubb']
+    assert 'gah' in grand_child
+    assert 'goo' not in grand_child
+    assert 'bah' not in grand_child
+
+
+def test_nested_constructor_only_and_exclude():
+    class GrandChildSchema(Schema):
+        goo = fields.Field()
+        gah = fields.Field()
+        bah = fields.Field()
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        flubb = fields.Nested(GrandChildSchema)
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(
+            ChildSchema,
+            only=('foo', 'flubb.goo', 'flubb.gah'),
+            exclude=('flubb.goo',)
+        )
+    sch = ParentSchema(only=('bla', 'blubb'))
+    data = dict(bla=1, bli=2, blubb=dict(foo=3, bar=4, flubb=dict(goo=5, gah=6, bah=7)))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'flubb' in child
+    assert 'bar' not in child
+    grand_child = child['flubb']
+    assert 'gah' in grand_child
+    assert 'goo' not in grand_child
+    assert 'bah' not in grand_child
+
+
 def test_only_and_exclude():
     class MySchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Redesigned implementation of #463 based on the [discussion in #405](https://github.com/marshmallow-code/marshmallow/pull/405#issuecomment-223774115).

This fixes #402 by applying nested `only` and `exclude` arguments to the `Nested` field instances during the `Schema` construction and normalizing the `only` and `exclude` attributes of the schema to the flat field names previously expected by `Schema.__filter_fields()` and `Marshaller.serialize()`.
