### PR TITLE
Missing partial attribute in docstring

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -596,6 +596,9 @@ class BaseSchema(base.SchemaABC):
         :param dict data: The data to validate.
         :param bool many: Whether to validate `data` as a collection. If `None`, the
             value for `self.many` is used.
+        :param bool|tuple partial: Whether to ignore missing fields. If `None`,
+            the value for `self.partial` is used. If its value is an iterable,
+            only missing fields listed in that iterable will be ignored.
         :return: A dictionary of validation errors.
         :rtype: dict
 


### PR DESCRIPTION
There's an attribute `partial` in `Schema.validate()`, but it's not present in documentation.
To fix this, I put there the same description from `Schema.load()`.
