### PR TITLE
Structured Dictionaries

### DIFF
--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -542,6 +542,13 @@ class TestFieldDeserialization:
             field.deserialize('baddict')
         assert excinfo.value.args[0] == 'Not a valid mapping type.'
 
+    def test_structured_dict_value_deserialization(self):
+        field = fields.Dict(values=fields.Str)
+        assert field.deserialize({"foo": "bar"}) == {"foo": "bar"}
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({"foo": 1})
+        assert excinfo.value.args[0] == {'foo': ['Invalid value: Not a valid string.']}
+
     def test_url_field_deserialization(self):
         field = fields.Url()
         assert field.deserialize('https://duckduckgo.com') == 'https://duckduckgo.com'

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -388,6 +388,17 @@ class TestFieldSerialization:
         assert field.serialize('various_data', user) == \
             OrderedDict([("foo", "bar"), ("bar", "baz")])
 
+    def test_structured_dict_value_serialize(self, user):
+        user.various_data = {"foo": decimal.Decimal('1')}
+        field = fields.Dict(values=fields.Decimal)
+        assert field.serialize('various_data', user) == {"foo": 1}
+
+    def test_structured_dict_validates(self, user):
+        user.various_data = {"foo": "bar"}
+        field = fields.Dict(values=fields.Decimal)
+        with pytest.raises(ValidationError):
+            field.serialize('various_data', user)
+
     def test_url_field_serialize_none(self, user):
         user.homepage = None
         field = fields.Url()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -393,6 +393,16 @@ class TestFieldSerialization:
         field = fields.Dict(values=fields.Decimal)
         assert field.serialize('various_data', user) == {"foo": 1}
 
+    def test_structured_dict_key_serialize(self, user):
+        user.various_data = {1: "bar"}
+        field = fields.Dict(keys=fields.Str)
+        assert field.serialize('various_data', user) == {"1": "bar"}
+
+    def test_structured_dict_key_value_serialize(self, user):
+        user.various_data = {1: decimal.Decimal('1')}
+        field = fields.Dict(keys=fields.Str, values=fields.Decimal)
+        assert field.serialize('various_data', user) == {"1": 1}
+
     def test_structured_dict_validates(self, user):
         user.various_data = {"foo": "bar"}
         field = fields.Dict(values=fields.Decimal)


### PR DESCRIPTION
Fixes #483

Add support for structured dictionaries by providing `values` and `keys` arguments to the `Dict` field's constructor. This mirrors the `List` field's ability to validate it's items.