### PR TITLE
Change the get_value util signature to match built-ins

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -277,7 +277,7 @@ However, if you want to specify how values are accessed from an object, you can 
 
         # If we know we're only serializing dictionaries, we can
         # use dict.get for all input objects
-        def get_attribute(self, key, obj, default):
+        def get_attribute(self, obj, key, default):
             return obj.get(key, default)
 
         class Meta:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -175,14 +175,14 @@ class Field(FieldABC):
                 'error_messages={self.error_messages})>'
                 .format(ClassName=self.__class__.__name__, self=self))
 
-    def get_value(self, attr, obj, accessor=None, default=missing_):
+    def get_value(self, obj, attr, accessor=None, default=missing_):
         """Return the value for a given key from an object."""
         # NOTE: Use getattr instead of direct attribute access here so that
         # subclasses aren't required to define `attribute` member
         attribute = getattr(self, 'attribute', None)
         accessor_func = accessor or utils.get_value
         check_key = attr if attribute is None else attribute
-        return accessor_func(check_key, obj, default)
+        return accessor_func(obj, check_key, default)
 
     def _validate(self, value):
         """Perform validation on ``value``. Raise a :exc:`ValidationError` if validation
@@ -238,7 +238,7 @@ class Field(FieldABC):
         :raise ValidationError: In case of formatting problem
         """
         if self._CHECK_ATTRIBUTE:
-            value = self.get_value(attr, obj, accessor=accessor)
+            value = self.get_value(obj, attr, accessor=accessor)
             if value is missing_:
                 if hasattr(self, 'default'):
                     if callable(self.default):
@@ -509,16 +509,16 @@ class List(Field):
                                            'marshmallow.base.FieldABC')
             self.container = cls_or_instance
 
-    def get_value(self, attr, obj, accessor=None):
+    def get_value(self, obj, attr, accessor=None):
         """Return the value for a given key from an object."""
-        value = super(List, self).get_value(attr, obj, accessor=accessor)
+        value = super(List, self).get_value(obj, attr, accessor=accessor)
         if self.container.attribute:
             if utils.is_collection(value):
                 return [
-                    self.container.get_value(self.container.attribute, each)
+                    self.container.get_value(each, self.container.attribute)
                     for each in value
                 ]
