### PR TITLE
Nested field: store data and valid_data in ValidationError on dump/load

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -455,7 +455,7 @@ class Nested(Field):
             else:
                 return ret[self.only]
         if errors:
-            raise ValidationError(errors, data=ret)
+            raise ValidationError(errors, data=obj, valid_data=ret)
         return ret
 
     def _deserialize(self, value, attr, data):
@@ -467,10 +467,10 @@ class Nested(Field):
                 value = [{self.only: v} for v in value]
             else:
                 value = {self.only: value}
-        data, errors = self.schema.load(value)
+        valid_data, errors = self.schema.load(value)
         if errors:
-            raise ValidationError(errors, data=data)
-        return data
+            raise ValidationError(errors, data=data, valid_data=valid_data)
+        return valid_data
 
     def _validate_missing(self, value):
         """Validate missing values. Raise a :exc:`ValidationError` if

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -79,8 +79,8 @@ class ErrorStore(object):
             else:
                 errors.setdefault(field_name, []).extend(err.messages)
             # When a Nested field fails validation, the marshalled data is stored
-            # on the ValidationError's data attribute
-            value = err.data or missing
+            # on the ValidationError's valid_data attribute
+            value = err.valid_data or missing
         return value
 
 class Marshaller(ErrorStore):


### PR DESCRIPTION
I think this was forgotten when implementing afb12308.

Without this change, `valid_data` contains wrong data when loading a nested field with errors.