### PR TITLE
Remove get_from_dict from extending docs.

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -280,8 +280,6 @@ However, if you want to specify how values are accessed from an object, you can 
         def get_attribute(self, key, obj, default):
             return obj.get(key, default)
 
-        class Meta:
-            accessor = get_from_dict
 
 
 Custom "class Meta" Options


### PR DESCRIPTION
While experimenting with a custom way of accessing attributes I got trapped by the option `accessor` in the class `Meta`. It seems to me that this is not supported anymore.
