### PR TITLE
Fix raw False value validation

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -15,6 +15,7 @@ from marshmallow.base import FieldABC, SchemaABC
 from marshmallow.utils import missing as missing_
 from marshmallow.compat import text_type, basestring
 from marshmallow.exceptions import ValidationError
+from marshmallow.validate import Validator
 
 __all__ = [
     'Field',
@@ -192,7 +193,8 @@ class Field(FieldABC):
         kwargs = {}
         for validator in self.validators:
             try:
-                if validator(value) is False:
+                r = validator(value)
+                if not isinstance(validator, Validator) and r is False:
                     self.fail('validator_failed')
             except ValidationError as err:
                 kwargs.update(err.kwargs)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -8,6 +8,7 @@ import pytest
 from marshmallow import fields, utils, Schema, validate
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import basestring
+from marshmallow.validate import Equal
 
 from tests.base import (
     assert_almost_equal,
@@ -1218,6 +1219,19 @@ class TestValidation:
         data, errors = sch.load({'w': 90, 'n': {'x': 90, 'y': -1, 'z': 180}})
         assert 'y' in errors['n']
         assert data == {'w': 90, 'n': {'x': 90, 'z': 180}}
+
+    def test_false_value_validation(self):
+        class Sch(Schema):
+            lamb = fields.Raw(validate=lambda x: x is False)
+            equal = fields.Raw(validate=Equal(False))
+
+        errors = Sch().validate({'lamb': False, 'equal': False})
+        assert not errors
+        errors = Sch().validate({'lamb': True, 'equal': True})
+        assert 'lamb' in errors
+        assert errors['lamb'] == ['Invalid value.']
+        assert 'equal' in errors
+        assert errors['equal'] == ['Must be equal to False.']
 
 
 FIELDS_TO_TEST = [f for f in ALL_FIELDS if f not in [fields.FormattedString]]


### PR DESCRIPTION
Fixes #484.

Validator's return value is now evaluated only when using "ad-hoc" callable
(lambda, function or method). With `Validator` instances, return value has no
meaning (instead, `ValidationError` are thrown) so set to ignore it when using
`Validator` sub-classes.

Would you like if-else block instead of using a temporary `r` variable?

Not sure if tests are in correct place?
