### PR TITLE
Fix Nested field root method

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -325,7 +325,7 @@ class Field(FieldABC):
         ret = self
         while hasattr(ret, 'parent') and ret.parent:
             ret = ret.parent
-        return ret
+        return ret if isinstance(ret, SchemaABC) else None
 
 class Raw(Field):
     """Field that applies no formatting or validation."""


### PR DESCRIPTION
Makes `root` method in Nested field not return itself but `None` if the `ret` field isn't a schema

This is a fix for the issue being reported here: https://github.com/marshmallow-code/marshmallow/pull/572#issuecomment-275800288