### PR TITLE
Proposal: add support for field-level pre/post-processing

### DIFF
--- a/docs/custom_fields.rst
+++ b/docs/custom_fields.rst
@@ -4,6 +4,8 @@
 Custom Fields
 =============
 
+A lot of functionality can be added to the existing field classes on Instantiation using :ref:`field-level pre- and post-processing <field_pre_post>` functions.  For more flexibility in creating new functionality, marshmallow supports custom field classes.
+
 There are three ways to create a custom-formatted field for a `Schema`:
 
 - Create a custom :class:`Field <marshmallow.fields.Field>` class

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -7,7 +7,9 @@ Extending Schemas
 Pre-processing and Post-processing Methods
 ------------------------------------------
 
-Data pre-processing and post-processing methods can be registered using the `pre_load <marshmallow.decorators.pre_load>`, `post_load <marshmallow.decorators.post_load>`, `pre_dump <marshmallow.decorators.pre_dump>`, and `post_dump <marshmallow.decorators.post_dump>` decorators.
+:ref:`Field-level pre-processing and post-processing <field_pre_post>` functions can cover many use cases in a very straightforward manner, but sometimes it may be necessary to apply pre- or post-processing to several fields or even the input collection as a whole.
+
+Schema-level pre-processing and post-processing methods can be registered using the `pre_load <marshmallow.decorators.pre_load>`, `post_load <marshmallow.decorators.post_load>`, `pre_dump <marshmallow.decorators.pre_dump>`, and `post_dump <marshmallow.decorators.post_dump>` decorators.
 
 
 .. code-block:: python
@@ -21,11 +23,11 @@ Data pre-processing and post-processing methods can be registered using the `pre
 
         @pre_load
         def slugify_name(self, in_data):
-            in_data['slug'] = in_data['slug'].lower().strip().replace(' ', '-')
+            in_data.setdefault('slug', in_data['name'].lower().strip().replace(' ', '-'))
             return in_data
 
     schema = UserSchema()
-    result, errors = schema.load({'name': 'Steve', 'slug': 'Steve Loria '})
+    result, errors = schema.load({'name': 'Steve Loria '})
     result['slug']  # => 'steve-loria'
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -494,6 +494,26 @@ In the context of a web API, the ``dump_only`` and ``load_only`` parameters are 
         created_at = fields.DateTime(dump_only=True)
 
 
+.. _field_pre_post:
+
+Field-Level Pre- and Post-Processing
+-------------------------------------
+
+Marshmallow comes with :ref:`field classes <api_fields>` for a wide range of datatypes.  Sometimes you might just want to adapt an existing field by extending its functionality in a minimal way.
+
+For example, say you want to silently limit a number to a certain range instead of raising an error when it is out-of-bounds.
+
+It's easy to add this kind of behavior to existing field classes by specifying field-level pre- and/or post-processing functions with the ``pre_deserialize``, ``post_deserialize``, ``pre_serialize`` and ``post_serialize`` parameters.
+
+.. code-block:: python
+    :emphasize-lines: 4
+
+    from marshmallow import fields, Schema
+
+    class ItemSchema(Schema):
+        quantity = fields.Integer(post_deserialize=lambda v: max(1, min(30, v)))
+
+
 Next Steps
 ----------
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -769,6 +769,7 @@ class TestFieldDeserialization:
     def test_pre_deserialize_method(self):
         class PreDeserialize(Schema):
             data = fields.List(fields.Str(), pre_deserialize='listify')
+
             def listify(self, value):
                 return value.split(',')
         s = PreDeserialize(strict=True)
@@ -785,6 +786,7 @@ class TestFieldDeserialization:
     def test_post_deserialize_method(self):
         class PostDeserialize(Schema):
             days = fields.Int(post_deserialize='to_days')
+
             def to_days(self, value):
                 return dt.timedelta(value + 1)
         s = PostDeserialize(strict=True)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -789,6 +789,7 @@ class TestFieldSerialization:
     def test_pre_serialize_method(self):
         class PreSerialize(Schema):
             days = fields.Int(pre_serialize='from_days')
+
             def from_days(self, td):
                 return td.days
         s = PreSerialize(strict=True)
@@ -806,6 +807,7 @@ class TestFieldSerialization:
     def test_post_serialize_method(self):
         class PostSerialize(Schema):
             ages = fields.List(fields.Int(), post_serialize='commasep')
+
             def commasep(self, a):
                 return ','.join(map(str, a))
         s = PostSerialize(strict=True)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -782,6 +782,40 @@ class TestFieldSerialization:
         else:
             assert res is None
 
+    def test_pre_serialize(self):
+        field = fields.Field(pre_serialize=lambda d: d.days)
+        assert field.serialize('days', {'days': dt.timedelta(2)}) == 2
+
+    def test_pre_serialize_method(self):
+        class PreSerialize(Schema):
+            days = fields.Int(pre_serialize='from_days')
+            def from_days(self, td):
+                return td.days
+        s = PreSerialize(strict=True)
+        obj = {'days': dt.timedelta(2)}
+        assert s.dump(obj).data == {'days': 2}
+
+    def test_pre_serialize_not_callable(self):
+        with pytest.raises(ValueError):
+            fields.Field(pre_serialize={})
+
+    def test_post_serialize(self):
+        field = fields.List(fields.Str(), post_serialize=','.join)
+        assert field.serialize('ages', {'ages': [28, 30, 22]}) == '28,30,22'
+
+    def test_post_serialize_method(self):
+        class PostSerialize(Schema):
+            ages = fields.List(fields.Int(), post_serialize='commasep')
+            def commasep(self, a):
+                return ','.join(map(str, a))
+        s = PostSerialize(strict=True)
+        obj = {'ages': [13, 34, 42]}
+        assert s.dump(obj).data == {'ages': '13,34,42'}
+
+    def test_post_serialize_not_callable(self):
+        with pytest.raises(ValueError):
+            fields.Field(post_serialize=False)
+
 
 def test_serializing_named_tuple():
     Point = namedtuple('Point', ['x', 'y'])


### PR DESCRIPTION
This is a feature I've been meaning to suggest since we used marshmallow in 
a small project back in December.  I am not a long time marshmallow user, 
and I haven't fully explored all its features or dug deep into the 
"marshmallow way."  I certainly haven't read any dev discussions regarding 
what features to include, but it seems to me this one could simplify 
several things.

I really like the ease `fields.Function` provides for defining custom field 
behavior. I'd love to see an equally easy way to build on top of all the 
functionality packed into the existing type fields.  To leverage the type 
conversion/checking they provide, I would have to subclass:

```
>>> from marshmallow import fields
>>> f = fields.Int()
>>> f.deserialize('2')
2
>>> f.deserialize('2.1')
Traceback (most recent call last):
...
marshmallow.exceptions.ValidationError: Not a valid integer.
>>> f = fields.Function(deserialize=lambda x: x + 1)
>>> f.deserialize(2)
3
>>> f.deserialize(2.1)
3.1
>>> f.deserialize('2')
Traceback (most recent call last):
...
TypeError: Can't convert 'int' object to str implicitly
```

With pre- and post-processing functions on the base field class, this 
becomes much easier:

```
>>> from marshmallow import fields
>>> f = fields.Int(post_deserialize=lambda x: x + 1)
>>> f.deserialize('2')
3
>>> f.deserialize('2.1')
Traceback (most recent call last):
...
marshmallow.exceptions.ValidationError: Not a valid integer.
```

One real-world case for this I came across was in handling optional search 
paramaters for a GET /entries api endpoint.  Each entry has a timestamp, 
and we needed to implement a `limit_days` parameter to get only entries 
from the last _n_ days.  `fields.Function(deserialize=timedelta)` doesn't 
cut it, because we really want all that `fields.Int()` validation first.  
So the options are either subclass `fields.Int` or process the data in a 
`post_load` function:

```
class EntrySearch(Schema):
    limit_days = fields.Int(missing=None)

    @post_load
    def post_process(self, data):
        if data['limit_days'] is not None:
            data['limit_days'] = timedelta(max(1, data['limit_days']))
