### PR TITLE
Allow duplicates in ContainsOnly

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,3 +83,4 @@ Contributors (chronological)
 - Roy Williams `@rowillia <https://github.com/rowillia>`_
 - Vlad Frolov `@frol <https://github.com/frol>`_
 - Erling Børresen `@erlingbo <https://github.com/erlingbo>`_
+- Jérôme Lafréchoux  `@lafrech <https://github.com/lafrech>`_

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -456,14 +456,9 @@ class ContainsOnly(OneOf):
         if not value and choices:
             raise ValidationError(self._format_error(value))
 
-        # We check list.index instead of using set.issubset so that
-        # unhashable types are handled.
+        # We can't use set.issubset as it does not handle unhashable types.
         for val in value:
-            try:
-                index = choices.index(val)
-            except ValueError:
+            if val not in choices:
                 raise ValidationError(self._format_error(value))
-            else:
-                del choices[index]
 
         return value

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -601,6 +601,7 @@ def test_containsonly_in_list():
     assert validate.ContainsOnly([1, 2, 3])([1, 2, 3]) == [1, 2, 3]
     assert validate.ContainsOnly([1, 2, 3])([3, 1, 2]) == [3, 1, 2]
     assert validate.ContainsOnly([1, 2, 3])([2, 3, 1]) == [2, 3, 1]
+    assert validate.ContainsOnly([1, 2, 3])([1, 2, 3, 1]) == [1, 2, 3, 1]
 
     with pytest.raises(ValidationError):
         validate.ContainsOnly([1, 2, 3])([4])
@@ -660,14 +661,6 @@ def test_contains_only_in_string():
     with pytest.raises(ValidationError):
         validate.ContainsOnly('')('a')
 
-def test_contains_only_invalid():
-    with pytest.raises(ValidationError) as excinfo:
-        validate.ContainsOnly([1, 2, 3])([1, 1])
-    assert 'One or more of the choices you made was not acceptable.' in str(excinfo)
-    with pytest.raises(ValidationError):
-        validate.ContainsOnly([1, 1, 2])([2, 2])
-    with pytest.raises(ValidationError):
-        validate.ContainsOnly([1, 1, 2])([1, 1, 1])
 
 def test_containsonly_custom_message():
     containsonly = validate.ContainsOnly(


### PR DESCRIPTION
Fixes #603 

From the tests, it is clear that this behavior was intentional, but I really think duplicates should be accepted. Someone wanting the old behavior can do it in a custom validator.