### PR TITLE
fix #664: validate.URL: add option to allow hostnames with no dots

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -42,6 +42,7 @@ class URL(Validator):
         Can be interpolated with `{input}`.
     :param set schemes: Valid schemes. By default, ``http``, ``https``,
         ``ftp``, and ``ftps`` are allowed.
+    :param bool require_tld: Whether to reject non-FQDN hostnames
     """
 
     class RegexMemoizer(object):
@@ -49,7 +50,7 @@ class URL(Validator):
         def __init__(self):
             self._memoized = {}
 
-        def _regex_generator(self, relative):
+        def _regex_generator(self, relative, require_tld):
             return re.compile(r''.join((
                 r'^',
                 r'(' if relative else r'',
@@ -58,6 +59,8 @@ class URL(Validator):
                 r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
                 r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
                 r'localhost|',  # localhost...
+                (r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|'
+                 if not require_tld else r''),  # allow dotless hostnames
                 r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
                 r'\[?[A-F0-9]*:[A-F0-9:]+\]?)',  # ...or ipv6
                 r'(?::\d+)?',  # optional port
@@ -65,11 +68,12 @@ class URL(Validator):
                 r'(?:/?|[/?]\S+)$',
             )), re.IGNORECASE)
 
-        def __call__(self, relative):
-            if relative not in self._memoized:
-                self._memoized[relative] = self._regex_generator(relative)
+        def __call__(self, relative, require_tld):
+            key = (relative, require_tld)
+            if key not in self._memoized:
+                self._memoized[key] = self._regex_generator(relative, require_tld)
 
-            return self._memoized[relative]
+            return self._memoized[key]
 
     _regex = RegexMemoizer()
 
@@ -77,10 +81,11 @@ class URL(Validator):
     default_schemes = set(['http', 'https', 'ftp', 'ftps'])
 
     # TODO; Switch position of `error` and `schemes` in 3.0
-    def __init__(self, relative=False, error=None, schemes=None):
+    def __init__(self, relative=False, error=None, schemes=None, require_tld=True):
         self.relative = relative
         self.error = error or self.default_message
         self.schemes = schemes or self.default_schemes
+        self.require_tld = require_tld
 
     def _repr_args(self):
         return 'relative={0!r}'.format(self.relative)
@@ -99,7 +104,7 @@ class URL(Validator):
             if scheme not in self.schemes:
                 raise ValidationError(message)
 
-        regex = self._regex(self.relative)
+        regex = self._regex(self.relative, self.require_tld)
 
         if not regex.search(value):
             raise ValidationError(message)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -81,6 +81,32 @@ def test_url_relative_invalid(invalid_url):
     with pytest.raises(ValidationError):
         validator(invalid_url)
 
+@pytest.mark.parametrize('valid_url', [
+    'http://example.org',
+    'http://123.45.67.8/',
+    'http://example',
+    'http://example.',
+    'http://example:80',
+    'http://user.name:pass.word@example',
+    'http://example/foo/bar',
+])
+def test_url_dont_require_tld_valid(valid_url):
+    validator = validate.URL(require_tld=False)
+    assert validator(valid_url) == valid_url
+
+@pytest.mark.parametrize('invalid_url', [
+    'http//example',
+    'http://.example.org',
+    'http:///foo/bar',
+    'http:// /foo/bar',
+    '',
+    None,
+])
+def test_url_dont_require_tld_invalid(invalid_url):
+    validator = validate.URL(require_tld=False)
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
 def test_url_custom_scheme():
     validator = validate.URL()
     # By default, ws not allowed


### PR DESCRIPTION
reason: a hostname with no dots is valid, and useful in some cases,
e.g. a host in the same subdomain than the client, a shorter alias to
a longer hostname, a local network without TLD

This is a followup on #665.