### PR TITLE
Fixed error in Specifying Serialization Keys quickstart example.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -407,7 +407,7 @@ If you want to marshal a field to a different key than the field name you can us
 
     data = {
         'name': 'Mike',
-        'CamelCasedEmail': 'foo@bar.com'
+        'email': 'foo@bar.com'
     }
     s = UserSchema()
     result, errors = s.dump(data)


### PR DESCRIPTION
**The issue**
UserSchema has field **email**, but the data object has **CamelCasedEmail**.  The dump method will not find the email field in the data object and will only dump the name field. 

**The fix**
Renamed **CamelCasedEmail** to **email** in the data object
