### PR TITLE
Changes from_iso to from_iso_datetime

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -920,8 +920,8 @@ class DateTime(Field):
     }
 
     DATEFORMAT_DESERIALIZATION_FUNCS = {
-        'iso': utils.from_iso,
-        'iso8601': utils.from_iso,
+        'iso': utils.from_iso_datetime,
+        'iso8601': utils.from_iso_datetime,
         'rfc': utils.from_rfc,
         'rfc822': utils.from_rfc,
     }

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -258,7 +258,7 @@ def from_rfc(datestring, use_dateutil=True):
         return datetime.datetime.fromtimestamp(timestamp)
 
 
-def from_iso(datestring, use_dateutil=True):
+def from_iso_datetime(datestring, use_dateutil=True):
     """Parse an ISO8601-formatted datetime string and return a datetime object.
 
     Use dateutil's parser if possible and return a timezone-aware datetime.

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -10,6 +10,7 @@ import json
 import re
 import time
 import types
+import warnings
 from calendar import timegm
 from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
@@ -256,6 +257,11 @@ def from_rfc(datestring, use_dateutil=True):
         parsed = parsedate(datestring)  # as a tuple
         timestamp = time.mktime(parsed)
         return datetime.datetime.fromtimestamp(timestamp)
+
+
+def from_iso(datestring, use_dateutil=True):
+    warnings.warn('from_iso is deprecated. Use from_iso_datetime instead.', UserWarning)
+    return from_iso_datetime(datestring, use_dateutil)
 
 
 def from_iso_datetime(datestring, use_dateutil=True):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,17 +187,17 @@ def test_from_rfc(use_dateutil):
     assert_datetime_equal(result, d)
 
 @pytest.mark.parametrize('use_dateutil', [True, False])
-def test_from_iso(use_dateutil):
+def test_from_iso_datetime(use_dateutil):
     d = dt.datetime.now()
     formatted = d.isoformat()
-    result = utils.from_iso(formatted, use_dateutil=use_dateutil)
+    result = utils.from_iso_datetime(formatted, use_dateutil=use_dateutil)
     assert type(result) == dt.datetime
     assert_datetime_equal(result, d)
 
 def test_from_iso_with_tz():
     d = central.localize(dt.datetime.now())
     formatted = d.isoformat()
-    result = utils.from_iso(formatted)
+    result = utils.from_iso_datetime(formatted)
     assert_datetime_equal(result, d)
     if utils.dateutil_available:
         # Note a naive datetime


### PR DESCRIPTION
Since the iso regex used in `utils.from_iso` does not handle iso-formatted dates (`%Y-%m-%d`), I renamed this method to make its functionality clearer.