### PR TITLE
Fix typo in exception message in ValidatedField._validated()

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1148,7 +1148,7 @@ class ValidatedField(Field):
     """A field that validates input on serialization."""
 
     def _validated(self, value):
-        raise NotImplementedError('Must implement _validate method')
+        raise NotImplementedError('Must implement _validated method')
 
     def _serialize(self, value, *args, **kwargs):
         ret = super(ValidatedField, self)._serialize(value, *args, **kwargs)


### PR DESCRIPTION
Fix typo reported by wonderbeyond
https://github.com/marshmallow-code/marshmallow/issues/659