### PR TITLE
Bugfix Issue 540 type annotations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,3 +73,4 @@ Contributors (chronological)
 - Tero Vuotila `@tvuotila <https://github.com/tvuotila>`_
 - Paul Zumbrun `@pauljz <https://github.com/pauljz>`_
 - Gary Wilson Jr. `@gdub <https://github.com/gdub>`_
+- Sabine Maennel `@sabinem <https://github.com/sabinem>`_

--- a/marshmallow/compat.py
+++ b/marshmallow/compat.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 import itertools
+import functools
+import inspect
 
 PY2 = int(sys.version_info[0]) == 2
 PY26 = PY2 and int(sys.version_info[1]) < 7
@@ -22,6 +24,13 @@ if PY2:
     else:
         from collections import OrderedDict
     OrderedDict = OrderedDict
+    def get_func_args(func):
+        if isinstance(func, functools.partial):
+            return list(inspect.getargspec(func.func).args)
+        if inspect.isfunction(func) or inspect.ismethod(func):
+            return list(inspect.getargspec(func).args)
+        if callable(func):
+            return list(inspect.getargspec(func.__call__).args)
 else:
     import urllib.parse
     urlparse = urllib.parse
@@ -36,6 +45,13 @@ else:
     zip_longest = itertools.zip_longest
     from collections import OrderedDict
     OrderedDict = OrderedDict
+    def get_func_args(func):
+        if isinstance(func, functools.partial):
+            return list(inspect.signature(func.func).parameters)
+        if inspect.isfunction(func):
+            return list(inspect.signature(func).parameters)
+        if callable(func) or inspect.ismethod(func):
+            return ['self'] + list(inspect.signature(func.__call__).parameters)
 
 
 # From six

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, unicode_literals
 
 import collections
 import datetime
-import functools
 import inspect
 import json
 import time
@@ -15,6 +14,7 @@ from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
 from marshmallow.compat import OrderedDict, binary_type, text_type
+from marshmallow.compat import get_func_args as compat_get_func_args
 
 
 dateutil_available = False
@@ -334,16 +334,10 @@ def callable_or_raise(obj):
     return obj
 
 
-def get_func_args(func):
-    """Given a callable, return a tuple of argument names. Handles
-    `functools.partial` objects and class-based callables.
-    """
-    if isinstance(func, functools.partial):
-        return inspect.getargspec(func.func).args
-    if inspect.isfunction(func) or inspect.ismethod(func):
-        return inspect.getargspec(func).args
-    # Callable class
-    return inspect.getargspec(func.__call__).args
+get_func_args = compat_get_func_args
+"""Given a callable, return a list of argument names.
+Handles `functools.partial` objects and callable objects.
+"""
 
 
 def if_none(value, default):

--- a/tasks.py
+++ b/tasks.py
@@ -21,6 +21,8 @@ def test(ctx, watch=False, last_failing=False):
         args.append('-f')
     if last_failing:
         args.append('--lf')
+    if int(sys.version_info[0]) < 3:
+        args.append('--ignore={0}'.format(os.path.join('tests', 'test_py3')))
     retcode = pytest.main(args)
     sys.exit(retcode)
 

--- a/tests/test_py3/test_utils.py
+++ b/tests/test_py3/test_utils.py
@@ -1,0 +1,14 @@
+from marshmallow import fields, Schema
+
+
+# Regression test for https://github.com/marshmallow-code/marshmallow/issues/540
+def test_function_field_using_type_annotation():
+    def get_split_words(value: str):
+        return value.split(';')
+
+    class MySchema(Schema):
+        friends = fields.Function(deserialize=get_split_words)
+
+    data = {'name': 'Bruce Wayne', 'friends': 'Clark;Alfred;Robin'}
+    result = MySchema().load(data)
+    assert result.data == {'friends': ['Clark', 'Alfred', 'Robin']}


### PR DESCRIPTION
[Fix for Issue 540](https://github.com/marshmallow-code/marshmallow/issues/540)

**Problem**
In Python 3 function parameters can have type annotations. Adding
annotations to a deserialization function used in schema caused a crash
on a utility function: `utils.get_func_args`. 

**Fix**
Since the inspect modul changed a lot from Python 2 to Python 3, I implemented a branching in
compat and a new version of the utility function for python 3. 
Both of these functions return now the arguments as tuples, the old function returned a list, but the new `inspect.signature` in Python3 returns a Ordered Dict, therefore I settled for a tuple as was stated in the docstring of the original function. 

**Open Points**
1. I tried to branch from `1.2-line`, but run into an error, like this here: [#475](https://github.com/marshmallow-code/marshmallow/pull/475), when I tried to set up my development environment, therefor I branched from `dev`instead.
2. I did not know how to set up a test case, since the test case with annotations is not valid python2 code and the python2 syntax check crashes on it.

**Feedback?**
This is my first meaningful open source bug fix. So please excuse, if I did something wrong and tell me how to improve.