-            return self.container.get_value(self.container.attribute, value)
+            return self.container.get_value(value, self.container.attribute)
         return value
 
     def _add_to_schema(self, field_name, schema):

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -372,12 +372,12 @@ class BaseSchema(base.SchemaABC):
         """
         pass
 
-    def get_attribute(self, attr, obj, default):
+    def get_attribute(self, obj, attr, default):
         """Defines how to pull values from an object to serialize.
 
         .. versionadded:: 2.0.0
         """
-        return utils.get_value(attr, obj, default)
+        return utils.get_value(obj, attr, default)
 
     ##### Serialization/Deserialization API #####
 

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -298,23 +298,23 @@ def pluck(dictlist, key):
 
 # Various utilities for pulling keyed values from objects
 
-def get_value(key, obj, default=missing):
+def get_value(obj, key, default=missing):
     """Helper for pulling a keyed value off various types of objects"""
     if isinstance(key, int):
-        return _get_value_for_key(key, obj, default)
+        return _get_value_for_key(obj, key, default)
     else:
-        return _get_value_for_keys(key.split('.'), obj, default)
+        return _get_value_for_keys(obj, key.split('.'), default)
 
 
-def _get_value_for_keys(keys, obj, default):
+def _get_value_for_keys(obj, keys, default):
     if len(keys) == 1:
-        return _get_value_for_key(keys[0], obj, default)
+        return _get_value_for_key(obj, keys[0], default)
     else:
         return _get_value_for_keys(
-            keys[1:], _get_value_for_key(keys[0], obj, default), default)
+            _get_value_for_key(obj, keys[0], default), keys[1:], default)
 
 
-def _get_value_for_key(key, obj, default):
+def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, AttributeError, IndexError, TypeError):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1631,7 +1631,7 @@ class TestFieldInheritance:
             field_d = expected['field_d']
         assert SerializerD._declared_fields == expected
 
-def get_from_dict(schema, key, obj, default=None):
+def get_from_dict(schema, obj, key, default=None):
     return obj.get('_' + key, default)
 
 class TestGetAttribute:
@@ -1641,8 +1641,8 @@ class TestGetAttribute:
             name = fields.Str()
             email = fields.Email()
 
-            def get_attribute(self, attr, obj, default):
-                return get_from_dict(self, attr, obj, default)
+            def get_attribute(self, obj, attr, default):
+                return get_from_dict(self, obj, attr, default)
 
         user_dict = {'_name': 'joe', '_email': 'joe@shmoe.com'}
         schema = UserDictSchema()
@@ -1660,8 +1660,8 @@ class TestGetAttribute:
             name = fields.Str()
             email = fields.Email()
 
-            def get_attribute(self, attr, obj, default):
-                return get_from_dict(self, attr, obj, default)
+            def get_attribute(self, obj, attr, default):
+                return get_from_dict(self, obj, attr, default)
 
         user_dicts = [{'_name': 'joe', '_email': 'joe@shmoe.com'},
                       {'_name': 'jane', '_email': 'jane@shmane.com'}]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,17 +53,17 @@ class PointClass(object):
     {'x': 24, 'y': 42}
 ])
 def test_get_value(obj):
-    result = utils.get_value('x', obj)
+    result = utils.get_value(obj, 'x')
     assert result == 24
-    result2 = utils.get_value('y', obj)
+    result2 = utils.get_value(obj, 'y')
     assert result2 == 42
 
 def test_get_value_from_namedtuple_with_default():
     p = PointNT(x=42, y=None)
     # Default is only returned if key is not found
-    assert utils.get_value('z', p, default=123) == 123
+    assert utils.get_value(p, 'z', default=123) == 123
     # since 'y' is an attribute, None is returned instead of the default
-    assert utils.get_value('y', p, default=123) is None
+    assert utils.get_value(p, 'y', default=123) is None
 
 class Triangle(object):
     def __init__(self, p1, p2, p3):
@@ -74,24 +74,24 @@ class Triangle(object):
 
 def test_get_value_for_nested_object():
     tri = Triangle(p1=PointClass(1, 2), p2=PointNT(3, 4), p3={'x': 5, 'y': 6})
-    assert utils.get_value('p1.x', tri) == 1
-    assert utils.get_value('p2.x', tri) == 3
-    assert utils.get_value('p3.x', tri) == 5
+    assert utils.get_value(tri, 'p1.x') == 1
+    assert utils.get_value(tri, 'p2.x') == 3
+    assert utils.get_value(tri, 'p3.x') == 5
 
 # regression test for https://github.com/marshmallow-code/marshmallow/issues/62
 def test_get_value_from_dict():
     d = dict(items=['foo', 'bar'], keys=['baz', 'quux'])
-    assert utils.get_value('items', d) == ['foo', 'bar']
-    assert utils.get_value('keys', d) == ['baz', 'quux']
+    assert utils.get_value(d, 'items') == ['foo', 'bar']
+    assert utils.get_value(d, 'keys') == ['baz', 'quux']
 
 def test_get_value():
     l = [1,2,3]
-    assert utils.get_value(1, l) == 2
+    assert utils.get_value(l, 1) == 2
 
     class MyInt(int):
         pass
 
-    assert utils.get_value(MyInt(1), l) == 2
+    assert utils.get_value(l, MyInt(1)) == 2
 
 def test_is_keyed_tuple():
     Point = namedtuple('Point', ['x', 'y'])


### PR DESCRIPTION
Fixes #341 by changing the `get_value` utility's signature to match built-in python accessors.
