### PR TITLE
Deprecated getargspec

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Task execution
-invoke
+invoke==0.12.2
 
 # Soft dependencies
 python-dateutil

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Task execution
-invoke==0.12.2
+invoke>=0.13.0
 
 # Soft dependencies
 python-dateutil

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -334,16 +334,26 @@ def callable_or_raise(obj):
     return obj
 
 
+def _signature(func):
+    if hasattr(inspect, 'signature'):
+        return list(inspect.signature(func).parameters.keys())
+    if hasattr(func, '__self__'):
+        # Remove bound arg to match inspect.signature()
+        return inspect.getargspec(func).args[1:]
+    # All args are unbound
+    return inspect.getargspec(func).args
+
+
 def get_func_args(func):
     """Given a callable, return a tuple of argument names. Handles
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return list(inspect.signature(func.func).parameters.keys())
+        return _signature(func.func)
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return list(inspect.signature(func).parameters.keys())
+        return _signature(func)
     # Callable class
-    return list(inspect.signature(func.__call__).parameters.keys())
+    return _signature(func.__call__)
 
 
 def if_none(value, default):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -339,11 +339,11 @@ def get_func_args(func):
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return inspect.getargspec(func.func).args
+        return inspect.signature(func.func).args
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return inspect.getargspec(func).args
+        return inspect.signature(func).args
     # Callable class
-    return inspect.getargspec(func.__call__).args
+    return inspect.signature(func.__call__).args
 
 
 def if_none(value, default):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -339,11 +339,11 @@ def get_func_args(func):
     `functools.partial` objects and class-based callables.
     """
     if isinstance(func, functools.partial):
-        return inspect.signature(func.func).args
+        return list(inspect.signature(func.func).parameters.keys())
     if inspect.isfunction(func) or inspect.ismethod(func):
-        return inspect.signature(func).args
+        return list(inspect.signature(func).parameters.keys())
     # Callable class
-    return inspect.signature(func.__call__).args
+    return list(inspect.signature(func.__call__).parameters.keys())
 
 
 def if_none(value, default):

--- a/tasks.py
+++ b/tasks.py
@@ -9,13 +9,13 @@ docs_dir = 'docs'
 build_dir = os.path.join(docs_dir, '_build')
 
 @task
-def test(watch=False, last_failing=False):
+def test(ctx, watch=False, last_failing=False):
     """Run the tests.
 
     Note: --watch requires pytest-xdist to be installed.
     """
     import pytest
-    flake()
+    flake(ctx)
     args = []
     if watch:
         args.append('-f')
@@ -25,40 +25,40 @@ def test(watch=False, last_failing=False):
     sys.exit(retcode)
 
 @task
-def flake():
+def flake(ctx):
     """Run flake8 on codebase."""
     run('flake8 .', echo=True)
 
 @task
-def clean():
+def clean(ctx):
     run("rm -rf build")
     run("rm -rf dist")
     run("rm -rf marshmallow.egg-info")
-    clean_docs()
+    clean_docs(ctx)
     print("Cleaned up.")
 
 @task
-def clean_docs():
+def clean_docs(ctx):
     run("rm -rf %s" % build_dir)
 
 @task
-def browse_docs():
+def browse_docs(ctx):
     path = os.path.join(build_dir, 'index.html')
     webbrowser.open_new_tab(path)
 
 @task
-def docs(clean=False, browse=False, watch=False):
+def docs(ctx, clean=False, browse=False, watch=False):
     """Build the docs."""
     if clean:
-        clean_docs()
+        clean_docs(ctx)
     run("sphinx-build %s %s" % (docs_dir, build_dir), echo=True)
     if browse:
-        browse_docs()
+        browse_docs(ctx)
     if watch:
-        watch_docs()
+        watch_docs(ctx)
 
 @task
-def watch_docs():
+def watch_docs(ctx):
     """Run build the docs when a file changes."""
     try:
         import sphinx_autobuild  # noqa
@@ -71,15 +71,15 @@ def watch_docs():
         docs_dir, build_dir, 'marshmallow'), echo=True, pty=True)
 
 @task
-def readme(browse=False):
+def readme(ctx, browse=False):
     run("rst2html.py README.rst > README.html")
     if browse:
         webbrowser.open_new_tab('README.html')
 
 @task
-def publish(test=False):
+def publish(ctx, test=False):
     """Publish to the cheeseshop."""
-    clean()
+    clean(ctx)
     if test:
         run('python setup.py register -r test sdist bdist_wheel', echo=True)
         run('twine upload dist/* -r test', echo=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1527,6 +1527,22 @@ class TestContext:
         msg = 'No context available for Function field {0!r}'.format('is_collab')
         assert msg in str(excinfo)
 
+    def test_function_field_handles_bound_serializer(self):
+        class SerializeA(object):
+            def __call__(self, value):
+                return 'value'
+        serialize = SerializeA()
+        # only has a function field
+        class UserFunctionContextSchema(Schema):
+            is_collab = fields.Function(serialize)
+
+        owner = User('Joe')
+        serializer = UserFunctionContextSchema(strict=True)
+        # no context
+        serializer.context = None
+        data = serializer.dump(owner)[0]
+        assert data['is_collab'] is 'value'
+
     def test_fields_context(self):
         class CSchema(Schema):
             name = fields.String()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,7 +210,7 @@ def test_from_iso_date(use_dateutil):
     assert_date_equal(result, d)
 
 def test_get_func_args():
-    def f1(self, foo, bar):
+    def f1(foo, bar):
         pass
 
     f2 = partial(f1, 'baz')
@@ -221,4 +221,4 @@ def test_get_func_args():
     f3 = F3()
 
     for func in [f1, f2, f3]:
-        assert utils.get_func_args(func) == ['self', 'foo', 'bar']
+        assert utils.get_func_args(func) == ['foo', 'bar']


### PR DESCRIPTION
Replaces #415 and #478.
- Ignore bound arguments returned from `inspect.getargspec()` to match the behavior of `inspect.signature()`.
- Add a test demonstrating how using `get_func_args()` with `inspect.getargspec()` was broken when the serializer had a bound argument.
