### PR TITLE
Fix spelling mistake for test method name

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -89,3 +89,4 @@ Contributors (chronological)
 - Michal Kononenko `@MichalKononenko <https://github.com/MichalKononenko>`_
 - Yoichi NAKAYAMA `@yoichi <https://github.com/yoichi>`_
 - Bernhard M. Wiedemann `@bmwiedemann <https://github.com/bmwiedemann>`_
+- Scott Werner `@scottwernervt <https://github.com/scottwernervt>`_

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -154,7 +154,7 @@ class TestFieldOrdering:
         keys = list(user_data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
-    def test_nested_field_order_with_exlude_arg_is_maintained(self, user):
+    def test_nested_field_order_with_exclude_arg_is_maintained(self, user):
         class HasNestedExclude(Schema):
             class Meta:
                 ordered = True


### PR DESCRIPTION
Correct spelling of `exlude` in `test_nested_field_order_with_exlude_arg_is_maintained`.