### PR TITLE
Fix bug: field that is not UTF-8 will raise a UnicodeDecodeError

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,3 +83,4 @@ Contributors (chronological)
 - Vlad Frolov `@frol <https://github.com/frol>`_
 - Michal Kononenko `@MichalKononenko <https://github.com/MichalKononenko>`_
 - `@sduthil <https://github.com/sduthil>`_
+- Alisson Silveira `@4lissonsilveira <https://github.com/4lissonsilveira>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -590,7 +590,8 @@ class String(Field):
     """
 
     default_error_messages = {
-        'invalid': 'Not a valid string.'
+        'invalid': 'Not a valid string.',
+        'invalid_utf8': 'Not a valid utf-8 string.'
     }
 
     def _serialize(self, value, attr, obj):
@@ -601,7 +602,11 @@ class String(Field):
     def _deserialize(self, value, attr, data):
         if not isinstance(value, basestring):
             self.fail('invalid')
-        return utils.ensure_text_type(value)
+
+        try:
+            return utils.ensure_text_type(value)
+        except UnicodeDecodeError:
+            self.fail('invalid_utf8')
 
 
 class UUID(String):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -715,6 +715,13 @@ class TestFieldDeserialization:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
 
+    def test_field_deserialization_non_utf8_with(self):
+        non_utf8_char = '\xc8'
+        field = fields.String()
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(non_utf8_char)
+        assert excinfo.value.args[0] == 'Not a valid utf-8 string.'
+
 # No custom deserialization behavior, so a dict is returned
 class SimpleUserSchema(Schema):
     name = fields.String()


### PR DESCRIPTION
- A new test has been added.
- Related:
 #650 https://github.com/marshmallow-code/marshmallow/issues/650