### PR TITLE
Fix ordered schema support for inherited fields

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -94,7 +94,7 @@ class SchemaMeta(type):
                 ordered = False
         cls_fields = _get_fields(attrs, base.FieldABC, pop=True, ordered=ordered)
         klass = super(SchemaMeta, mcs).__new__(mcs, name, bases, attrs)
-        inherited_fields = _get_fields_by_mro(klass, base.FieldABC)
+        inherited_fields = _get_fields_by_mro(klass, base.FieldABC, ordered=ordered)
 
         # Use getattr rather than attrs['Meta'] so that we get inheritance for free
         meta = getattr(klass, 'Meta')


### PR DESCRIPTION
@sloria I am sorry, I am completely lost here. I have a biggish project in which I use ordered schemas with Marshmallow-SQLAlchemy, and I have noticed that fields on some of the schemas end up being resorted on every restart... My debug lead me to this change, but I cannot create a test for it :(