### PR TITLE
Add priority to decorator processors

### DIFF
--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -61,15 +61,16 @@ VALIDATES = 'validates'
 VALIDATES_SCHEMA = 'validates_schema'
 
 
-def validates(field_name):
+def validates(field_name, priority=0):
     """Register a field validator.
 
     :param str field_name: Name of the field that the method validates.
     """
-    return tag_processor(VALIDATES, None, False, field_name=field_name)
+    return tag_processor(VALIDATES, None, False, priority=priority, field_name=field_name)
 
 
-def validates_schema(fn=None, pass_many=False, pass_original=False, skip_on_field_errors=True):
+def validates_schema(fn=None, pass_many=False, pass_original=False, skip_on_field_errors=True,
+                     priority=0):
     """Register a schema-level validator.
 
     By default, receives a single object at a time, regardless of whether ``many=True``
@@ -85,11 +86,11 @@ def validates_schema(fn=None, pass_many=False, pass_original=False, skip_on_fiel
     .. versionchanged:: 3.0.0b1
         ``skip_on_field_errors`` defaults to `True`.
     """
-    return tag_processor(VALIDATES_SCHEMA, fn, pass_many, pass_original=pass_original,
-                         skip_on_field_errors=skip_on_field_errors)
+    return tag_processor(VALIDATES_SCHEMA, fn, pass_many, priority=priority,
+                         pass_original=pass_original, skip_on_field_errors=skip_on_field_errors)
 
 
-def pre_dump(fn=None, pass_many=False):
+def pre_dump(fn=None, pass_many=False, priority=0):
     """Register a method to invoke before serializing an object. The method
     receives the object to be serialized and returns the processed object.
 
@@ -97,10 +98,10 @@ def pre_dump(fn=None, pass_many=False):
     is passed to the `Schema`. If ``pass_many=True``, the raw data (which may be a collection)
     and the value for ``many`` is passed.
     """
-    return tag_processor(PRE_DUMP, fn, pass_many)
+    return tag_processor(PRE_DUMP, fn, pass_many, priority=priority)
 
 
-def post_dump(fn=None, pass_many=False, pass_original=False):
+def post_dump(fn=None, pass_many=False, pass_original=False, priority=0):
     """Register a method to invoke after serializing an object. The method
     receives the serialized object and returns the processed object.
 
@@ -108,10 +109,10 @@ def post_dump(fn=None, pass_many=False, pass_original=False):
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_DUMP, fn, pass_many, pass_original=pass_original)
+    return tag_processor(POST_DUMP, fn, pass_many, priority=priority, pass_original=pass_original)
 
 
-def pre_load(fn=None, pass_many=False):
+def pre_load(fn=None, pass_many=False, priority=0):
     """Register a method to invoke before deserializing an object. The method
     receives the data to be deserialized and returns the processed data.
 
@@ -119,10 +120,10 @@ def pre_load(fn=None, pass_many=False):
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(PRE_LOAD, fn, pass_many)
+    return tag_processor(PRE_LOAD, fn, pass_many, priority=priority)
 
 
-def post_load(fn=None, pass_many=False, pass_original=False):
+def post_load(fn=None, pass_many=False, pass_original=False, priority=0):
     """Register a method to invoke after deserializing an object. The method
     receives the deserialized data and returns the processed data.
 
@@ -130,7 +131,7 @@ def post_load(fn=None, pass_many=False, pass_original=False):
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
     """
-    return tag_processor(POST_LOAD, fn, pass_many, pass_original=pass_original)
+    return tag_processor(POST_LOAD, fn, pass_many, priority=priority, pass_original=pass_original)
 
 
 def tag_processor(tag_name, fn, pass_many, **kwargs):

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -173,6 +173,16 @@ class SchemaMeta(type):
                 # the processor was a descriptor or something.
                 self.__processors__[tag].append(attr_name)
 
+        # Sort all processor tags by priority, descending
+        for tag, processors in self.__processors__.items():
+            sorted_processors = sorted(processors,
+                                       key=lambda proc: self._get_priority(proc, tag))
+            self.__processors__[tag] = sorted_processors
+
+    def _get_priority(self, attr_name, tag):
+        processor = getattr(self, attr_name)
+        return processor.__marshmallow_kwargs__[tag].get('priority', 0)
+
 
 class SchemaOpts(object):
     """class Meta options for the :class:`Schema`. Defines defaults."""

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -706,3 +706,29 @@ def test_decorator_strict_error_handling_with_dump(decorator):
         schema.dump(object())
     assert exc.value.messages == {'foo': 'error'}
     schema.load({})
+
+class TestProcessorPriorities:
+
+    def test_pass_ordered_processors(self):
+        class MySchema(Schema):
+            data = fields.Field()
+
+            @post_load(priority=1)
+            def first_post_load(self, ret):
+                ret['data'].append(1)
+                return ret
+
+            @post_load(priority=10)
+            def third_post_load(self, ret):
+                ret['data'].append(10)
+                return ret
+
+            @post_load(priority=5)
+            def second_post_load(self, ret):
+                ret['data'].append(5)
+                return ret
+
+        schema = MySchema()
+        datum = {'data': []}
+        item_loaded = schema.load(datum).data
+        assert item_loaded['data'] == [1, 5, 10]


### PR DESCRIPTION
In the documentation, it's quite explicit about there being no prioritization of processors. I believe this would be a great addition for a few reasons. It allows more complex post-processing flows.

For example, the case I need `priority` is where an abstract schema will post-process into a model object, but before that must be some specialized post-processing in an implementation of the schema. This is less than ideal to implement using the suggested pattern due to the post-processor belonging to the abstract class.


This will retain backward compatibility, given that every processor will default to the same priority and the disclaimer in the documentation.

I'm open to suggestions for an alternative interface for this. Defaulting all processors to `0` would require other processors to run before them to have negative values, so likely a non-zero priority is more appropriate.

ps. love marshmallow, and all of the work that y'all do for it! The documentation is among the best that I've experienced, and every time I read through I discover a new solution to an anti-pattern I've had :).