### PR TITLE
Better example of check_unknown_fields validator

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -262,7 +262,7 @@ Validating Original Input Data
 Normally, unspecified field names are ignored by the validator. If you would like access to the original, raw input (e.g. to fail validation if an unknown field name is sent), add ``pass_original=True`` to your call to `validates_schema <marshmallow.decorators.validates_schema>`.
 
 .. code-block:: python
-    :emphasize-lines: 5
+    :emphasize-lines: 7
 
     from marshmallow import Schema, fields, validates_schema, ValidationError
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -264,6 +264,8 @@ Normally, unspecified field names are ignored by the validator. If you would lik
 .. code-block:: python
     :emphasize-lines: 5
 
+    from marshmallow import Schema, fields, validates_schema, ValidationError
+
     class MySchema(Schema):
         foo = fields.Int()
         bar = fields.Int()
@@ -272,7 +274,7 @@ Normally, unspecified field names are ignored by the validator. If you would lik
         def check_unknown_fields(self, data, original_data):
             unknown = set(original_data) - set(self.fields)
             if unknown:
-                raise marshmallow.ValidationError('Unknown field', unknown)
+                raise ValidationError('Unknown field', unknown)
 
     schema = MySchema()
     errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4}).errors

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -275,8 +275,8 @@ Normally, unspecified field names are ignored by the validator. If you would lik
                 raise marshmallow.ValidationError('Unknown field', unknown)
 
     schema = MySchema()
-    result, errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4})
-    errors['_schema']  # => ["Unknown field 'baz'", "Unknown field 'bu'"]
+    errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4}).errors
+    # {'baz': 'Unknown field', 'bu': 'Unknown field'}
 
 
 Storing Errors on Specific Fields

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -270,13 +270,14 @@ Normally, unspecified field names are ignored by the validator. If you would lik
 
         @validates_schema(pass_original=True)
         def check_unknown_fields(self, data, original_data):
-            for key in original_data:
-                if key not in self.fields:
-                    raise ValidationError('Unknown field name {}'.format(key))
+            unknown = set(original_data) - set(self.fields)
+            if unknown:
+                errors = list(map("Unknown field '{}'".format, unknown))
+                raise marshmallow.ValidationError(errors)
 
     schema = MySchema()
-    result, errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3})
-    errors['_schema']  # => ['Unknown field name baz']
+    result, errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4})
+    errors['_schema']  # => ["Unknown field 'baz'", "Unknown field 'bu'"]
 
 
 Storing Errors on Specific Fields

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -272,8 +272,7 @@ Normally, unspecified field names are ignored by the validator. If you would lik
         def check_unknown_fields(self, data, original_data):
             unknown = set(original_data) - set(self.fields)
             if unknown:
-                errors = list(map("Unknown field '{}'".format, unknown))
-                raise marshmallow.ValidationError(errors)
+                raise marshmallow.ValidationError('Unknown field', unknown)
 
     schema = MySchema()
     result, errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4})


### PR DESCRIPTION
Include all unknown fields in the error message.  The current example
reports at most one, even if more are present.  Fixes #558