### PR TITLE
Implement `ordered` option inheritance without breaking the API of 2.x line

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -103,7 +103,9 @@ class SchemaMeta(type):
         meta = getattr(klass, 'Meta')
         # Set klass.opts in __new__ rather than __init__ so that it is accessible in
         # get_declared_fields
-        klass.opts = klass.OPTIONS_CLASS(meta, ordered=ordered)
+        klass.opts = klass.OPTIONS_CLASS(meta)
+        # Pass the inherited `ordered` into opts
+        klass.opts.ordered = ordered
         # Add fields specifid in the `include` class Meta option
         cls_fields += list(klass.opts.include.items())
 
@@ -180,7 +182,7 @@ class SchemaMeta(type):
 class SchemaOpts(object):
     """class Meta options for the :class:`Schema`. Defines defaults."""
 
-    def __init__(self, meta, ordered=False):
+    def __init__(self, meta):
         self.fields = getattr(meta, 'fields', ())
         if not isinstance(self.fields, (list, tuple)):
             raise ValueError("`fields` option must be a list or tuple.")
@@ -202,7 +204,7 @@ class SchemaOpts(object):
                 'Schema.dump will be excluded from the serialized output by default.',
                 UserWarning
             )
-        self.ordered = getattr(meta, 'ordered', ordered)
+        self.ordered = getattr(meta, 'ordered', False)
         self.index_errors = getattr(meta, 'index_errors', True)
         self.include = getattr(meta, 'include', {})
         self.load_only = getattr(meta, 'load_only', ())

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, SchemaOpts
 from marshmallow.exceptions import ValidationError
 from marshmallow.compat import OrderedDict
 
@@ -227,3 +227,18 @@ class TestIncludeOption:
         assert 'email' in s._declared_fields.keys()
         assert 'from' in s._declared_fields.keys()
         assert isinstance(s._declared_fields['from'], fields.Str)
+
+
+class CustomSchemaOpts(SchemaOpts):
+    def __init__(self, meta):
+        super(CustomSchemaOpts, self).__init__(meta)
+        self.custom_option = True
+
+class SchemaWithCustomSchemaOpts(Schema):
+    OPTIONS_CLASS = CustomSchemaOpts
+
+class TestSchemaOptsClass:
+
+    def test_schema_with_custom_schema_opts(self):
+        s = SchemaWithCustomSchemaOpts()
+        assert s.opts.custom_option


### PR DESCRIPTION
*Fixes #597*

Reimplemented 3ffb74d71b5e647ddc3793f464e271a2eeb98bad for 2.x-line to avoid API breakage.

I have added a test to ensure that the API don't break.

I think this implementation shouldn't land to 3.x branch because it feels a bit cumbersome.