### PR TITLE
Add strict option to fields.Integer

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -86,3 +86,4 @@ Contributors (chronological)
 - Jérôme Lafréchoux  `@lafrech <https://github.com/lafrech>`_
 - Roy Williams `@rowillia <https://github.com/rowillia>`_
 - `@dradetsky <https://github.com/dradetsky>`_
+- Yoichi NAKAYAMA `@yoichi <https://github.com/yoichi>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, unicode_literals
 
 import collections
 import datetime as dt
+import numbers
 import uuid
 import warnings
 import decimal
@@ -698,6 +699,18 @@ class Integer(Number):
     default_error_messages = {
         'invalid': 'Not a valid integer.'
     }
+
+    # override Number
+    def __init__(self, strict=False, **kwargs):
+        self.strict = strict
+        super(Integer, self).__init__(**kwargs)
+
+    # override Number
+    def _format_num(self, value):
+        if self.strict and isinstance(value, numbers.Number):
+            if not isinstance(value, numbers.Integral):
+                self.fail('invalid')
+        return super(Integer, self)._format_num(value)
 
 
 class Decimal(Number):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -83,6 +83,15 @@ class TestFieldDeserialization:
             field.deserialize({})
         assert excinfo.value.args[0] == 'Not a valid integer.'
 
+    def test_strict_integer_field_deserialization(self):
+        field = fields.Integer(strict=True)
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(42.0)
+        assert excinfo.value.args[0] == 'Not a valid integer.'
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(decimal.Decimal('42.0'))
+        assert excinfo.value.args[0] == 'Not a valid integer.'
+
     def test_decimal_field_deserialization(self):
         m1 = 12
         m2 = '12.355'


### PR DESCRIPTION
I want a feature to get validation error on float and Decimal value for fields.Integer instead of rounding it to integer.
Compare with https://github.com/marshmallow-code/marshmallow/issues/231, we already have tests expecting current rounding behaviour, so I've added a constructor option 'strict' and keep the default behavior.

# before the change

```
from marshmallow import fields
from marshmallow import Schema

DATA = {'foo': '3.0', 'bar': 3.14, 'baz': 3.0}

class MySchema(Schema):
    foo = fields.Integer(required=True)
    bar = fields.Integer(required=True)
    baz = fields.Integer(required=True)

s = MySchema()
print('--- Marshmallow ---')
print(s.validate(DATA))


from django.conf import settings
settings.configure(INSTALLED_APPS=['rest_framework'])
import django
django.setup()

from rest_framework import serializers as ser

class MySer(ser.Serializer):
    foo = ser.IntegerField()
    bar = ser.IntegerField()
    baz = ser.IntegerField()

ser = MySer(data=DATA)
ser.is_valid()
print('--- DRF ---')
print(ser.errors)
```

```
--- Marshmallow ---
{'foo': ['Not a valid integer.']}
--- DRF ---
{'bar': ['A valid integer is required.']}
```

# after the change

```
from marshmallow import fields
from marshmallow import Schema

DATA = {'foo': '3.0', 'bar': 3.14, 'baz': 3.0}

class MySchema(Schema):
    foo = fields.Integer(required=True, strict=True)
    bar = fields.Integer(required=True, strict=True)
    baz = fields.Integer(required=True, strict=True)

s = MySchema()
print('--- Marshmallow ---')
print(s.validate(DATA))
```

```
--- Marshmallow ---
{'baz': ['Not a valid integer.'], 'bar': ['Not a valid integer.'], 'foo': ['Not a valid integer.']}
```