### PR TITLE
stuff for building dash docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+marshmallow.docset
+marshmallow.tgz

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+DASHING       = dashing
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -19,7 +20,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext dash
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -48,6 +49,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf marshmallow.docset marshmallow.tgz
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
@@ -175,3 +177,7 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+dash: html
+	$(DASHING) build
+	@tar czf marshmallow.tgz marshmallow.docset

--- a/docs/dashing.json
+++ b/docs/dashing.json
@@ -1,0 +1,22 @@
+{
+    "name": "Marshmallow",
+    "package": "marshmallow",
+    "index": "_build/index.html",
+    "selectors": {
+        "dl.class dt": {
+            "type": "Class",
+            "attr": "id"
+        },
+        "dl.exception dt": {
+            "type": "Exception",
+            "attr": "id"
+        },
+        "dl.function dt": {
+            "type": "Function",
+            "attr": "id"
+        }
+    },
+    "icon32x32": "",
+    "allowJS": false,
+    "ExternalURL": ""
+}


### PR DESCRIPTION
This allows you to build docs suitable for use in [helm-dash](https://github.com/areina/helm-dash) (and possibly regular osx dash, but I can't be sure), provided you have [dashing](https://github.com/technosophos/dashing) installed.