### PR TITLE
Update Decimal field serialization to use fixed-point notation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -71,3 +71,4 @@ Contributors (chronological)
 - Alexandre Bonnetain `@Shir0kamii <https://github.com/Shir0kamii>`_
 - Tuukka Mustonen `@tuukkamustonen <https://github.com/tuukkamustonen>`_
 - Tero Vuotila `@tvuotila <https://github.com/tvuotila>`_
+- Gary Wilson Jr. `@gdub <https://github.com/gdub>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -626,7 +626,10 @@ class Number(Field):
         as `Field`.
         """
         ret = Field.serialize(self, attr, obj, accessor=accessor)
-        return str(ret) if (self.as_string and ret is not None) else ret
+        return self._to_string(ret) if (self.as_string and ret is not None) else ret
+
+    def _to_string(self, value):
+        return str(value)
 
     def _serialize(self, value, attr, obj):
         return self._validated(value)
@@ -721,6 +724,10 @@ class Decimal(Number):
             return super(Decimal, self)._validated(value)
         except decimal.InvalidOperation:
             self.fail('invalid')
+
+    # override Number
+    def _to_string(self, value):
+        return format(value, 'f')
 
 
 class Boolean(Field):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -238,6 +238,20 @@ class TestFieldSerialization:
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero() and m7s.is_signed()
 
+        field = fields.Decimal(as_string=True, allow_nan=True)
+
+        m2s = field.serialize('m2', user)
+        assert isinstance(m2s, basestring)
+        assert m2s == user.m2
+
+        m5s = field.serialize('m5', user)
+        assert isinstance(m5s, basestring)
+        assert m5s == user.m5
+
+        m6s = field.serialize('m6', user)
+        assert isinstance(m6s, basestring)
+        assert m6s == user.m6
+
     def test_decimal_field_special_values_not_permitted(self, user):
         user.m1 = '-NaN'
         user.m2 = 'NaN'
@@ -265,6 +279,25 @@ class TestFieldSerialization:
         m7s = field.serialize('m7', user)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero() and m7s.is_signed()
+
+    def test_decimal_field_fixed_point_representation(self, user):
+        """
+        Test we get fixed-point string representation for a Decimal number that would normally
+        output in engineering notation.
+        """
+        user.m1 = '0.00000000100000000'
+
+        field = fields.Decimal()
+        assert isinstance(field.serialize('m1', user), decimal.Decimal)
+        assert field.serialize('m1', user) == decimal.Decimal('1.00000000E-9')
+
+        field = fields.Decimal(as_string=True)
+        assert isinstance(field.serialize('m1', user), basestring)
+        assert field.serialize('m1', user) == user.m1
+
+        field = fields.Decimal(as_string=True, places=2)
+        assert isinstance(field.serialize('m1', user), basestring)
+        assert field.serialize('m1', user) == '0.00'
 
     def test_boolean_field_serialization(self, user):
         field = fields.Boolean()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -288,16 +288,19 @@ class TestFieldSerialization:
         user.m1 = '0.00000000100000000'
 
         field = fields.Decimal()
-        assert isinstance(field.serialize('m1', user), decimal.Decimal)
-        assert field.serialize('m1', user) == decimal.Decimal('1.00000000E-9')
+        s = field.serialize('m1', user)
+        assert isinstance(s, decimal.Decimal)
+        assert s == decimal.Decimal('1.00000000E-9')
 
         field = fields.Decimal(as_string=True)
-        assert isinstance(field.serialize('m1', user), basestring)
-        assert field.serialize('m1', user) == user.m1
+        s = field.serialize('m1', user)
+        assert isinstance(s, basestring)
+        assert s == user.m1
 
         field = fields.Decimal(as_string=True, places=2)
-        assert isinstance(field.serialize('m1', user), basestring)
-        assert field.serialize('m1', user) == '0.00'
+        s = field.serialize('m1', user)
+        assert isinstance(s, basestring)
+        assert s == '0.00'
 
     def test_boolean_field_serialization(self, user):
         field = fields.Boolean()


### PR DESCRIPTION
This avoids engineering-notation output, which occurs with default Decimal type string formatting in certain situations.

While Python does not have an issue round-tripping the engineering-notation strings, I imagine the fixed-point notation [[1]](https://docs.python.org/3/library/string.html#formatspec) more compatible with other languages/parsers.  FWIW, Django REST framework also uses fixed-point notation string output for Decimals [[2]](https://github.com/tomchristie/django-rest-framework/blob/3.4.7/rest_framework/fields.py#L1018).

Old behavior:

```
>>> fields.Decimal(as_string=True).serialize('x', {'x': Decimal('0.0000000')})
'0E-7'
```

New behavior:

```
>>> fields.Decimal(as_string=True).serialize('x', {'x': Decimal('0.0000000')})
'0.0000000'
```
