### PR TITLE
Make UUIDs valid if input is string representation or 16 byte rep

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,7 +623,10 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            return uuid.UUID(value)
+            if isinstance(value, bytes) or len(value) == 16:
+                return uuid.UUID(bytes=value)
+            else:
+                return uuid.UUID(value)
         except (ValueError, AttributeError):
             self.fail('invalid_uuid')
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,8 +623,11 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            return uuid.UUID(value)
-        except (ValueError, AttributeError):
+            if isinstance(value, bytes) and len(value) == 16:
+                return uuid.UUID(bytes=value)
+            else:
+                return uuid.UUID(value)
+        except (TypeError, ValueError, AttributeError):
             self.fail('invalid_uuid')
 
     def _serialize(self, value, attr, obj):


### PR DESCRIPTION
My database contains UUIDs in a 16 byte representation and not the string representation. The python UUID library does not automatically detect the difference if passed as the first argument, byte representations must be passed into the `bytes` kwarg of the constructor.

This PR is to allow marshmallow to accept both the normal string representation and the byte representation.

In python 2.x bytes is the same type as string so for a valid string representation this will pass, so an additional check is made on the length being 12.  For python 3.x a string representation will be a different type so the first statement will catch it.