### PR TITLE
Make a series of small optmizations for dumping objects

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -393,15 +393,15 @@ class Nested(Field):
         .. versionchanged:: 1.0.0
             Renamed from `serializer` to `schema`
         """
-        # Ensure that only parameter is a tuple
-        if isinstance(self.only, basestring):
-            only = (self.only, )
-        else:
-            only = self.only
-
-        # Inherit context from parent.
-        context = getattr(self.parent, 'context', {})
         if not self.__schema:
+            # Ensure that only parameter is a tuple
+            if isinstance(self.only, basestring):
+                only = (self.only,)
+            else:
+                only = self.only
+
+            # Inherit context from parent.
+            context = getattr(self.parent, 'context', {})
             if isinstance(self.nested, SchemaABC):
                 self.__schema = self.nested
                 self.__schema.context.update(context)
@@ -421,7 +421,7 @@ class Nested(Field):
             else:
                 raise ValueError('Nested fields must be passed a '
                                  'Schema, not {0}.'.format(self.nested.__class__))
-        self.__schema.ordered = getattr(self.parent, 'ordered', False)
+            self.__schema.ordered = getattr(self.parent, 'ordered', False)
         return self.__schema
 
     def _serialize(self, nested_obj, attr, obj):


### PR DESCRIPTION
These optimizations are fairly small, a 5-10% win on the benchmark, but when
jitting serializers in https://github.com/marshmallow-code/marshmallow/pull/573
these changes wind up being a fairly big when the serializer is compiled.