### PR TITLE
Fix _serialize() of Time field with microseconds

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -65,3 +65,4 @@ Contributors (chronological)
 - Mike Yumatov `@yumike <https://github.com/yumike>`_
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
 - Russell Davies `@russelldavies <https://github.com/russelldavies>`_
+- Vuong Hoang `@vuonghv <https://github.com/vuonghv>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -908,7 +908,7 @@ class Time(Field):
         except AttributeError:
             self.fail('format', input=value)
         if value.microsecond:
-            return ret[:12]
+            return ret[:15]
         return ret
 
     def _deserialize(self, value, attr, data):

--- a/tasks.py
+++ b/tasks.py
@@ -9,13 +9,13 @@ docs_dir = 'docs'
 build_dir = os.path.join(docs_dir, '_build')
 
 @task
-def test(watch=False, last_failing=False):
+def test(ctx, watch=False, last_failing=False):
     """Run the tests.
 
     Note: --watch requires pytest-xdist to be installed.
     """
     import pytest
-    flake()
+    flake(ctx)
     args = []
     if watch:
         args.append('-f')
@@ -25,40 +25,40 @@ def test(watch=False, last_failing=False):
     sys.exit(retcode)
 
 @task
-def flake():
+def flake(ctx):
     """Run flake8 on codebase."""
     run('flake8 .', echo=True)
 
 @task
-def clean():
+def clean(ctx):
     run("rm -rf build")
     run("rm -rf dist")
     run("rm -rf marshmallow.egg-info")
-    clean_docs()
+    clean_docs(ctx)
     print("Cleaned up.")
 
 @task
-def clean_docs():
+def clean_docs(ctx):
     run("rm -rf %s" % build_dir)
 
 @task
-def browse_docs():
+def browse_docs(ctx):
     path = os.path.join(build_dir, 'index.html')
     webbrowser.open_new_tab(path)
 
 @task
-def docs(clean=False, browse=False, watch=False):
+def docs(ctx, clean=False, browse=False, watch=False):
     """Build the docs."""
     if clean:
-        clean_docs()
+        clean_docs(ctx)
     run("sphinx-build %s %s" % (docs_dir, build_dir), echo=True)
     if browse:
-        browse_docs()
+        browse_docs(ctx)
     if watch:
-        watch_docs()
+        watch_docs(ctx)
 
 @task
-def watch_docs():
+def watch_docs(ctx):
     """Run build the docs when a file changes."""
     try:
         import sphinx_autobuild  # noqa
@@ -71,15 +71,15 @@ def watch_docs():
         docs_dir, build_dir, 'marshmallow'), echo=True, pty=True)
 
 @task
-def readme(browse=False):
+def readme(ctx, browse=False):
     run("rst2html.py README.rst > README.html")
     if browse:
         webbrowser.open_new_tab('README.html')
 
 @task
-def publish(test=False):
+def publish(ctx, test=False):
     """Publish to the cheeseshop."""
-    clean()
+    clean(ctx)
     if test:
         run('python setup.py register -r test sdist bdist_wheel', echo=True)
         run('twine upload dist/* -r test', echo=True)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -579,7 +579,7 @@ def test_can_serialize_uuid(serialized_user, user):
     assert serialized_user.data['uid'] == str(user.uid)
 
 def test_can_serialize_time(user, serialized_user):
-    expected = user.time_registered.isoformat()[:12]
+    expected = user.time_registered.isoformat()[:15]
     assert serialized_user.data['time_registered'] == expected
 
 def test_invalid_time():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -454,7 +454,7 @@ class TestFieldSerialization:
 
     def test_time_field(self, user):
         field = fields.Time()
-        expected = user.time_registered.isoformat()[:12]
+        expected = user.time_registered.isoformat()[:15]
         assert field.serialize('time_registered', user) == expected
 
         user.time_registered = None


### PR DESCRIPTION
When a Time object has microsecond value, the _serialize() method
returns the following string format: 'HH:mm:ss.SSSSSS'

Issue #464
