### PR TITLE
Enum field

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ invoke>=0.13.0
 # Soft dependencies
 python-dateutil
 pytz
+enum34 ; python_version < '3.4'
 
 # Distribution
 wheel

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1312,6 +1312,24 @@ class Constant(Field):
         return self.constant
 
 
+class Enum(Field):
+
+    default_error_messages = {'invalid': 'Not a valid choice.'}
+
+    def __init__(self, enum, *args, **kwargs):
+        super(Enum, self).__init__(*args, **kwargs)
+        self._enum = enum
+
+    def _serialize(self, value, *args, **kwargs):
+        return value.name
+
+    def _deserialize(self, value, *args, **kwargs):
+        try:
+            return self._enum[value]
+        except KeyError:
+            self.fail('invalid')
+
+
 # Aliases
 URL = Url
 Str = String

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -2,12 +2,7 @@
 import datetime as dt
 import uuid
 import decimal
-
-try:
-    from enum import Enum
-    enum_import_error = None
-except ImportError:
-    enum_import_error = "Cannot import Enum"
+import enum
 
 import pytest
 
@@ -766,10 +761,9 @@ class TestFieldDeserialization:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
 
-    @pytest.mark.skipif(enum_import_error is not None, reason=enum_import_error)
     def test_enum_field_deserialization(self):
 
-        class MyEnum(Enum):
+        class MyEnum(enum.Enum):
             val_1 = 1
             val_2 = 2
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -3,6 +3,12 @@ import datetime as dt
 import uuid
 import decimal
 
+try:
+    from enum import Enum
+    enum_import_error = None
+except ImportError:
+    enum_import_error = "Cannot import Enum"
+
 import pytest
 
 from marshmallow import fields, utils, Schema, validate
@@ -759,6 +765,20 @@ class TestFieldDeserialization:
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
+
+    @pytest.mark.skipif(enum_import_error is not None, reason=enum_import_error)
+    def test_enum_field_deserialization(self):
+
+        class MyEnum(Enum):
+            val_1 = 1
+            val_2 = 2
+
+        field = fields.Enum(MyEnum)
+        assert field.deserialize('val_1') is MyEnum.val_1
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize('invalid')
+        assert 'Not a valid choice' in str(excinfo)
+
 
 # No custom deserialization behavior, so a dict is returned
 class SimpleUserSchema(Schema):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -774,9 +774,16 @@ class TestFieldDeserialization:
             val_2 = 2
 
         field = fields.Enum(MyEnum)
-        assert field.deserialize('val_1') is MyEnum.val_1
+        field_as_str = fields.Enum(MyEnum, as_string=True)
+
+        assert field.deserialize(MyEnum.val_1) is MyEnum.val_1
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize('invalid')
+        assert 'Not a valid choice' in str(excinfo)
+
+        assert field_as_str.deserialize('val_1') is MyEnum.val_1
+        with pytest.raises(ValidationError) as excinfo:
+            field_as_str.deserialize('invalid')
         assert 'Not a valid choice' in str(excinfo)
 
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,6 +6,12 @@ import itertools
 import decimal
 import uuid
 
+try:
+    from enum import Enum
+    enum_import_error = None
+except ImportError:
+    enum_import_error = "Cannot import Enum"
+
 import pytest
 
 from marshmallow import Schema, fields, utils
@@ -781,6 +787,16 @@ class TestFieldSerialization:
             assert res == 'None'
         else:
             assert res is None
+
+    @pytest.mark.skipif(enum_import_error is not None, reason=enum_import_error)
+    def test_enum_field_serialization(self):
+
+        class MyEnum(Enum):
+            val_1 = 1
+            val_2 = 2
+
+        field = fields.Enum(MyEnum)
+        assert field.serialize('foo', {'foo': MyEnum.val_1}) == 'val_1'
 
 
 def test_serializing_named_tuple():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -796,7 +796,10 @@ class TestFieldSerialization:
             val_2 = 2
 
         field = fields.Enum(MyEnum)
-        assert field.serialize('foo', {'foo': MyEnum.val_1}) == 'val_1'
+        field_as_str = fields.Enum(MyEnum, as_string=True)
+
+        assert field.serialize('foo', {'foo': MyEnum.val_1}) is MyEnum.val_1
+        assert field_as_str.serialize('foo', {'foo': MyEnum.val_1}) == 'val_1'
 
 
 def test_serializing_named_tuple():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,12 +5,7 @@ import datetime as dt
 import itertools
 import decimal
 import uuid
-
-try:
-    from enum import Enum
-    enum_import_error = None
-except ImportError:
-    enum_import_error = "Cannot import Enum"
+import enum
 
 import pytest
 
@@ -788,10 +783,9 @@ class TestFieldSerialization:
         else:
             assert res is None
 
-    @pytest.mark.skipif(enum_import_error is not None, reason=enum_import_error)
     def test_enum_field_serialization(self):
 
-        class MyEnum(Enum):
+        class MyEnum(enum.Enum):
             val_1 = 1
             val_2 = 2
 


### PR DESCRIPTION
Our models often use string fields where the value must be in an `Enum`. We use a `String` field and add a `OneOf` validator, so that the deserialized string is validated against the `Enum`.

This fields allows to deserialize as an `Enum` instance rather than as a string.

I also added an `as_string` parameter, like in `Number` field. Some may want to serialize as `Enum` and only use the validation feature. It defaults to `False`, like in `Number` field.

This does not add a dependency to `enum`. It is not imported in the code, and corresponding tests are skipped if it can't be imported. When using Python < 3.4, the backported version can be used.

This is not critical to us, but I thought it might help.

Feedback welcome.