### PR TITLE
Use Changelog date instead of build date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'marshmallow'
 copyright = ' {0:%Y} <a href="http://stevenloria.com">Steven Loria</a>'.format(
-    dt.datetime.utcnow()
+    dt.datetime.utcfromtimestamp(os.path.getmtime('../CHANGELOG.rst'))
 )
 
 version = release = marshmallow.__version__


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Without this patch, when building packages (e.g. for openSUSE Linux) in different years, results differed slightly:
```diff
     <div class="footer">
     -      &copy; 2017 <a href="http://stevenloria.com">Steven Loria</a>. 
     +      &copy; 2018 <a href="http://stevenloria.com">Steven Loria</a>.
```