### PR TITLE
Add python 3.6 to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,pypy
+envlist=py27,py34,py35,py36,pypy
 [testenv]
 deps=
   -rdev-requirements.txt


### PR DESCRIPTION
I noticed that python 3.6 is supported, travis is running tests against it, but was missing in `tox.ini`.