### PR TITLE
Add `strict` parameter for fields.Method

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1187,7 +1187,7 @@ class Method(Field):
     _CHECK_ATTRIBUTE = False
 
     def __init__(self, serialize=None, deserialize=None, method_name=None,
-                 strict=True, **kwargs):
+                 strict=False, **kwargs):
         if method_name is not None:
             warnings.warn('"method_name" argument of fields.Method is deprecated. '
                           'Use the "serialize" argument instead.', DeprecationWarning)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -585,6 +585,21 @@ class TestFieldDeserialization:
 
         assert m.deserialize('ALEC') == 'alec'
 
+    def test_method_field_deserialization_with_strict_param(self):
+        class Serializer(Schema):
+            m = fields.Method(deserialize='foo')
+            def foo(self, value):
+                raise AttributeError()
+        result, _ = Serializer().load({'m': 0})
+        assert result == {'m': 0}
+
+        class Serializer(Schema):
+            m = fields.Method(deserialize='foo', strict=True)
+            def foo(self, value):
+                raise AttributeError()
+        with pytest.raises(AttributeError):
+            Serializer().load({'m': 0})
+
     def test_datetime_list_field_deserialization(self):
         dtimes = dt.datetime.now(), dt.datetime.now(), dt.datetime.utcnow()
         dstrings = [each.isoformat() for each in dtimes]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -398,6 +398,21 @@ class TestFieldSerialization:
         with pytest.raises(ValueError):
             BadSerializer().dump(u)
 
+    def test_method_field_with_strict_param(self):
+        class Serializer(Schema):
+            m = fields.Method('foo')
+            def foo(self, obj):
+                raise AttributeError()
+        result, _ = Serializer().dump({})
+        assert result == {}
+
+        class Serializer(Schema):
+            m = fields.Method('foo', strict=True)
+            def foo(self, obj):
+                raise AttributeError()
+        with pytest.raises(AttributeError):
+            Serializer().dump({})
+
     def test_method_prefers_serialize_over_method_name(self):
         m = fields.Method(serialize='serialize', method_name='method')
         assert m.serialize_method_name == 'serialize'


### PR DESCRIPTION
I had create a schema like this:

```
from marshmallow import Schema, fields


class TestSchema(Schema):
     avatar_url = fields.Method('get_avatar_url')

     def get_avatar_url(self, obj):
          path = obj['path']
          if not path.starts_with('/'):
               path = '/' + path
          return path


s = TestSchema()
print(s.dump({'path': '/some/path'}))
```

the result is `MarshalResult(data={}, errors={})`. because AttributeError be ignored. but error is caused by other place(In this case, path has no attribute 'starts_with') rather than `obj`

i think this is  very puzzled, should add a `strict` parameter for developers