### PR TITLE
Fix inaccessible python-dateutil deserialization logic by adding a configuration parameter to DateTime

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -931,29 +931,29 @@ class DateTime(Field):
     def _serialize(self, value, attr, obj):
         if value is None:
             return None
-        self.dateformat = self.dateformat or self.DEFAULT_FORMAT
-        format_func = self.DATEFORMAT_SERIALIZATION_FUNCS.get(self.dateformat, None)
+        dateformat = self.dateformat or self.DEFAULT_FORMAT
+        format_func = self.DATEFORMAT_SERIALIZATION_FUNCS.get(dateformat, None)
         if format_func:
             try:
                 return format_func(value, localtime=self.localtime)
             except (AttributeError, ValueError) as err:
                 self.fail('format', input=value)
         else:
-            return value.strftime(self.dateformat)
+            return value.strftime(dateformat)
 
     def _deserialize(self, value, attr, data):
         if not value:  # Falsy values, e.g. '', None, [] are not valid
             raise self.fail('invalid')
-        self.dateformat = self.dateformat or self.DEFAULT_FORMAT
-        func = self.DATEFORMAT_DESERIALIZATION_FUNCS.get(self.dateformat)
+        dateformat = self.dateformat or self.DEFAULT_FORMAT
+        func = self.DATEFORMAT_DESERIALIZATION_FUNCS.get(dateformat)
         if func:
             try:
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid')
-        elif self.dateformat:
+        elif dateformat:
             try:
-                return dt.datetime.strptime(value, self.dateformat)
+                return dt.datetime.strptime(value, dateformat)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid')
         elif utils.dateutil_available:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -891,6 +891,9 @@ class DateTime(Field):
 
     :param str format: Either ``"rfc"`` (for RFC822), ``"iso"`` (for ISO8601),
         or a date format string. If `None`, defaults to "iso".
+    :param bool auto_deserialize_format: If `True`, automatically infer format
+        of DateTime strings upon deserialization. Requires the python-dateutil
+        package.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
 
     """

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -954,17 +954,11 @@ class DateTime(Field):
             raise self.fail('invalid')
 
         def deserialize_with_format(dateformat):
-            func = self.DATEFORMAT_DESERIALIZATION_FUNCS.get(dateformat)
-            if func:
-                try:
-                    return func(value)
-                except (TypeError, AttributeError, ValueError):
-                    raise self.fail('invalid')
-            elif dateformat:
-                try:
-                    return dt.datetime.strptime(value, dateformat)
-                except (TypeError, AttributeError, ValueError):
-                    raise self.fail('invalid')
+            try:
+                func = self.DATEFORMAT_DESERIALIZATION_FUNCS.get(dateformat)
+                return func(value) if func else dt.datetime.strptime(value, dateformat)
+            except (TypeError, AttributeError, ValueError):
+                raise self.fail('invalid')
 
         def deserialize_with_dateutil():
             try:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -7,7 +7,6 @@ import collections
 import datetime as dt
 import numbers
 import uuid
-import warnings
 import decimal
 
 from marshmallow import validate, utils, class_registry
@@ -949,7 +948,8 @@ class DateTime(Field):
         self.dateformat = format
 
         if auto_deserialize_format and not utils.dateutil_available:
-            raise RuntimeError('auto_deserialize_format option requires the python-dateutil library')
+            raise RuntimeError('auto_deserialize_format option requires the '
+                'python-dateutil library')
 
         self.auto_deserialize_format = auto_deserialize_format
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -961,7 +961,7 @@ class DateTime(Field):
         def deserialize_with_dateutil():
             try:
                 return utils.from_datestring(value)
-            except TypeError:
+            except (TypeError, ValueError):
                 raise self.fail('invalid')
 
         if self.dateformat:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -391,7 +391,6 @@ class TestFieldDeserialization:
             return
 
         field = fields.DateTime()
-        expected = dt.datetime(2017, 4, 29, 19, 30)
         noncompliant_string = '7:30PM on April 29, 2017'
 
         with pytest.raises(ValidationError):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -376,6 +376,16 @@ class TestFieldDeserialization:
         field = fields.DateTime(format=fmt)
         assert_datetime_equal(field.deserialize(datestring), dtime)
 
+    def test_dateutil_fallback(self):
+        if not utils.dateutil_available:
+            return
+
+        field = fields.DateTime()
+        expected = dt.datetime(2017, 4, 29, 19, 30)
+        noncompliant_string = '7:30PM on April 29, 2017'
+
+        assert_datetime_equal(field.deserialize(noncompliant_string), expected)
+
     def test_localdatetime_field_deserialization(self):
         dtime = dt.datetime.now()
         localized_dtime = central.localize(dtime)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -386,6 +386,17 @@ class TestFieldDeserialization:
 
         assert_datetime_equal(field.deserialize(noncompliant_string), expected)
 
+    def test_noncompliant_exception_when_auto_deser_disabled(self):
+        if not utils.dateutil_available:
+            return
+
+        field = fields.DateTime()
+        expected = dt.datetime(2017, 4, 29, 19, 30)
+        noncompliant_string = '7:30PM on April 29, 2017'
+
+        with pytest.raises(ValidationError):
+            field.deserialize(noncompliant_string)
+
     def test_localdatetime_field_deserialization(self):
         dtime = dt.datetime.now()
         localized_dtime = central.localize(dtime)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -376,11 +376,11 @@ class TestFieldDeserialization:
         field = fields.DateTime(format=fmt)
         assert_datetime_equal(field.deserialize(datestring), dtime)
 
-    def test_dateutil_fallback(self):
+    def test_auto_deserialize_format(self):
         if not utils.dateutil_available:
             return
 
-        field = fields.DateTime()
+        field = fields.DateTime(auto_deserialize_format=True)
         expected = dt.datetime(2017, 4, 29, 19, 30)
         noncompliant_string = '7:30PM on April 29, 2017'
 


### PR DESCRIPTION
The existing implementation of `fields.DateTime` contains an [inaccessible code path](https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/fields.py#L959-L967) that appears to have intended fall back to `python-dateutil` for deserialization in cases when a `dateformat` is not defined.  It even contains a warning message suggesting that `python-dateutil` be installed, but the logging of this message is also inaccessible.

The code is inaccessible because it only runs if `self.dateformat` is `None`, but `self.dateformat` is always re-assigned to `self.DEFAULT_FORMAT` in an [earlier line](https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/fields.py#L947).

The changes I made here enable format-free deserialization via `python-dateutil`, requiring the user to "opt-in" by setting a parameter when constructing the `DateTime` field, e.g.:
```python
class MySchema(Schema):
    dt = DateTime(auto_deserialize_format=True)
```
I considered implementing this as a fallback, rather than an opt-in parameter, as the existing code seemed to be written.  However, it is clear that this could have unintended consequences: for example, one of the unit tests requires that a year-only input date be rejected, while `dateutil` will parse a year-only input using *today's date* as the source of default values for all missing fields, which is quite unintuitive (IMO).

Also, as another minor change, the reassignment of `self.dateformat` described above is both unnecessary and unexpected, as a typical user would probably not assume that `deserialize()` or `serialize()` methods would mutate class variables.  While it seems unlikely that this would ever have caused a problem, it still should probably be avoided, so I have changed both `serialize()` and `deserialize()` to eliminate this pattern.

I added a unit test to confirm that the code does correctly parse non-standard date formats when so configured (and not otherwise).  All other existing unit tests continue to pass.