### PR TITLE
Record invalid type errors per index with many=True

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -256,14 +256,19 @@ class Unmarshaller(ErrorStore):
                 try:
                     raw_value = data.get(attr_name, missing)
                 except AttributeError:  # Input data is not a dict
-                    errors = self.get_errors(index=index)
                     msg = field_obj.error_messages['type'].format(
                         input=data, input_type=data.__class__.__name__
                     )
-                    self.error_field_names = [SCHEMA]
-                    self.error_fields = []
-                    errors = self.get_errors()
-                    errors.setdefault(SCHEMA, []).append(msg)
+                    if index is None or not index_errors:
+                        errors = self.get_errors()
+                        errors.setdefault(SCHEMA, []).append(msg)
+                        self.error_field_names = [SCHEMA]
+                        self.error_fields = []
+                    else:
+                        errors = self.get_errors(index=index)
+                        errors.setdefault(SCHEMA, []).append(msg)
+                        self.error_field_names = []
+                        self.error_fields = []
                     # Input data type is incorrect, so we can bail out early
                     break
                 field_name = attr_name

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -356,7 +356,8 @@ class TestValidatesSchemaDecorator:
         assert errors
         assert 'nested' in errors
         assert 0 in errors['nested']
-        assert '_schema' in errors['nested']
+        assert '_schema' in errors['nested'][0]
+        assert '_schema' not in errors['nested']
         assert 'foo' not in errors['nested']
 
     def test_decorated_validators(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -329,6 +329,38 @@ def test_load_many():
     assert type(result.data[0]) == User
     assert result.data[0].name == 'Mick'
 
+def test_load_many_records_errors_per_index():
+    class Sch(Schema):
+        name = fields.String()
+
+    s = Sch(many=True)
+    result = s.load([1, {'name': 'Jacob'}, 3])
+    assert len(result.errors) == 2
+    assert result.errors[0] == {'_schema': ['Invalid input type.']}
+    assert result.errors[2] == {'_schema': ['Invalid input type.']}
+
+    s = Sch(many=True)
+    result = s.load([1, {'name': 1111}, 3])
+    assert len(result.errors) == 3
+    assert result.errors[0] == {'_schema': ['Invalid input type.']}
+    assert result.errors[1] == {'name': ['Not a valid string.']}
+    assert result.errors[2] == {'_schema': ['Invalid input type.']}
+
+    class SchNoIndex(Sch):
+        class Meta:
+            index_errors = False
+
+    s = SchNoIndex(many=True)
+    result = s.load([1, {'name': 'Jacob'}, 3])
+    assert len(result.errors) == 1
+    assert result.errors == {'_schema': ['Invalid input type.', 'Invalid input type.']}
+
+    s = SchNoIndex(many=True)
+    result = s.load([1, {'name': 1111}, 3])
+    assert len(result.errors) == 2
+    assert result.errors['_schema'] == ['Invalid input type.', 'Invalid input type.']
+    assert result.errors['name'] == ['Not a valid string.']
+
 def test_loads_returns_an_unmarshalresult(user):
     s = UserSchema()
     result = s.loads(json.dumps({'name': 'Monty'}))


### PR DESCRIPTION
Earlier, errors about invalid types (such as giving primitive for dict) got recorded on `_schema` level for list elements, rather than for each index separately.

So for example, first block in the added test used to produce:

```python
{
    '_schema': ['Invalid input type.', 'Invalid input type.']}
    0: {},
    1: {}
}
```

With this change it now produces:

```python
{
    0: {'_schema': ['Invalid input type.']}
    1: {'_schema': ['Invalid input type.']}
}
```

I don't know marshmallow internals well, and I am quite unsure this. But if this fix makes sense, we can iterate it into a proper form! :)

I used slightly different style to do asserts. I can replace strings by references to `Field.default_error_messages`, if that's better. Or remove value comparisons altogether. I just think this slightly more verbose form gives reader a better understanding of what is actually in `result.errors`.