### PR TITLE
Fix the inconsistency of validates decorator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,3 +66,4 @@ Contributors (chronological)
 - Tim Mundt `@Tim-Erwin <https://github.com/Tim-Erwin>`_
 - Russell Davies `@russelldavies <https://github.com/russelldavies>`_
 - David Thornton `@davidthornton <https://github.com/davidthornton>`_
+- Vuong Hoang `@vuonghv <https://github.com/vuonghv>`_

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -20,6 +20,7 @@ from marshmallow.exceptions import ValidationError
 from marshmallow.orderedset import OrderedSet
 from marshmallow.decorators import (PRE_DUMP, POST_DUMP, PRE_LOAD, POST_LOAD,
                                     VALIDATES, VALIDATES_SCHEMA)
+from marshmallow.utils import missing
 
 
 #: Return type of :meth:`Schema.dump` including serialized data and errors
@@ -822,25 +823,29 @@ class BaseSchema(base.SchemaABC):
                     except KeyError:
                         pass
                     else:
-                        self._unmarshal.call_and_store(
+                        validated_value = self._unmarshal.call_and_store(
                             getter_func=validator,
                             data=value,
                             field_name=field_name,
                             field_obj=field_obj,
                             index=(idx if self.opts.index_errors else None)
                         )
+                        if validated_value is missing:
+                            data[idx].pop(field_name, None)
             else:
                 try:
                     value = data[field_obj.attribute or field_name]
                 except KeyError:
                     pass
                 else:
-                    self._unmarshal.call_and_store(
+                    validated_value = self._unmarshal.call_and_store(
                         getter_func=validator,
                         data=value,
                         field_name=field_name,
                         field_obj=field_obj
                     )
+                    if validated_value is missing:
+                        data.pop(field_name, None)
 
     def _invoke_validators(self, pass_many, data, original_data, many, field_errors=False):
         errors = {}

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -285,6 +285,18 @@ class TestValidatesDecorator:
         errors = schema.validate({})
         assert errors == {}
 
+        result, errors = schema.load({'foo': 41})
+        assert errors
+        assert result == {}
+
+        result, errors = schema.load([{'foo': 42}, {'foo': 43}], many=True)
+        assert len(result) == 2
+        assert result[0] == {'foo': 42}
+        assert result[1] == {}
+        assert 1 in errors
+        assert 'foo' in errors[1]
+        assert errors[1]['foo'] == ['The answer to life the universe and everything.']
+
     def test_field_not_present(self):
         class BadSchema(ValidatesSchema):
             @validates('bar')


### PR DESCRIPTION
Make the result of field validators as methods (through validates decorator) consistent with validations via validate callable (e.g function, lambda, or object with `__call__` defined).

Issue #391 
