### PR TITLE
Implement hooks for a JIT to integrate into marshmallow.

### DIFF
--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from marshmallow.schema import (
     Schema,
+    SchemaJit,
     SchemaOpts,
     MarshalResult,
     UnmarshalResult,
@@ -19,6 +20,7 @@ __author__ = 'Steven Loria'
 
 __all__ = [
     'Schema',
+    'SchemaJit',
     'SchemaOpts',
     'fields',
     'validates',

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -430,6 +430,7 @@ class Nested(Field):
                 raise ValueError('Nested fields must be passed a '
                                  'Schema, not {0}.'.format(self.nested.__class__))
             self.__schema.ordered = getattr(self.parent, 'ordered', False)
+            self.__schema.jit = getattr(self.parent, 'jit', None)
         return self.__schema
 
     def _nested_normalized_option(self, option_name):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -430,6 +430,7 @@ class Nested(Field):
                 raise ValueError('Nested fields must be passed a '
                                  'Schema, not {0}.'.format(self.nested.__class__))
             self.__schema.ordered = getattr(self.parent, 'ordered', False)
+            # If the parent has a jit specified we should use that same jit.
             self.__schema.jit = getattr(self.parent, 'jit', None)
         return self.__schema
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -554,10 +554,11 @@ class BaseSchema(base.SchemaABC):
         """
         result = None
         errors = {}
+        marshalling_method.reset_errors()
         if jitted_method:
             try:
                 result = jitted_method(obj, many=many)
-            except (ValidationError, KeyError, AttributeError, ValueError):
+            except (ValidationError, KeyError, AttributeError, ValueError, TypeError):
                 # Fall through to slow path
                     pass
         if not result:

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -27,6 +27,7 @@ from marshmallow.utils import missing, suppress
 DEFAULT_JIT_ENVIRONMENT_VARIABLE = 'MARSHMALLOW_SCHEMA_DEFAULT_JIT'
 DEFAULT_JIT = missing
 
+
 def get_default_jit():
     """Allows overriding the default JIT to use from the environment.
 
@@ -43,8 +44,8 @@ def get_default_jit():
                 parts = default_jit_path.split('.')
                 module_name = '.'.join(parts[0:-1])
                 class_name = parts[-1]
-                module = importlib.import_module(module_name)
-                DEFAULT_JIT = getattr(module, class_name, None)
+                jit_module = importlib.import_module(module_name)
+                DEFAULT_JIT = getattr(jit_module, class_name, None)
     return DEFAULT_JIT
 
 
@@ -555,11 +556,7 @@ class BaseSchema(base.SchemaABC):
         errors = {}
         if jitted_method:
             try:
-                if many:
-                    result = [jitted_method(x)
-                              for x in obj]
-                else:
-                    result = jitted_method(obj)
+                result = jitted_method(obj, many=many)
             except (ValidationError, KeyError, AttributeError, ValueError):
                 # Fall through to slow path
                     pass

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -11,6 +11,7 @@ import re
 import time
 import types
 from calendar import timegm
+from contextlib import contextmanager
 from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
@@ -394,3 +395,10 @@ def get_func_args(func):
 
 def if_none(value, default):
     return value if value is not None else default
+
+@contextmanager
+def suppress(*exceptions):
+    try:
+        yield
+    except exceptions:
+        pass

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2299,13 +2299,13 @@ class TestSchemaWithJit:
 
         @property
         def jitted_marshal_method(self):
-            def marshal(obj):
+            def marshal(obj, many=False):
                 return 'The Jit Marshaled'
             return marshal
 
         @property
         def jitted_unmarshal_method(self):
-            def unmarshal(obj):
+            def unmarshal(obj, many=False):
                 return 'The Jit Unmarshaled'
             return unmarshal
 
@@ -2315,13 +2315,13 @@ class TestSchemaWithJit:
 
         @property
         def jitted_marshal_method(self):
-            def marshal(obj):
+            def marshal(obj, many=False):
                 raise ValueError()
             return marshal
 
         @property
         def jitted_unmarshal_method(self):
-            def unmarshal(obj):
+            def unmarshal(obj, many=False):
                 raise ValueError()
             return unmarshal
 
@@ -2397,23 +2397,11 @@ class TestSchemaWithJit:
         assert not result.errors
         assert result.data == 'The Jit Marshaled'
 
-    def test_hello_world_jit_dump_many(self, schema):
-        schema.jit = self.HelloWorldJit
-        result = schema.dump([{'name': 'foo'}], many=True)
-        assert not result.errors
-        assert result.data == ['The Jit Marshaled']
-
     def test_hello_world_jit_load(self, schema):
         schema.jit = self.HelloWorldJit
         result = schema.load({'name': 'foo'})
         assert not result.errors
         assert result.data == 'The Jit Unmarshaled'
-
-    def test_hello_world_jit_load_many(self, schema):
-        schema.jit = self.HelloWorldJit
-        result = schema.load([{'name': 'foo'}], many=True)
-        assert not result.errors
-        assert result.data == ['The Jit Unmarshaled']
 
     def test_bad_jit_dump_fallback(self, schema):
         schema.jit = self.BadJit


### PR DESCRIPTION
This is a revival of https://github.com/marshmallow-code/marshmallow/pull/573

Unfortunately other personal/professional priorities prempted me from focusing on this for the past few months, but I'd like to revisit open sourcing this again.

When we deployed this to production we saw ~20x improvement in serialization time which, in turn, dropped our response times in half.

I totally understand the apprehension on the original PR due to the complexity this introduces, so I've created a follow on PR that integrates the hooks I need into marshmallow, leaving everything else relatively unchanged.

We're still able to get the same performance gains, and I'm able to iterate on my JIT library without having to pester you with PRs :D.  If we can get this integration working we'll have an awesome story about how Marshmallow allows engineers to have the amazing API of Marshmallow without having to sacrifice performance.
