### PR TITLE
Fix UUID fields not validating on serialize

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -71,3 +71,4 @@ Contributors (chronological)
 - Alexandre Bonnetain `@Shir0kamii <https://github.com/Shir0kamii>`_
 - Tuukka Mustonen `@tuukkamustonen <https://github.com/tuukkamustonen>`_
 - Tero Vuotila `@tvuotila <https://github.com/tvuotila>`_
+- Paul Zumbrun `@pauljz <https://github.com/pauljz>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -583,11 +583,23 @@ class UUID(String):
         'invalid_guid': 'Not a valid UUID.'  # TODO: Remove this in marshmallow 3.0
     }
 
-    def _deserialize(self, value, attr, data):
+    def _validated(self, value):
+        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return value
         try:
             return uuid.UUID(value)
         except (ValueError, AttributeError):
             self.fail('invalid_uuid')
+
+    def _serialize(self, value, attr, obj):
+        validated = str(self._validated(value)) if value is not None else None
+        return super(String, self)._serialize(validated, attr, obj)
+
+    def _deserialize(self, value, attr, data):
+        return self._validated(value)
 
 
 class Number(Field):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import datetime as dt
 import itertools
 import decimal
+import uuid
 
 import pytest
 
@@ -104,6 +105,27 @@ class TestFieldSerialization:
     def test_callable_field(self, user):
        field = fields.String()
        assert field.serialize('call_me', user) == 'This was called.'
+
+    def test_uuid_field(self, user):
+        user.uuid1 = '{12345678-1234-5678-1234-567812345678}'
+        user.uuid2 = uuid.UUID('12345678123456781234567812345678')
+        user.uuid3 = None
+        user.uuid4 = 'this is not a UUID'
+        user.uuid5 = 42
+        user.uuid6 = {}
+
+        field = fields.UUID()
+        assert isinstance(field.serialize('uuid1', user), str)
+        assert field.serialize('uuid1', user) == '12345678-1234-5678-1234-567812345678'
+        assert isinstance(field.serialize('uuid2', user), str)
+        assert field.serialize('uuid2', user) == '12345678-1234-5678-1234-567812345678'
+        assert field.serialize('uuid3', user) is None
+        with pytest.raises(ValidationError):
+            field.serialize('uuid4', user)
+        with pytest.raises(ValidationError):
+            field.serialize('uuid5', user)
+        with pytest.raises(ValidationError):
+            field.serialize('uuid6', user)
 
     def test_decimal_field(self, user):
         user.m1 = 12


### PR DESCRIPTION
UUIDs are currently only validated on deserialization/load. This validates them on serialize/dump as well. This is technically a breaking change, but the current behavior is probably undesirable in any case where it's being used.