```

A `post_deserialize` function on the field makes this much more 
straightforward:

```
>>> class EntrySearch(Schema):
...   limit_days = fields.Int(missing=None,
...                           post_deserialize=lambda d: timedelta(max(1, d)))
... 
>>> s = EntrySearch()
>>> s.load({})
UnmarshalResult(data={'limit_days': None}, errors={})
>>> s.load({'limit_days': '3'})
UnmarshalResult(data={'limit_days': datetime.timedelta(3)}, errors={})
```

Another real-world case I came across was handling different field formats, 
such as comma-separated list:

```
>>> f = fields.List(fields.Int(),
>>>                 pre_deserialize=lambda v: v.split(','),
>>>                 post_serialize=lambda v: ','.join(map(str, v)))
>>> f.deserialize('1,2,3')
[1, 2, 3]
>>> f.serialize('data', {'data': [2, 4, 6]})
'2,4,6'
```

(Incidentially, I would have thought `List(Int(as_string=True))` would 
serialize a list of ints to a list of str, but it doesn't)

Another real-world case I came across was a situation where a certain 
framework was parsing data sometimes as a list and sometimes as a scalar.

```
def force_list(val)
    if hasattr(v, 'join'):
        return v
    return [v]

class EntrySchema(Schema):
    ref_ids = fields.List(fields.Int(), pre_deserialize=force_list)
```

and another:

```
    id = fields.UUID(pre_deserialize=decrypt, post_serialize=encrypt)
```

and so forth.  Schema-level `pre_load`, `post_load`, `pre_dump` and 
`post_dump` still have applicability, just like schema-level validation in 
contradistinction to field-level validation.

So I hope you'll agree that this is a worthwhile feature to support.

I believe with this change, some of the examples could be simplified, but I 
only glanced at them.  If you like, I could update the examples to use 
these where sensible.