### PR TITLE
Automatically import `fields` module.

### DIFF
--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -7,6 +7,7 @@ from marshmallow.schema import (
     MarshalResult,
     UnmarshalResult,
 )
+from . import fields
 from marshmallow.decorators import (
     pre_dump, post_dump, pre_load, post_load, validates, validates_schema
 )
@@ -19,6 +20,7 @@ __author__ = 'Steven Loria'
 __all__ = [
     'Schema',
     'SchemaOpts',
+    'fields',
     'validates',
     'validates_schema',
     'pre_dump',


### PR DESCRIPTION
`marshmallow/__init__.py` should do `from . import fields`. This would save some lines for the users. Any schema needs fields, there is no reason to not import the module automatically.

This would help in such case:
```
import marshmallow as mm

class UpgradeNowSchema(mm.Schema):
    plan = mm.fields.String(required=True)
```

Otherwise I need to:
```
import marshmallow as mm
import marshmallow.fields
```
which looks strange and ugly.

I would be even better to have fields in the main namespace:
```
plan = marshmallow.String(required=True)
```
then I would avoid shortening `marshmallow` -> `mm` or `ma`.