### PR TITLE
Deprecated getargspec

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -334,16 +334,26 @@ def callable_or_raise(obj):
     return obj
 
 
+def _signature(func):
+    if hasattr(inspect, 'signature'):
+        return list(inspect.signature(func).parameters.keys())
+    if hasattr(func, '__self__'):
+        # Remove bound arg to match inspect.signature()
+        return inspect.getargspec(func).args[1:]
+    # All args are unbound
+    return inspect.getargspec(func).args
+
+
 def get_func_args(func):
     """Given a callable, return a tuple of argument names. Handles
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return list(inspect.signature(func.func).parameters.keys())
+        return _signature(func.func)
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return list(inspect.signature(func).parameters.keys())
+        return _signature(func)
     # Callable class
-    return list(inspect.signature(func.__call__).parameters.keys())
+    return _signature(func.__call__)
 
 
 def if_none(value, default):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -339,11 +339,11 @@ def get_func_args(func):
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return inspect.getargspec(func.func).args
+        return inspect.signature(func.func).args
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return inspect.getargspec(func).args
+        return inspect.signature(func).args
     # Callable class
-    return inspect.getargspec(func.__call__).args
+    return inspect.signature(func.__call__).args
 
 
 def if_none(value, default):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -339,11 +339,11 @@ def get_func_args(func):
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return inspect.signature(func.func).args
+        return list(inspect.signature(func.func).parameters.keys())
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return inspect.signature(func).args
+        return list(inspect.signature(func).parameters.keys())
     # Callable class
-    return inspect.signature(func.__call__).args
+    return list(inspect.signature(func.__call__).parameters.keys())
 
 
 def if_none(value, default):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1550,6 +1550,22 @@ class TestContext:
         msg = 'No context available for Function field {0!r}'.format('is_collab')
         assert msg in str(excinfo)
 
+    def test_function_field_handles_bound_serializer(self):
+        class SerializeA(object):
+            def __call__(self, value):
+                return 'value'
+        serialize = SerializeA()
+        # only has a function field
+        class UserFunctionContextSchema(Schema):
+            is_collab = fields.Function(serialize)
+
+        owner = User('Joe')
+        serializer = UserFunctionContextSchema(strict=True)
+        # no context
+        serializer.context = None
+        data = serializer.dump(owner)[0]
+        assert data['is_collab'] is 'value'
+
     def test_fields_context(self):
         class CSchema(Schema):
             name = fields.String()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,7 +210,7 @@ def test_from_iso_date(use_dateutil):
     assert_date_equal(result, d)
 
 def test_get_func_args():
-    def f1(self, foo, bar):
+    def f1(foo, bar):
         pass
 
     f2 = partial(f1, 'baz')
@@ -221,4 +221,4 @@ def test_get_func_args():
     f3 = F3()
 
     for func in [f1, f2, f3]:
-        assert utils.get_func_args(func) == ['self', 'foo', 'bar']
+        assert utils.get_func_args(func) == ['foo', 'bar']


### PR DESCRIPTION
> DeprecationWarning is occurring in Python 3.5

https://github.com/marshmallow-code/marshmallow/pull/415#issue-140108078

> I'm thinking that the best solution might be to change the behavior of get_func_args to match the behavior of inspect.signature, i.e. omit self for bound methods.
> 
> This would happen in marshmallow 3.0, since it's a breaking change.

https://github.com/marshmallow-code/marshmallow/pull/415#issuecomment-222388642
- Ignore bound arguments returned from `inspect.getargspec()` to match the behavior of `inspect.signature()`.
- Add a test demonstrating how using `get_func_args()` with `inspect.getargspec()` was broken when the serializer had a bound argument.
