### PR TITLE
fix #664: validate.URL: allow hostnames with no dots

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -47,7 +47,7 @@ class URL(Validator):
     URL_REGEX = re.compile(
         r'^(?:[a-z0-9\.\-\+]*)://'  # scheme is validated separately
         r'(?:[^:@]+?:[^:@]*?@|)'  # basic auth
-        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+'
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)+'
         r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain...
         r'localhost|'  # localhost...
         r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # ...or ipv4

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -23,6 +23,7 @@ from marshmallow import validate, ValidationError
     'http://123.45.67.8/',
     'http://2001:db8::ff00:42:8329',
     'http://www.example.com:8000/foo',
+    'http://my-local-neighbor',
 ])
 def test_url_absolute_valid(valid_url):
     validator = validate.URL(relative=False)


### PR DESCRIPTION
reason: a hostname with no dots is valid, and useful in some cases,
e.g. a host in the same subdomain than the client, a shorter alias to
a longer hostname, a local network without TLD