### PR TITLE
Fix redefinition of test_utils.test_get_value()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,7 @@ class PointClass(object):
     PointClass(24, 42),
     {'x': 24, 'y': 42}
 ])
-def test_get_value(obj):
+def test_get_value_from_object(obj):
     result = utils.get_value('x', obj)
     assert result == 24
     result2 = utils.get_value('y', obj)
@@ -85,7 +85,7 @@ def test_get_value_from_dict():
     assert utils.get_value('keys', d) == ['baz', 'quux']
 
 def test_get_value():
-    l = [1,2,3]
+    l = [1, 2, 3]
     assert utils.get_value(1, l) == 2
 
     class MyInt(int):


### PR DESCRIPTION
This redefinition was preventing py.test from collecting and executing
three test cases of `utils.get_value`