### PR TITLE
When validators called when many elements are provided, but pass_many is False, all elements from the original_data are still passed to the validator

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -834,7 +834,7 @@ class BaseSchema(base.SchemaABC):
                 for idx, item in enumerate(data):
                     try:
                         self._unmarshal.run_validator(validator,
-                                                  item, original_data, self.fields, many=many,
+                                                  item, original_data[idx], self.fields, many=many,
                                                   index=idx, pass_original=pass_original)
                     except ValidationError as err:
                         errors.update(err.messages)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -170,6 +170,19 @@ class TestPassOriginal:
         item_dumped = schema.dump(datum, many=False).data
         assert item_dumped == {'foo': 42, '_post_dump': 24}
 
+    def test_invoke_validators_with_many(self):
+        class MySchema(Schema):
+            email = fields.Email()
+
+            @validates_schema(pass_original=True)
+            def validate_schema_with_original(self, data, original_data):
+                assert not isinstance(original_data, list)
+
+        myschema = MySchema()
+        myschema.load([{'name': 'Joe', 'email': 'joe@null.null'},
+            {'name': 'Jill', 'email': 'jill@null.null'}], many=True)
+
+
 def test_decorated_processor_inheritance():
     class ParentSchema(Schema):
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -63,6 +63,18 @@ def test_dump_with_strict_mode_raises_error(SchemaClass):
     assert type(exc.messages) == dict
     assert exc.messages == {'email': ['Not a valid email address.']}
 
+def test_invoke_validators_with_many():
+    class MySchema(Schema):
+        email = fields.Email()
+
+        @validates_schema(pass_original=True)
+        def validate_schema_with_original(self, data, original_data):
+            assert not isinstance(original_data, list)
+
+    myschema = MySchema()
+    myschema.load([ { 'name': 'Joe', 'email': 'joe@null.null' }, { 'name': 'Jill', 'email': 'jill@null.null'} ], many=True)
+
+
 def test_dump_resets_errors():
     class MySchema(Schema):
         email = fields.Email()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,7 +72,8 @@ def test_invoke_validators_with_many():
             assert not isinstance(original_data, list)
 
     myschema = MySchema()
-    myschema.load([ { 'name': 'Joe', 'email': 'joe@null.null' }, { 'name': 'Jill', 'email': 'jill@null.null'} ], many=True)
+    myschema.load([{'name': 'Joe', 'email': 'joe@null.null'},
+        {'name': 'Jill', 'email': 'jill@null.null'}], many=True)
 
 
 def test_dump_resets_errors():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -63,18 +63,6 @@ def test_dump_with_strict_mode_raises_error(SchemaClass):
     assert type(exc.messages) == dict
     assert exc.messages == {'email': ['Not a valid email address.']}
 
-def test_invoke_validators_with_many():
-    class MySchema(Schema):
-        email = fields.Email()
-
-        @validates_schema(pass_original=True)
-        def validate_schema_with_original(self, data, original_data):
-            assert not isinstance(original_data, list)
-
-    myschema = MySchema()
-    myschema.load([{'name': 'Joe', 'email': 'joe@null.null'},
-        {'name': 'Jill', 'email': 'jill@null.null'}], many=True)
-
 
 def test_dump_resets_errors():
     class MySchema(Schema):


### PR DESCRIPTION
In _invoke_validators, where many data elements exist, but pass_many is not True, there is a for loop to call the validator on each element. However, for that case, while the call to the validator only provides the specific data element, all of the original_data is sent (instead of the respective original_data element). Change is to only provide the respective element for the original_data to the call to the validator