### PR TITLE
Allow Number fields to prohibit boolean values.

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -639,8 +639,6 @@ class Number(Field):
     """Base class for number fields.
 
     :param bool as_string: If True, format the serialized value as a string.
-    :param bool prohibit_boolean: If True, attempting to serialize a boolean
-        will result in a ValueError instead of coercing the value to a number.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
@@ -649,9 +647,8 @@ class Number(Field):
         'invalid': 'Not a valid number.'
     }
 
-    def __init__(self, as_string=False, prohibit_boolean=False, **kwargs):
+    def __init__(self, as_string=False, **kwargs):
         self.as_string = as_string
-        self.prohibit_boolean = prohibit_boolean
         super(Number, self).__init__(**kwargs)
 
     def _format_num(self, value):
@@ -659,9 +656,9 @@ class Number(Field):
         if value is None:
             return None
         # (value is True or value is False) is ~5x faster than isinstance(value, bool)
-        if self.prohibit_boolean and (value is True or value is False):
+        if value is True or value is False:
             raise TypeError(
-                'value must not be a boolean when prohibit_boolean is set.  value is '
+                'value must be a Number, not a boolean.  value is '
                 '{}'.format(value))
         return self.num_type(value)
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -639,6 +639,8 @@ class Number(Field):
     """Base class for number fields.
 
     :param bool as_string: If True, format the serialized value as a string.
+    :param bool prohibit_boolean: If True, attempting to serialize a boolean
+        will result in a ValueError instead of coercing the value to a number.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
@@ -647,14 +649,20 @@ class Number(Field):
         'invalid': 'Not a valid number.'
     }
 
-    def __init__(self, as_string=False, **kwargs):
+    def __init__(self, as_string=False, prohibit_boolean=False, **kwargs):
         self.as_string = as_string
+        self.prohibit_boolean = prohibit_boolean
         super(Number, self).__init__(**kwargs)
 
     def _format_num(self, value):
         """Return the number value for value, given this field's `num_type`."""
         if value is None:
             return None
+        # (value is True or value is False) is ~5x faster than isinstance(value, bool)
+        if self.prohibit_boolean and (value is True or value is False):
+            raise TypeError(
+                'value must not be a boolean when prohibit_boolean is set.  value is '
+                '{}'.format(value))
         return self.num_type(value)
 
     def _validated(self, value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -78,6 +78,18 @@ class TestField:
         result = MySchema().dump({'name': 'Monty', 'foo': 42})
         assert result.data == {'_NaMe': 'Monty'}
 
+    def test_number_fields_prohbit_boolean(self):
+        permissive_field = fields.Float()
+        assert 0.0 == permissive_field.serialize('value', {'value': False})
+
+        strict_field = fields.Float(prohibit_boolean=True)
+        with pytest.raises(ValidationError) as excinfo:
+            strict_field.serialize('value', {'value': False})
+        assert excinfo.value.args[0] == 'Not a valid number.'
+        with pytest.raises(ValidationError) as excinfo:
+            strict_field.serialize('value', {'value': True})
+        assert excinfo.value.args[0] == 'Not a valid number.'
+
 class TestParentAndName:
     class MySchema(Schema):
         foo = fields.Field()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -78,11 +78,8 @@ class TestField:
         result = MySchema().dump({'name': 'Monty', 'foo': 42})
         assert result.data == {'_NaMe': 'Monty'}
 
-    def test_number_fields_prohbit_boolean(self):
-        permissive_field = fields.Float()
-        assert 0.0 == permissive_field.serialize('value', {'value': False})
-
-        strict_field = fields.Float(prohibit_boolean=True)
+    def test_number_fields_prohbits_boolean(self):
+        strict_field = fields.Float()
         with pytest.raises(ValidationError) as excinfo:
             strict_field.serialize('value', {'value': False})
         assert excinfo.value.args[0] == 'Not a valid number.'


### PR DESCRIPTION
After a bunch of research, I decided to _explicitly_ special case booleans as opposed
to adding a flag for only allowing numbers to be serialized.  I came across code in
our repositories that, for example, overload `__int__` or `__float__` that would expect
to be able to be serialized.  I agree, however, that allowing booleans to be serialized
as numbers is likely incorrect.

This fixes https://github.com/marshmallow-code/marshmallow/issues/623