### PR TITLE
Fix URL validator for ipv6 (brackets required always)

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -62,7 +62,7 @@ class URL(Validator):
                 (r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)|'
                  if not require_tld else r''),  # allow dotless hostnames
                 r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|',  # ...or ipv4
-                r'\[?[A-F0-9]*:[A-F0-9:]+\]?)',  # ...or ipv6
+                r'\[[A-F0-9]*:[A-F0-9:]+\])',  # ...or ipv6
                 r'(?::\d+)?',  # optional port
                 r')?' if relative else r'',  # host is optional, allow for relative URLs
                 r'(?:/?|[/?]\S+)$',

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -22,7 +22,9 @@ from marshmallow import validate, ValidationError
     'http://www.example.com/?array%5Bkey%5D=value',
     'http://xn--rsum-bpad.example.org/',
     'http://123.45.67.8/',
-    'http://2001:db8::ff00:42:8329',
+    'http://123.45.67.8:8329/',
+    'http://[2001:db8::ff00:42]:8329',
+    'http://[2001::1]:8329',
     'http://www.example.com:8000/foo',
 ])
 def test_url_absolute_valid(valid_url):
@@ -40,6 +42,8 @@ def test_url_absolute_valid(valid_url):
     'http:/example.org',
     'foo://example.org',
     '../icons/logo.gif',
+    'http://2001:db8::ff00:42:8329',
+    'http://[192.168.1.1]:8329',
     'abc',
     '..',
     '/',


### PR DESCRIPTION
By RFC "Format for Literal IPv6 Addresses in URL's" (https://tools.ietf.org/html/rfc2732) , square brackets always requried in ipv6 URI.