### PR TITLE
Reset user-defined error kwargs on schema dump/load

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,3 +74,4 @@ Contributors (chronological)
 - Paul Zumbrun `@pauljz <https://github.com/pauljz>`_
 - Gary Wilson Jr. `@gdub <https://github.com/gdub>`_
 - Sabine Maennel `@sabinem <https://github.com/sabinem>`_
+- Victor Varvaryuk `@mindojo-victor <https://github.com/mindojo-victor>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Features:
 
 - Import ``marshmallow.fields`` in ``marshmallow/__init__.py`` to save an import when importing the ``marshmallow`` module (:issue:`557`). Thanks :user:`mindojo-victor`.
 
+Support:
+
+- Documentation: Improve example in "Validating Original Input Data" (:issue:`558`). Thanks :user:`altaurog`.
+- Tests: Fix redefinition of ``test_utils.test_get_value()`` (:issue:`562`). Thanks :user:`nelfin`.
+
 2.10.4 (2016-11-18)
 +++++++++++++++++++
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+2.11.0 (unreleased)
+++++++++++++++++++
+
+Features:
+
+- Import ``marshmallow.fields`` in ``marshmallow/__init__.py`` to save an import when importing the ``marshmallow`` module (:issue:`557`). Thanks :user:`mindojo-victor`.
+
 2.10.4 (2016-11-18)
 +++++++++++++++++++
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -262,7 +262,9 @@ Validating Original Input Data
 Normally, unspecified field names are ignored by the validator. If you would like access to the original, raw input (e.g. to fail validation if an unknown field name is sent), add ``pass_original=True`` to your call to `validates_schema <marshmallow.decorators.validates_schema>`.
 
 .. code-block:: python
-    :emphasize-lines: 5
+    :emphasize-lines: 7
+
+    from marshmallow import Schema, fields, validates_schema, ValidationError
 
     class MySchema(Schema):
         foo = fields.Int()
@@ -270,13 +272,13 @@ Normally, unspecified field names are ignored by the validator. If you would lik
 
         @validates_schema(pass_original=True)
         def check_unknown_fields(self, data, original_data):
-            for key in original_data:
-                if key not in self.fields:
-                    raise ValidationError('Unknown field name {}'.format(key))
+            unknown = set(original_data) - set(self.fields)
+            if unknown:
+                raise ValidationError('Unknown field', unknown)
 
     schema = MySchema()
-    result, errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3})
-    errors['_schema']  # => ['Unknown field name baz']
+    errors = schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4}).errors
+    # {'baz': 'Unknown field', 'bu': 'Unknown field'}
 
 
 Storing Errors on Specific Fields

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -14,7 +14,7 @@ from marshmallow.decorators import (
 from marshmallow.utils import pprint, missing
 from marshmallow.exceptions import ValidationError
 
-__version__ = '2.10.4'
+__version__ = '2.11.0.dev0'
 __author__ = 'Steven Loria'
 
 __all__ = [

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -7,6 +7,7 @@ from marshmallow.schema import (
     MarshalResult,
     UnmarshalResult,
 )
+from . import fields
 from marshmallow.decorators import (
     pre_dump, post_dump, pre_load, post_load, validates, validates_schema
 )
@@ -19,6 +20,7 @@ __author__ = 'Steven Loria'
 __all__ = [
     'Schema',
     'SchemaOpts',
+    'fields',
     'validates',
     'validates_schema',
     'pre_dump',

--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -24,7 +24,7 @@ Example: ::
             namespace = 'results' if many else 'result'
             return data[namespace]
 
-        @post_dump(pass_many=True):
+        @post_dump(pass_many=True)
         def add_envelope(self, data, many):
             namespace = 'results' if many else 'result'
             return {namespace: data}

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -42,6 +42,7 @@ class ErrorStore(object):
         self.errors = {}
         self.error_field_names = []
         self.error_fields = []
+        self.error_kwargs = {}
 
     def get_errors(self, index=None):
         if index is not None:


### PR DESCRIPTION
Fixes issue when user-defined kwargs on ValidationError aren't reset and kwargs for each new ValidationError are a merge of all previous kwargs.