### PR TITLE
Fixes missing import in validates example

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -245,7 +245,7 @@ It is often convenient to write validators as methods. Use the `validates <marsh
 
 .. code-block:: python
 
-    from marshmallow import fields, Schema, validates
+    from marshmallow import fields, Schema, validates, ValidationError
 
     class ItemSchema(Schema):
         quantity = fields.Integer()


### PR DESCRIPTION
Current example would break on validation

```
>>> item_schema = ItemSchema()
>>> item_schema.load({'quantity': 35})  # raises "NameError: name 'ValidationError' is not defined"
```
