### PR TITLE
Remove strict parameter and return [de|]serialiazed data or raise ValidationError

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -15,9 +15,6 @@ Schema
 
 .. autoclass:: marshmallow.SchemaOpts
 
-.. autoclass:: marshmallow.MarshalResult
-.. autoclass:: marshmallow.UnmarshalResult
-
 .. autofunction:: marshmallow.pprint
 
 .. _api_fields:

--- a/docs/custom_fields.rst
+++ b/docs/custom_fields.rst
@@ -83,7 +83,7 @@ Both :class:`Function <marshmallow.fields.Function>` and :class:`Method <marshma
 
     schema = UserSchema()
     result = schema.load({'balance': '100.00'})
-    result.data['balance']  # => 100.0
+    result['balance']  # => 100.0
 
 .. _adding-context:
 
@@ -115,9 +115,9 @@ As an example, you might want your ``UserSchema`` to output whether or not a ``U
     blog = Blog('Bicycle Blog', author=user)
 
     schema.context = {'blog': blog}
-    data, errors = schema.dump(user)
-    data['is_author']  # => True
-    data['likes_bikes']  # => True
+    result = schema.dump(user)
+    result['is_author']  # => True
+    result['likes_bikes']  # => True
 
 
 Customizing Error Messages

--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -46,7 +46,7 @@ The serialized blog will have the nested user representation.
 
     user = User(name="Monty", email="monty@python.org")
     blog = Blog(title="Something Completely Different", author=user)
-    result, errors = BlogSchema().dump(blog)
+    result = BlogSchema().dump(blog)
     pprint(result)
     # {'title': u'Something Completely Different',
     # {'author': {'name': u'Monty',
@@ -75,7 +75,7 @@ You can explicitly specify which attributes of the nested objects you want to se
         author = fields.Nested(UserSchema, only=["email"])
 
     schema = BlogSchema2()
-    result, errors = schema.dump(blog)
+    result = schema.dump(blog)
     pprint(result)
     # {
     #     'title': u'Something Completely Different',
@@ -91,7 +91,7 @@ You can represent the attributes of deeply nested objects using dot delimiters.
         blog = fields.Nested(BlogSchema2)
 
     schema = SiteSchema(only=['blog.author.email'])
-    result, errors = schema.dump(site)
+    result = schema.dump(site)
     pprint(result)
     # {
     #     'blog': {
@@ -111,14 +111,14 @@ You can represent the attributes of deeply nested objects using dot delimiters.
             email = fields.Email()
             friends = fields.Nested('self', only='name', many=True)
         # ... create ``user`` ...
-        serialized_data, errors = UserSchema().dump(user)
+        serialized_data = UserSchema().dump(user)
         pprint(serialized_data)
         # {
         #     "name": "Steve",
         #     "email": "steve@example.com",
         #     "friends": ["Mike", "Joe"]
         # }
-        deserialized_data, errors = UserSchema().load(result)
+        deserialized_data = UserSchema().load(result)
         pprint(deserialized_data)
         # {
         #     "name": "Steve",
@@ -161,7 +161,7 @@ For example, a representation of an ``Author`` model might include the books tha
 
     author = Author(name='William Faulkner')
     book = Book(title='As I Lay Dying', author=author)
-    book_result, errors = BookSchema().dump(book)
+    book_result = BookSchema().dump(book)
     pprint(book_result, indent=2)
     # {
     #   "id": 124,
@@ -172,7 +172,7 @@ For example, a representation of an ``Author`` model might include the books tha
     #   }
     # }
 
-    author_result, errors = AuthorSchema().dump(author)
+    author_result = AuthorSchema().dump(author)
     pprint(author_result, indent=2)
     # {
     #   "id": 8,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -44,7 +44,7 @@ Create a schema by defining a class with variables mapping attribute names to :c
 Serializing Objects ("Dumping")
 -------------------------------
 
-Serialize objects by passing them to your schema's :meth:`dump <marshmallow.Schema.dump>` method, which returns the formatted result (as well as a dictionary of validation errors, which we'll :ref:`revisit later <validation>`).
+Serialize objects by passing them to your schema's :meth:`dump <marshmallow.Schema.dump>` method, which returns the formatted result (or raises a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` with a dictionary of validation errors, which we'll :ref:`revisit later <validation>`).
 
 .. code-block:: python
 
@@ -53,7 +53,7 @@ Serialize objects by passing them to your schema's :meth:`dump <marshmallow.Sche
     user = User(name="Monty", email="monty@python.org")
     schema = UserSchema()
     result = schema.dump(user)
-    pprint(result.data)
+    pprint(result)
     # {"name": "Monty",
     #  "email": "monty@python.org",
     #  "created_at": "2014-08-17T14:54:16.049594+00:00"}
@@ -63,7 +63,7 @@ You can also serialize to a JSON-encoded string using :meth:`dumps <marshmallow.
 .. code-block:: python
 
     json_result = schema.dumps(user)
-    pprint(json_result.data)
+    pprint(json_result)
     # '{"name": "Monty", "email": "monty@python.org", "created_at": "2014-08-17T14:54:16.049594+00:00"}'
 
 Filtering output
@@ -74,7 +74,7 @@ You may not need to output all declared fields every time you use a schema. You 
 .. code-block:: python
 
     summary_schema = UserSchema(only=('name', 'email'))
-    summary_schema.dump(user).data
+    summary_schema.dump(user)
     # {"name": "Monty Python", "email": "monty@python.org"}
 
 You can also exclude fields by passing in the ``exclude`` parameter.
@@ -98,7 +98,7 @@ By default, :meth:`load <Schema.load>` will return a dictionary of field names m
     }
     schema = UserSchema()
     result = schema.load(user_data)
-    pprint(result.data)
+    pprint(result)
     # {'name': 'Ken',
     #  'email': 'ken@yahoo.com',
     #  'created_at': datetime.datetime(2014, 8, 11, 5, 26, 3, 869245)},
@@ -134,7 +134,7 @@ Now, the :meth:`load <Schema.load>` method will return a ``User`` object.
     }
     schema = UserSchema()
     result = schema.load(user_data)
-    result.data  # => <User(name='Ronnie')>
+    result # => <User(name='Ronnie')>
 
 Handling Collections of Objects
 -------------------------------
@@ -149,7 +149,7 @@ Iterable collections of objects are also serializable and deserializable. Just s
     users = [user1, user2]
     schema = UserSchema(many=True)
     result = schema.dump(users)  # OR UserSchema().dump(users, many=True)
-    result.data
+    result
     # [{'name': u'Mick',
     #   'email': u'mick@stones.com',
     #   'created_at': '2014-08-17T14:58:57.600623+00:00'}
@@ -163,20 +163,24 @@ Iterable collections of objects are also serializable and deserializable. Just s
 Validation
 ----------
 
-:meth:`Schema.load` (and its JSON-decoding counterpart, :meth:`Schema.loads`) returns a dictionary of validation errors as the second element of its return value. Some fields, such as the :class:`Email <fields.Email>` and :class:`URL <fields.URL>` fields, have built-in validation.
+:meth:`Schema.load` (and its JSON-decoding counterpart, :meth:`Schema.loads`) raises a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` error when invalid data are passed in. You can access the dictionary of validation errors from the `ValidationError.messages <marshmallow.exceptions.ValidationError.messages>` attribute. The data that was correctly serialized / deserialized is accessible in `ValidationError.valid_data <marshmallow.exceptions.ValidationError.valid_data>`. Some fields, such as the :class:`Email <fields.Email>` and :class:`URL <fields.URL>` fields, have built-in validation.
 
 .. code-block:: python
 
-    data, errors = UserSchema().load({'email': 'foo'})
-    errors  # => {'email': ['"foo" is not a valid email address.']}
-    # OR, equivalently
-    result = UserSchema().load({'email': 'foo'})
-    result.errors  # => {'email': ['"foo" is not a valid email address.']}
+    from marshmallow import ValidationError
+
+    try:
+        result = UserSchema().load({'name': 'John', 'email': 'foo'})
+    except ValidationError as err:
+        err.messages  # => {'email': ['"foo" is not a valid email address.']}
+        valid_data = err.valid_data  # => {'name': 'John'}
 
 
 When validating a collection, the errors dictionary will be keyed on the indices of invalid items.
 
 .. code-block:: python
+
+    from marshmallow import ValidationError
 
     class BandMemberSchema(Schema):
         name = fields.String(required=True)
@@ -189,8 +193,10 @@ When validating a collection, the errors dictionary will be keyed on the indices
         {'email': 'charlie@stones.com'},  # missing "name"
     ]
 
-    result = BandMemberSchema(many=True).load(user_data)
-    result.errors
+    try:
+        BandMemberSchema(many=True).load(user_data)
+    except ValidationError as err:
+        err.messages
     # {1: {'email': ['"invalid" is not a valid email address.']},
     #  3: {'name': ['Missing data for required field.']}}
 
@@ -199,14 +205,18 @@ You can perform additional validation for a field by passing it a ``validate`` c
 .. code-block:: python
     :emphasize-lines: 4
 
+    from marshmallow import ValidationError
+
     class ValidatedUserSchema(UserSchema):
         # NOTE: This is a contrived example.
         # You could use marshmallow.validate.Range instead of an anonymous function here
         age = fields.Number(validate=lambda n: 18 <= n <= 40)
 
     in_data = {'name': 'Mick', 'email': 'mick@stones.com', 'age': 71}
-    result = ValidatedUserSchema().load(in_data)
-    result.errors  # => {'age': ['Validator <lambda>(71.0) is False']}
+    try:
+        result = ValidatedUserSchema().load(in_data)
+    except ValidationError as err:
+        err.messages  # => {'age': ['Validator <lambda>(71.0) is False']}
 
 
 Validation functions either return a boolean or raise a :exc:`ValidationError`. If a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` is raised, its message is stored when validation fails.
@@ -226,8 +236,10 @@ Validation functions either return a boolean or raise a :exc:`ValidationError`. 
         quantity = fields.Integer(validate=validate_quantity)
 
     in_data = {'quantity': 31}
-    result, errors = ItemSchema().load(in_data)
-    errors  # => {'quantity': ['Quantity must not be greater than 30.']}
+    try:
+        result = ItemSchema().load(in_data)
+    except ValidationError as err:
+    err.messages  # => {'quantity': ['Quantity must not be greater than 30.']}
 
 .. note::
 
@@ -236,6 +248,14 @@ Validation functions either return a boolean or raise a :exc:`ValidationError`. 
 .. note::
 
     :meth:`Schema.dump` also returns a dictionary of errors, which will include any ``ValidationErrors`` raised during serialization. However, ``required``, ``allow_none``, ``validate``, `@validates <marshmallow.decorators.validates>`, and `@validates_schema <marshmallow.decorators.validates_schema>` only apply during deserialization.
+
+.. seealso::
+
+    You can register a custom error handler function for a schema by overriding the :func:`handle_error <Schema.handle_error>` method. See the :ref:`Extending Schemas <extending>` page for more info.
+
+.. seealso::
+
+    Need schema-level validation? See the :ref:`Extending Schemas <schemavalidation>` page.
 
 
 Field Validators as Methods
@@ -258,28 +278,6 @@ It is often convenient to write validators as methods. Use the `validates <marsh
                 raise ValidationError('Quantity must not be greater than 30.')
 
 
-``strict`` Mode
-+++++++++++++++
-
-    If you set ``strict=True`` in either the Schema constructor or as a ``class Meta`` option, an error will be raised when invalid data are passed in. You can access the dictionary of validation errors from the `ValidationError.messages <marshmallow.exceptions.ValidationError.messages>` attribute.
-
-    .. code-block:: python
-
-        from marshmallow import ValidationError
-
-        try:
-            UserSchema(strict=True).load({'email': 'foo'})
-        except ValidationError as err:
-            print(err.messages)# => {'email': ['"foo" is not a valid email address.']}
-
-.. seealso::
-
-    You can register a custom error handler function for a schema by overriding the :func:`handle_error <Schema.handle_error>` method. See the :ref:`Extending Schemas <extending>` page for more info.
-
-.. seealso::
-
-    Need schema-level validation? See the :ref:`Extending Schemas <schemavalidation>` page.
-
 Required Fields
 +++++++++++++++
 
@@ -288,6 +286,8 @@ You can make a field required by passing ``required=True``. An error will be sto
 To customize the error message for required fields, pass a `dict` with a ``required`` key as the ``error_messages`` argument for the field.
 
 .. code-block:: python
+
+    from marshmallow import ValidationError
 
     class UserSchema(Schema):
         name = fields.String(required=True)
@@ -301,8 +301,10 @@ To customize the error message for required fields, pass a `dict` with a ``requi
         )
         email = fields.Email()
 
-    data, errors = UserSchema().load({'email': 'foo@bar.com'})
-    errors
+    try:
+        result = UserSchema().load({'email': 'foo@bar.com'})
+    except ValidationError as err:
+        err.messages
     # {'name': ['Missing data for required field.'],
     #  'age': ['Age is required.'],
     #  'city': {'message': 'City required', 'code': 400}}
@@ -319,9 +321,9 @@ When using the same schema in multiple places, you may only want to check requir
         name = fields.String(required=True)
         age = fields.Integer(required=True)
 
-    data, errors = UserSchema().load({'age': 42}, partial=('name',))
+    result = UserSchema().load({'age': 42}, partial=('name',))
     # OR UserSchema(partial=('name',)).load({'age': 42})
-    data, errors  # => ({'age': 42}, {})
+    result  # => ({'age': 42}, {})
 
 Or you can ignore missing fields entirely by setting ``partial=True``.
 
@@ -332,9 +334,9 @@ Or you can ignore missing fields entirely by setting ``partial=True``.
         name = fields.String(required=True)
         age = fields.Integer(required=True)
 
-    data, errors = UserSchema().load({'age': 42}, partial=True)
+    result = UserSchema().load({'age': 42}, partial=True)
     # OR UserSchema(partial=True).load({'age': 42})
-    data, errors  # => ({'age': 42}, {})
+    result  # => ({'age': 42}, {})
 
 Schema.validate
 +++++++++++++++
@@ -362,7 +364,7 @@ By default, `Schemas` will marshal the object attributes that are identical to t
 
     user = User('Keith', email='keith@stones.com')
     ser = UserSchema()
-    result, errors = ser.dump(user)
+    result = ser.dump(user)
     pprint(result)
     # {'name': 'Keith',
     #  'email_addr': 'keith@stones.com',
@@ -386,7 +388,7 @@ By default `Schemas` will unmarshal an input dictionary to an output dictionary 
         'emailAddress': 'foo@bar.com'
     }
     s = UserSchema()
-    result, errors = s.load(data)
+    result = s.load(data)
     #{'name': u'Mike',
     # 'email': 'foo@bar.com'}
 
@@ -410,7 +412,7 @@ If you want to marshal a field to a different key than the field name you can us
         'email': 'foo@bar.com'
     }
     s = UserSchema()
-    result, errors = s.dump(data)
+    result = s.dump(data)
     #{'TheName': u'Mike',
     # 'CamelCasedEmail': 'foo@bar.com'}
 
@@ -468,9 +470,9 @@ For some use cases, it may be useful to maintain field ordering of serialized ou
     u = User('Charlie', 'charlie@stones.com')
     schema = UserSchema()
     result = schema.dump(u)
-    assert isinstance(result.data, OrderedDict)
+    assert isinstance(result, OrderedDict)
     # marshmallow's pprint function maintains order
-    pprint(result.data, indent=2)
+    pprint(result, indent=2)
     # {
     #   "name": "Charlie",
     #   "email": "charlie@stones.com",

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -17,6 +17,35 @@ The marshmallow 3.x series supports Python 2.7, 3.4, 3.5, and 3.6.
 
 Python 2.6 and 3.3 are no longer supported.
 
+
+``strict`` in Schema is deprecated
+**********************************
+
+`Schema().load` and `Schema().dump` don't return a (data, errors) duple anymore.
+
+Only data is returned. If invalid data are passed in, a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` is raised. The dictionary of validation errors is accessible from the `ValidationError.messages <marshmallow.exceptions.ValidationError.messages>` attribute, along with the valid data (values deserialized without error).
+
+.. code-block:: python
+
+    from marshmallow import Schema, ValidationError
+
+    # 2.x
+    user = User(name="Monty", email="monty@python.org")
+    schema = UserSchema()
+    data, errors = schema.dump(user)
+
+    # 3.x
+    user = User(name="Monty", email="monty@python.org")
+    schema = UserSchema()
+    try:
+        data = schema.dump(user)
+    except ValidationError as err:
+        errors = err.messages
+        valid_data = err.valid_data
+
+:meth:`Schema.validate` now always returns a dictionary of validation errors (same as 2.x with ``strict=False``).
+
+
 Overriding ``get_attribute``
 ****************************
 
@@ -80,7 +109,7 @@ The `Method <marshmallow.fields.Method>` and `Function <marshmallow.fields.Funct
     # In 2.x, the following would pass without errors
     # In 3.x, and AttributeError would be raised
     result = schema.dump(None)
-    result.data  # => {}
+    result  # => {}
 
 
     # 3.x
@@ -95,7 +124,7 @@ The `Method <marshmallow.fields.Method>` and `Function <marshmallow.fields.Funct
 
     schema = ShapeSchema()
     result = schema.dump(None)
-    result.data  # => {}
+    result  # => {}
 
 Adding additional data to serialized output
 *******************************************
@@ -113,7 +142,7 @@ Use a `post_dump <marshmallow.decorators.post_dump>` to add additional data on s
         y = fields.Int()
 
     schema = MySchema(extra={'z': 123})
-    schema.dump({'x': 1, 'y': 2}).data
+    schema.dump({'x': 1, 'y': 2})
     # => {'z': 123, 'y': 2, 'x': 1}
 
     # 3.x
@@ -127,7 +156,7 @@ Use a `post_dump <marshmallow.decorators.post_dump>` to add additional data on s
             return output
 
     schema = MySchema()
-    schema.dump({'x': 1, 'y': 2}).data
+    schema.dump({'x': 1, 'y': 2})
     # => {'z': 123, 'y': 2, 'x': 1}
 
 
@@ -150,7 +179,7 @@ By default, schema validator methods decorated by `validates_schema <marshmallow
                 raise ValidationError('x must be greater than y')
 
 
-    schema = MySchema(strict=True)
+    schema = MySchema()
 
     # 2.x
     # A KeyError is raised in validate_schema
@@ -179,7 +208,7 @@ If you want a schema validator to run even if a field validator fails, pass ``sk
                     raise ValidationError('x must be greater than y')
 
 
-    schema = MySchema(strict=True)
+    schema = MySchema()
     schema.load({'x': 2})
     # marshmallow.exceptions.ValidationError: {'y': ['Missing data for required field.']}
 

--- a/examples/textblob_example.py
+++ b/examples/textblob_example.py
@@ -24,7 +24,7 @@ blob_schema = BlobSchema()
 def analyze():
     blob = TextBlob(request.json['text'])
     result = blob_schema.dump(blob)
-    return result.data
+    return result
 
 
 run(reloader=True, port=5000)

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from marshmallow.schema import (
-    Schema,
-    SchemaOpts,
-    MarshalResult,
-    UnmarshalResult,
-)
+from marshmallow.schema import Schema, SchemaOpts
+
 from . import fields
 from marshmallow.decorators import (
     pre_dump, post_dump, pre_load, post_load, validates, validates_schema
@@ -28,8 +24,6 @@ __all__ = [
     'pre_load',
     'post_load',
     'pprint',
-    'MarshalResult',
-    'UnmarshalResult',
     'ValidationError',
     'missing',
 ]

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -520,8 +520,8 @@ class BaseSchema(base.SchemaABC):
         return self.load(data, many=many, partial=partial)
 
     def validate(self, data, many=None, partial=None):
-        """Validate `data` against the schema, raising a `ValidationError` if
-        errors are detected.
+        """Validate `data` against the schema, returning a dictionary of
+        validation errors.
 
         :param dict data: The data to validate.
         :param bool many: Whether to validate `data` as a collection. If `None`, the
@@ -529,10 +529,16 @@ class BaseSchema(base.SchemaABC):
         :param bool|tuple partial: Whether to ignore missing fields. If `None`,
             the value for `self.partial` is used. If its value is an iterable,
             only missing fields listed in that iterable will be ignored.
+        :return: A dictionary of validation errors.
+        :rtype: dict
 
         .. versionadded:: 1.1.0
         """
-        self._do_load(data, many, partial=partial, postprocess=False)
+        try:
+            self._do_load(data, many, partial=partial, postprocess=False)
+        except ValidationError as exc:
+            return exc.messages
+        return {}
 
     ##### Private Helpers #####
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -185,11 +185,6 @@ class SchemaOpts(object):
         self.exclude = getattr(meta, 'exclude', ())
         if not isinstance(self.exclude, (list, tuple)):
             raise ValueError("`exclude` must be a list or tuple.")
-        if hasattr(meta, 'strict'):
-            warnings.warn(
-                'The strict class Meta option is deprecated.',
-                DeprecationWarning
-            )
         self.dateformat = getattr(meta, 'dateformat', None)
         if hasattr(meta, 'json_module'):
             warnings.warn(
@@ -315,9 +310,8 @@ class BaseSchema(base.SchemaABC):
         """
         pass
 
-    def __init__(self, only=(), exclude=(), prefix='', strict=None,
-                 many=False, context=None, load_only=(), dump_only=(),
-                 partial=False):
+    def __init__(self, only=(), exclude=(), prefix='', many=False,
+                 context=None, load_only=(), dump_only=(), partial=False):
         # copy declared fields from metaclass
         self.declared_fields = copy.deepcopy(self._declared_fields)
         self.many = many
@@ -340,12 +334,6 @@ class BaseSchema(base.SchemaABC):
         self._normalize_nested_options()
         self._types_seen = set()
         self._update_fields(many=many)
-
-        if strict is not None:
-            warnings.warn(
-                'The strict parameter is deprecated.',
-                DeprecationWarning
-            )
 
     def __repr__(self):
         return '<{ClassName}(many={self.many})>'.format(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -267,24 +267,23 @@ class TestValidatesDecorator:
     def test_validates_decorator(self):
         schema = ValidatesSchema()
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 41})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 41})
         assert 'foo' in errors
         assert errors['foo'][0] == 'The answer to life the universe and everything.'
 
-        schema.validate({'foo': 42})
+        errors = schema.validate({'foo': 42})
+        assert errors == {}
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 42}, {'foo': 43}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 42}, {'foo': 43}], many=True)
         assert 'foo' in errors[1]
         assert len(errors[1]['foo']) == 1
         assert errors[1]['foo'][0] == 'The answer to life the universe and everything.'
 
-        schema.validate([{'foo': 42}, {'foo': 42}], many=True)
+        errors = schema.validate([{'foo': 42}, {'foo': 42}], many=True)
+        assert errors == {}
 
-        schema.validate({})
+        errors = schema.validate({})
+        assert errors == {}
 
         with pytest.raises(ValidationError) as excinfo:
             schema.load({'foo': 41})
@@ -328,23 +327,17 @@ class TestValidatesDecorator:
 
         schema = Schema2()
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 42})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 42})
         assert 'foo' in errors
         assert len(errors['foo']) == 1
         assert 'Invalid value.' in errors['foo'][0]
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'bar': 3})
-        errors = excinfo.value.messages
+        errors = schema.validate({'bar': 3})
         assert 'bar' in errors
         assert len(errors['bar']) == 1
         assert 'Invalid value.' in errors['bar'][0]
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'bar': 1})
-        errors = excinfo.value.messages
+        errors = schema.validate({'bar': 1})
         assert 'bar' in errors
         assert len(errors['bar']) == 1
         assert errors['bar'][0] == 'Must be 2'
@@ -365,9 +358,7 @@ class TestValidatesSchemaDecorator:
             nested = fields.Nested(NestedSchema, required=True, many=True)
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'nested': [1]})
-        errors = excinfo.value.messages
+        errors = schema.validate({'nested': [1]})
         assert errors
         assert 'nested' in errors
         assert 0 in errors['nested']
@@ -398,22 +389,16 @@ class TestValidatesSchemaDecorator:
                     raise ValidationError('bar must not be negative', 'bar')
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 3})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 3})
         assert '_schema' in errors
         assert errors['_schema'][0] == 'Must be greater than 3'
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 4}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 4}], many=True)
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
         assert errors['_schema'][0] == 'Must provide at least 2 items'
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 4, 'bar': -1})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 4, 'bar': -1})
         assert 'bar' in errors
         assert len(errors['bar']) == 1
         assert errors['bar'][0] == 'bar must not be negative'
@@ -435,18 +420,14 @@ class TestValidatesSchemaDecorator:
                     raise ValidationError('bar must not be negative')
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 3, 'bar': -1})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 3, 'bar': -1})
         assert type(errors) is dict
         assert '_schema' in errors
         assert len(errors['_schema']) == 2
         assert 'Must be greater than 3' in errors['_schema']
         assert 'bar must not be negative' in errors['_schema']
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 3, 'bar': -1}, {'foo': 3}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 3, 'bar': -1}, {'foo': 3}], many=True)
         assert type(errors) is dict
         assert '_schema' in errors[0]
         assert len(errors[0]['_schema']) == 2
@@ -480,24 +461,18 @@ class TestValidatesSchemaDecorator:
                     check(original_data)
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 4, 'baz': 42})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 4, 'baz': 42})
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
         assert errors['_schema'][0] == {'code': 'invalid_field'}
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': '4'})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': '4'})
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
         assert errors['_schema'][0] == 'foo cannot be a string'
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 4, 'baz': 42}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 4, 'baz': 42}], many=True)
         assert '_schema' in errors
         assert len(errors['_schema']) == 1
         assert errors['_schema'][0] == {'code': 'invalid_field'}
@@ -516,9 +491,7 @@ class TestValidatesSchemaDecorator:
                         raise ValidationError('Unknown field name', key)
 
         schema = MySchema()
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 2, 'baz': 42})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 2, 'baz': 42})
         assert 'baz' in errors
         assert len(errors['baz']) == 1
         assert errors['baz'][0] == 'Unknown field name'
@@ -543,34 +516,24 @@ class TestValidatesSchemaDecorator:
 
         schema = MySchema()
         # check that schema errors still occur with no field errors
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 3, 'bar': 4})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 3, 'bar': 4})
         assert '_schema' in errors
         assert errors['_schema'][0] == 'Foo and bar must be equal.'
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 3, 'bar': 3}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 3, 'bar': 3}], many=True)
         assert '_schema' in errors
         assert errors['_schema'][0] == 'Must provide at least 2 items'
 
         # check that schema errors don't occur when field errors do
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 3, 'bar': 'not an int'})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 3, 'bar': 'not an int'})
         assert 'bar' in errors
         assert '_schema' not in errors
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate({'foo': 2, 'bar': 2})
-        errors = excinfo.value.messages
+        errors = schema.validate({'foo': 2, 'bar': 2})
         assert 'foo' in errors
         assert '_schema' not in errors
 
-        with pytest.raises(ValidationError) as excinfo:
-            schema.validate([{'foo': 3, 'bar': 'not an int'}], many=True)
-        errors = excinfo.value.messages
+        errors = schema.validate([{'foo': 3, 'bar': 'not an int'}], many=True)
         assert 'bar' in errors[0]
         assert '_schema' not in errors
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -65,14 +65,14 @@ def test_decorated_processors():
     make_item = lambda: {'value': 3}
     make_items = lambda: [make_item(), {'value': 5}]
 
-    item_dumped = schema.dump(make_item()).data
+    item_dumped = schema.dump(make_item())
     assert item_dumped == {'datum': {'value': 'TAG4'}}
-    item_loaded = schema.load(item_dumped).data
+    item_loaded = schema.load(item_dumped)
     assert item_loaded == make_item()
 
-    items_dumped = schema.dump(make_items(), many=True).data
+    items_dumped = schema.dump(make_items(), many=True)
     assert items_dumped == {'data': [{'value': 'TAG4'}, {'value': 'TAG6'}]}
-    items_loaded = schema.load(items_dumped, many=True).data
+    items_loaded = schema.load(items_dumped, many=True)
     assert items_loaded == make_items()
 
 class TestPassOriginal:
@@ -95,11 +95,11 @@ class TestPassOriginal:
 
         schema = MySchema()
         datum = {'foo': 42, 'sentinel': 24}
-        item_loaded = schema.load(datum).data
+        item_loaded = schema.load(datum)
         assert item_loaded['foo'] == 42
         assert item_loaded['_post_load'] == 24
 
-        item_dumped = schema.dump(datum).data
+        item_dumped = schema.dump(datum)
 
         assert item_dumped['foo'] == 42
         assert item_dumped['_post_dump'] == 24
@@ -113,7 +113,7 @@ class TestPassOriginal:
                 data['_post_load'] = input_data['post_load']
 
         schema = MySchema()
-        item_loaded = schema.load({'foo': 42, 'post_load': 24}).data
+        item_loaded = schema.load({'foo': 42, 'post_load': 24})
         assert item_loaded['foo'] == 42
         assert item_loaded['_post_load'] == 24
 
@@ -147,7 +147,7 @@ class TestPassOriginal:
 
         schema = MySchema()
         data = [{'foo': 42, 'sentinel': 24}, {'foo': 424, 'sentinel': 242}]
-        items_loaded = schema.load(data, many=True).data
+        items_loaded = schema.load(data, many=True)
         assert items_loaded == [
             {'foo': 42, '_post_load': 24},
             {'foo': 424, '_post_load': 242},
@@ -155,7 +155,7 @@ class TestPassOriginal:
         test_values = [e['_post_load'] for e in items_loaded]
         assert test_values == [24, 242]
 
-        items_dumped = schema.dump(data, many=True).data
+        items_dumped = schema.dump(data, many=True)
         assert items_dumped == [
             {'foo': 42, '_post_dump': 24},
             {'foo': 424, '_post_dump': 242},
@@ -164,10 +164,10 @@ class TestPassOriginal:
         # Also check load/dump of single item
 
         datum = {'foo': 42, 'sentinel': 24}
-        item_loaded = schema.load(datum, many=False).data
+        item_loaded = schema.load(datum, many=False)
         assert item_loaded == {'foo': 42, '_post_load': 24}
 
-        item_dumped = schema.dump(datum, many=False).data
+        item_dumped = schema.dump(datum, many=False)
         assert item_dumped == {'foo': 42, '_post_dump': 24}
 
 def test_decorated_processor_inheritance():
@@ -197,14 +197,14 @@ def test_decorated_processor_inheritance():
 
         deleted = None
 
-    parent_dumped = ParentSchema().dump({}).data
+    parent_dumped = ParentSchema().dump({})
     assert parent_dumped == {
         'inherited': 'inherited',
         'overridden': 'base',
         'deleted': 'retained'
     }
 
-    child_dumped = ChildSchema().dump({}).data
+    child_dumped = ChildSchema().dump({})
     assert child_dumped == {
         'inherited': 'inherited',
         'overridden': 'overridden'
@@ -223,7 +223,7 @@ def test_pre_dump_is_invoked_before_implicit_field_generation():
             # Removing generated_field from here drops it from the output
             fields = ('field', 'generated_field')
 
-    assert Foo().dump({"field": 5}).data == {'field': 5, 'generated_field': 7}
+    assert Foo().dump({"field": 5}) == {'field': 5, 'generated_field': 7}
 
 
 class ValidatesSchema(Schema):
@@ -650,9 +650,8 @@ def test_decorator_error_handling():
             raise ValidationError('postdumpmsg1', 'foo')
 
     def make_item(foo, bar):
-        data, errors = schema.load({'foo': foo, 'bar': bar})
+        data = schema.load({'foo': foo, 'bar': bar})
         assert data is not None
-        assert not errors
         return data
 
     schema = ExampleSchema()

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -773,8 +773,8 @@ class TestFieldDeserialization:
             foo = fields.Constant(42)
 
         sch = MySchema()
-        assert sch.load({'bar': 24}).data['foo'] == 42
-        assert sch.load({'foo': 24}).data['foo'] == 42
+        assert sch.load({'bar': 24})['foo'] == 42
+        assert sch.load({'foo': 24})['foo'] == 42
 
     def test_field_deserialization_with_user_validator_function(self):
         field = fields.String(validate=lambda s: s.lower() == 'valid')
@@ -877,13 +877,13 @@ class TestSchemaDeserialization:
 
     def test_deserialize_to_dict(self):
         user_dict = {'name': 'Monty', 'age': '42.3'}
-        result, errors = SimpleUserSchema().load(user_dict)
+        result = SimpleUserSchema().load(user_dict)
         assert result['name'] == 'Monty'
         assert_almost_equal(result['age'], 42.3)
 
     def test_deserialize_with_missing_values(self):
         user_dict = {'name': 'Monty'}
-        result, errs = SimpleUserSchema().load(user_dict)
+        result = SimpleUserSchema().load(user_dict)
         # 'age' is not included in result
         assert result == {'name': 'Monty'}
 
@@ -892,7 +892,7 @@ class TestSchemaDeserialization:
             {'name': 'Mick', 'age': '914'},
             {'name': 'Keith', 'age': '8442'}
         ]
-        result, errors = SimpleUserSchema(many=True).load(users_data)
+        result = SimpleUserSchema(many=True).load(users_data)
         assert isinstance(result, list)
         user = result[0]
         assert user['age'] == int(users_data[0]['age'])
@@ -900,8 +900,8 @@ class TestSchemaDeserialization:
     def test_exclude(self):
         schema = SimpleUserSchema(exclude=('age', ))
         result = schema.load({'name': 'Monty', 'age': 42})
-        assert 'name' in result.data
-        assert 'age' not in result.data
+        assert 'name' in result
+        assert 'age' not in result
 
     def test_nested_single_deserialization_to_dict(self):
         class SimpleBlogSerializer(Schema):
@@ -912,7 +912,7 @@ class TestSchemaDeserialization:
             'title': 'Gimme Shelter',
             'author': {'name': 'Mick', 'age': '914', 'email': 'mick@stones.com'}
         }
-        result, errors = SimpleBlogSerializer().load(blog_dict)
+        result = SimpleBlogSerializer().load(blog_dict)
         author = result['author']
         assert author['name'] == 'Mick'
         assert author['age'] == 914
@@ -930,7 +930,7 @@ class TestSchemaDeserialization:
                 {'name': 'Keith', 'age': '8442'}
             ]
         }
-        result, errors = SimpleBlogSerializer().load(blog_dict)
+        result = SimpleBlogSerializer().load(blog_dict)
         assert isinstance(result['authors'], list)
         author = result['authors'][0]
         assert author['name'] == 'Mick'
@@ -1002,8 +1002,7 @@ class TestSchemaDeserialization:
 
         sch = MainSchema()
         result = sch.load({'pk': '123', 'child': '456'})
-        assert len(result.errors) == 0
-        assert result.data['child']['pk'] == '456'
+        assert result['child']['pk'] == '456'
 
     def test_nested_only_basestring_with_list_data(self):
         class ANestedSchema(Schema):
@@ -1015,12 +1014,11 @@ class TestSchemaDeserialization:
 
         sch = MainSchema()
         result = sch.load({'pk': '123', 'children': ['456', '789']})
-        assert len(result.errors) == 0
-        assert result.data['children'][0]['pk'] == '456'
-        assert result.data['children'][1]['pk'] == '789'
+        assert result['children'][0]['pk'] == '456'
+        assert result['children'][1]['pk'] == '789'
 
     def test_none_deserialization(self):
-        result, errors = SimpleUserSchema().load(None)
+        result = SimpleUserSchema().load(None)
         assert result is None
 
     def test_nested_none_deserialization(self):
@@ -1032,8 +1030,7 @@ class TestSchemaDeserialization:
             'title': 'Gimme Shelter',
             'author': None
         }
-        result, errors = SimpleBlogSerializer().load(blog_dict)
-        assert not errors
+        result = SimpleBlogSerializer().load(blog_dict)
         assert result['author'] is None
         assert result['title'] == blog_dict['title']
 
@@ -1045,7 +1042,7 @@ class TestSchemaDeserialization:
             'username': 'foo@bar.com',
             'years': '42'
         }
-        result, errors = AliasingUserSerializer().load(data)
+        result = AliasingUserSerializer().load(data)
         assert result['email'] == 'foo@bar.com'
         assert result['age'] == 42
 
@@ -1055,10 +1052,10 @@ class TestSchemaDeserialization:
             foo = fields.Field(attribute='bar.baz')
 
         schema = MySchema()
-        dump_data, errors = schema.dump({'bar': {'baz': 42}})
+        dump_data = schema.dump({'bar': {'baz': 42}})
         assert dump_data == {'foo': 42}
 
-        load_data, errors = schema.load({'foo': 42})
+        load_data = schema.load({'foo': 42})
         assert load_data == {'bar': {'baz': 42}}
 
     def test_deserialize_with_attribute_param_error_returns_field_name_not_attribute_name(self):
@@ -1101,7 +1098,7 @@ class TestSchemaDeserialization:
             'UserName': 'foo@bar.com',
             'years': '42'
         }
-        result, errors = AliasingUserSerializer().load(data)
+        result = AliasingUserSerializer().load(data)
         assert result['name'] == 'Mick'
         assert result['email'] == 'foo@bar.com'
         assert 'years' not in result
@@ -1116,7 +1113,7 @@ class TestSchemaDeserialization:
             'years': '42',
             'nicknames': ['Your Majesty', 'Brenda']
         }
-        result, errors = AliasingUserSerializer().load(data)
+        result = AliasingUserSerializer().load(data)
         assert result['name'] == 'Mick'
         assert 'years' not in result
         assert 'nicknames' not in result
@@ -1128,7 +1125,7 @@ class TestSchemaDeserialization:
         data = {
             'name': 'Mick',
         }
-        result, errors = AliasingUserSerializer().load(data)
+        result = AliasingUserSerializer().load(data)
         assert result['name'] == 'Mick'
         assert result['years'] == 10
 
@@ -1139,7 +1136,7 @@ class TestSchemaDeserialization:
         data = {
             'name': 'Mick',
         }
-        result, errors = AliasingUserSerializer().load(data)
+        result = AliasingUserSerializer().load(data)
         assert result['name'] == 'Mick'
         assert result['years'] == 20
 
@@ -1150,8 +1147,7 @@ class TestSchemaDeserialization:
         data = {
             'name': 'Mick',
         }
-        result, errors = AliasingUserSerializer().load(data)
-        assert not errors
+        result = AliasingUserSerializer().load(data)
         assert result['name'] == 'Mick'
         assert result['years'] is None
 
@@ -1279,11 +1275,10 @@ class TestSchemaDeserialization:
             schema_args['partial'] = True
         else:
             load_args['partial'] = True
-        data, errors = MySchema(**schema_args).load({'foo': 3}, **load_args)
+        data = MySchema(**schema_args).load({'foo': 3}, **load_args)
 
         assert data['foo'] == 3
         assert 'bar' not in data
-        assert not errors
 
     def test_partial_fields_deserialization(self):
         class MySchema(Schema):
@@ -1298,17 +1293,15 @@ class TestSchemaDeserialization:
         assert 'bar' in errors
         assert 'baz' in errors
 
-        data, errors = MySchema().load({'foo': 3}, partial=('bar', 'baz'))
+        data = MySchema().load({'foo': 3}, partial=('bar', 'baz'))
         assert data['foo'] == 3
         assert 'bar' not in data
         assert 'baz' not in data
-        assert not errors
 
-        data, errors = MySchema(partial=True).load({'foo': 3}, partial=('bar', 'baz'))
+        data = MySchema(partial=True).load({'foo': 3}, partial=('bar', 'baz'))
         assert data['foo'] == 3
         assert 'bar' not in data
         assert 'baz' not in data
-        assert not errors
 
     def test_partial_fields_validation(self):
         class MySchema(Schema):
@@ -1322,11 +1315,9 @@ class TestSchemaDeserialization:
         assert 'bar' in errors
         assert 'baz' in errors
 
-        errors = MySchema().validate({'foo': 3}, partial=('bar', 'baz'))
-        assert not errors
+        MySchema().validate({'foo': 3}, partial=('bar', 'baz'))
 
-        errors = MySchema(partial=True).validate({'foo': 3}, partial=('bar', 'baz'))
-        assert not errors
+        MySchema(partial=True).validate({'foo': 3}, partial=('bar', 'baz'))
 
 
 validators_gen = (func for func in [lambda x: x <= 24, lambda x: 18 <= x])

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -804,9 +804,7 @@ class TestFieldDeserialization:
         class MySchema(Schema):
             foo = fields.Field(validate=validator)
 
-        with pytest.raises(ValidationError) as excinfo:
-            MySchema().validate({'foo': 42})
-        errors = excinfo.value.messages
+        errors = MySchema().validate({'foo': 42})
         assert errors['foo'] == ['err1', 'err2']
 
     def test_validator_must_return_false_to_raise_error(self):
@@ -944,9 +942,7 @@ class TestSchemaDeserialization:
             pet = fields.Nested(PetSchema(), allow_none=False)
 
         sch = OwnerSchema()
-        with pytest.raises(ValidationError) as excinfo:
-            sch.validate({'pet': None})
-        errors = excinfo.value.messages
+        errors = sch.validate({'pet': None})
         assert 'pet' in errors
         assert errors['pet'] == ['Field may not be null.']
 
@@ -958,9 +954,7 @@ class TestSchemaDeserialization:
             pets = fields.Nested(PetSchema(), allow_none=False, many=True)
 
         sch = StoreSchema()
-        with pytest.raises(ValidationError) as excinfo:
-            sch.validate({'pets': None})
-        errors = excinfo.value.messages
+        errors = sch.validate({'pets': None})
         assert 'pets' in errors
         assert errors['pets'] == ['Field may not be null.']
 
@@ -972,9 +966,7 @@ class TestSchemaDeserialization:
             pet = fields.Nested(PetSchema(), required=True)
 
         sch = OwnerSchema()
-        with pytest.raises(ValidationError) as excinfo:
-            sch.validate({})
-        errors = excinfo.value.messages
+        errors = sch.validate({})
         assert 'pet' in errors
         assert errors['pet'] == ['Missing data for required field.']
 
@@ -986,9 +978,7 @@ class TestSchemaDeserialization:
             pets = fields.Nested(PetSchema(), required=True, many=True)
 
         sch = StoreSchema()
-        with pytest.raises(ValidationError) as excinfo:
-            sch.validate({})
-        errors = excinfo.value.messages
+        errors = sch.validate({})
         assert 'pets' in errors
         assert errors['pets'] == ['Missing data for required field.']
 
@@ -1309,15 +1299,15 @@ class TestSchemaDeserialization:
             bar = fields.Field(required=True)
             baz = fields.Field(required=True)
 
-        with pytest.raises(ValidationError) as excinfo:
-            MySchema().validate({'foo': 3}, partial=tuple())
-        errors = excinfo.value.messages
+        errors = MySchema().validate({'foo': 3}, partial=tuple())
         assert 'bar' in errors
         assert 'baz' in errors
 
-        MySchema().validate({'foo': 3}, partial=('bar', 'baz'))
+        errors = MySchema().validate({'foo': 3}, partial=('bar', 'baz'))
+        assert errors == {}
 
-        MySchema(partial=True).validate({'foo': 3}, partial=('bar', 'baz'))
+        errors = MySchema(partial=True).validate({'foo': 3}, partial=('bar', 'baz'))
+        assert errors == {}
 
 
 validators_gen = (func for func in [lambda x: x <= 24, lambda x: 18 <= x])
@@ -1429,9 +1419,7 @@ class TestValidation:
 
         errors = Sch().validate({'lamb': False, 'equal': False})
         assert not errors
-        with pytest.raises(ValidationError) as excinfo:
-            Sch().validate({'lamb': True, 'equal': True})
-        errors = excinfo.value.messages
+        errors = Sch().validate({'lamb': True, 'equal': True})
         assert 'lamb' in errors
         assert errors['lamb'] == ['Invalid value.']
         assert 'equal' in errors

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1381,9 +1381,9 @@ class TestValidation:
 
             def get_name(self, val):
                 return val.upper()
-        assert MethodSerializer(strict=True).load({'name': 'joe'})
+        assert MethodSerializer().load({'name': 'joe'})
         with pytest.raises(ValidationError) as excinfo:
-            MethodSerializer(strict=True).load({'name': 'joseph'})
+            MethodSerializer().load({'name': 'joseph'})
 
         assert 'Invalid value.' in str(excinfo)
 
@@ -1451,24 +1451,13 @@ def test_required_message_can_be_changed(message):
     expected = [message] if isinstance(message, basestring) else message
     assert expected == errors['age']
 
-# Regression test for https://github.com/marshmallow-code/marshmallow/issues/261
-def test_deserialize_doesnt_raise_exception_if_strict_is_false_and_input_type_is_incorrect():
+
+def test_deserialize_raises_exception_if_input_type_is_incorrect():
     class MySchema(Schema):
         foo = fields.Field()
         bar = fields.Field()
     with pytest.raises(ValidationError) as excinfo:
         MySchema().load([])
-    errors = excinfo.value.messages
-    assert '_schema' in errors
-    assert errors['_schema'] == ['Invalid input type.']
-
-
-def test_deserialize_raises_exception_if_strict_is_true_and_input_type_is_incorrect():
-    class MySchema(Schema):
-        foo = fields.Field()
-        bar = fields.Field()
-    with pytest.raises(ValidationError) as excinfo:
-        MySchema(strict=True).load([])
     assert 'Invalid input type.' in str(excinfo)
     exc = excinfo.value
     assert exc.field_names == ['_schema']

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -50,7 +50,7 @@ class TestField:
             name = MyField()
 
         result = MySchema().load({'name': 'Monty', 'foo': 42})
-        assert result.data == {'name': 'Monty'}
+        assert result == {'name': 'Monty'}
 
     def test_custom_field_receives_load_from_if_set(self, user):
         class MyField(fields.Field):
@@ -63,7 +63,7 @@ class TestField:
             Name = MyField(load_from='name')
 
         result = MySchema().load({'name': 'Monty', 'foo': 42})
-        assert result.data == {'Name': 'Monty'}
+        assert result == {'Name': 'Monty'}
 
     def test_custom_field_follows_dump_to_if_set(self, user):
         class MyField(fields.Field):
@@ -76,7 +76,7 @@ class TestField:
             name = MyField(dump_to='_NaMe')
 
         result = MySchema().dump({'name': 'Monty', 'foo': 42})
-        assert result.data == {'_NaMe': 'Monty'}
+        assert result == {'_NaMe': 'Monty'}
 
     def test_number_fields_prohbits_boolean(self):
         strict_field = fields.Float()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -5,32 +5,8 @@ import datetime as dt
 import pytest
 
 from marshmallow import fields, Schema
-from marshmallow.exceptions import ValidationError
 
-from tests.base import (
-    User,
-    UserSchema,
-)
-
-class TestStrict:
-
-    class StrictUserSchema(UserSchema):
-        class Meta:
-            strict = True
-
-    def test_strict_meta_option(self):
-        with pytest.raises(ValidationError):
-            self.StrictUserSchema().load({'email': 'foo.com'})
-
-    def test_strict_meta_option_is_inherited(self):
-        class StrictUserSchema(UserSchema):
-            class Meta:
-                strict = True
-
-        class ChildStrictSchema(self.StrictUserSchema):
-            pass
-        with pytest.raises(ValidationError):
-            ChildStrictSchema().load({'email': 'foo.com'})
+from tests.base import User
 
 
 class TestUnordered:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -22,14 +22,14 @@ class TestUnordered:
         schema = self.UnorderedSchema()
         u = User('steve', email='steve@steve.steve')
         result = schema.dump(u)
-        assert not isinstance(result.data, OrderedDict)
-        assert type(result.data) is dict
+        assert not isinstance(result, OrderedDict)
+        assert type(result) is dict
 
     def test_unordered_load_returns_dict(self):
         schema = self.UnorderedSchema()
         result = schema.load({'name': 'steve', 'email': 'steve@steve.steve'})
-        assert not isinstance(result.data, OrderedDict)
-        assert type(result.data) is dict
+        assert not isinstance(result, OrderedDict)
+        assert type(result) is dict
 
 
 class KeepOrder(Schema):
@@ -78,8 +78,7 @@ class TestFieldOrdering:
         assert schema.opts.ordered is True
         assert schema.dict_class == OrderedDict
 
-        data, errors = schema.dump(user)
-        assert not errors
+        data = schema.dump(user)
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
@@ -101,27 +100,26 @@ class TestFieldOrdering:
 
     def test_declared_field_order_is_maintained_on_dump(self, user):
         ser = KeepOrder()
-        data, errs = ser.dump(user)
+        data = ser.dump(user)
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
     def test_declared_field_order_is_maintained_on_load(self, serialized_user):
         schema = KeepOrder()
-        data, errs = schema.load(serialized_user.data)
-        assert not errs
+        data = schema.load(serialized_user)
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
     def test_nested_field_order_with_only_arg_is_maintained_on_dump(self, user):
         schema = OrderedNestedOnly()
-        data, errs = schema.dump({'user': user})
+        data = schema.dump({'user': user})
         user_data = data['user']
         keys = list(user_data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
     def test_nested_field_order_with_only_arg_is_maintained_on_load(self):
         schema = OrderedNestedOnly()
-        data, errs = schema.load({'user': {
+        data = schema.load({'user': {
             'name': 'Foo',
             'email': 'Foo@bar.com',
             'age': 42,
@@ -142,21 +140,20 @@ class TestFieldOrdering:
             user = fields.Nested(KeepOrder, exclude=('birthdate', ))
 
         ser = HasNestedExclude()
-        data, errs = ser.dump({'user': user})
+        data = ser.dump({'user': user})
         user_data = data['user']
         keys = list(user_data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage']
 
     def test_meta_fields_order_is_maintained_on_dump(self, user):
         ser = OrderedMetaSchema()
-        data, errs = ser.dump(user)
+        data = ser.dump(user)
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
     def test_meta_fields_order_is_maintained_on_load(self, serialized_user):
         schema = OrderedMetaSchema()
-        data, errs = schema.load(serialized_user.data)
-        assert not errs
+        data = schema.load(serialized_user)
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
@@ -174,7 +171,7 @@ class TestIncludeOption:
         s = self.AddFieldsSchema()
         in_data = {'name': 'Steve', 'from': 'Oskosh'}
         result = s.load({'name': 'Steve', 'from': 'Oskosh'})
-        assert result.data == in_data
+        assert result == in_data
 
     def test_ordered_included(self):
         class AddFieldsOrdered(Schema):
@@ -197,7 +194,7 @@ class TestIncludeOption:
         assert list(AddFieldsOrdered._declared_fields.keys()) == expected_fields
 
         result = s.load(in_data)
-        assert list(result.data.keys()) == expected_fields
+        assert list(result.keys()) == expected_fields
 
     def test_added_fields_are_inherited(self):
 

--- a/tests/test_py3/test_utils.py
+++ b/tests/test_py3/test_utils.py
@@ -11,4 +11,4 @@ def test_function_field_using_type_annotation():
 
     data = {'name': 'Bruce Wayne', 'friends': 'Clark;Alfred;Robin'}
     result = MySchema().load(data)
-    assert result.data == {'friends': ['Clark', 'Alfred', 'Robin']}
+    assert result == {'friends': ['Clark', 'Alfred', 'Robin']}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -55,16 +55,16 @@ def test_two_way_nesting():
 
     a_serialized = ASchema().dump(a_obj)
     b_serialized = BSchema().dump(b_obj)
-    assert a_serialized.data['b']['id'] == b_obj.id
-    assert b_serialized.data['a']['id'] == a_obj.id
+    assert a_serialized['b']['id'] == b_obj.id
+    assert b_serialized['a']['id'] == a_obj.id
 
 def test_nesting_with_class_name_many():
     c_obj = C(1, bs=[B(2), B(3), B(4)])
 
     c_serialized = CSchema().dump(c_obj)
 
-    assert len(c_serialized.data['bs']) == len(c_obj.bs)
-    assert c_serialized.data['bs'][0]['id'] == c_obj.bs[0].id
+    assert len(c_serialized['bs']) == len(c_obj.bs)
+    assert c_serialized['bs'][0]['id'] == c_obj.bs[0].id
 
 def test_invalid_class_name_in_nested_field_raises_error(user):
 
@@ -114,9 +114,9 @@ def test_can_use_full_module_path_to_class():
 
     # Note: The arguments here don't matter. What matters is that no
     # error is raised
-    assert sch.dump({'foo': {'_id': 42}}).data
+    assert sch.dump({'foo': {'_id': 42}})
 
     class Schema2(Schema):
         foo = fields.Nested('tests.test_registry.FooSerializer')
     sch = Schema2()
-    assert sch.dump({'foo': {'_id': 42}}).data
+    assert sch.dump({'foo': {'_id': 42}})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -682,20 +682,6 @@ def test_invalid_dict_but_okay():
     u = User('Joe', various_data='baddict')
     UserSchema().dump(u)
 
-def test_strict_is_deprecated():
-    with pytest.deprecated_call():
-        class StrictUserSchema(Schema):
-            name = fields.String()
-
-            class Meta:
-                strict = False
-
-    class UserSchema(Schema):
-        name = fields.String()
-
-    with pytest.deprecated_call():
-        UserSchema(strict=True)
-
 def test_json_module_is_deprecated():
     with pytest.deprecated_call():
         class UserJSONSchema(Schema):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -695,7 +695,7 @@ def test_invalid_dict_but_okay():
     UserSchema().dump(u)
 
 def test_strict_is_deprecated():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         class StrictUserSchema(Schema):
             name = fields.String()
 
@@ -705,11 +705,11 @@ def test_strict_is_deprecated():
     class UserSchema(Schema):
         name = fields.String()
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         UserSchema(strict=True)
 
 def test_json_module_is_deprecated():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         class UserJSONSchema(Schema):
             name = fields.String()
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -458,7 +458,7 @@ class TestFieldSerialization:
             'name': 'Richard',
             'years': 11
         }
-        result, errors = DumpToSchema().dump(data)
+        result = DumpToSchema().dump(data)
         assert result == {
             'NamE': 'Richard',
             'YearS': 11
@@ -474,7 +474,7 @@ class TestFieldSerialization:
             'uname': 'mick_the_awesome',
             'le_wild_age': 999
         }
-        result, errors = ConfusedDumpToAndAttributeSerializer().dump(data)
+        result = ConfusedDumpToAndAttributeSerializer().dump(data)
 
         assert result == {
             'FullName': 'Mick',
@@ -546,7 +546,7 @@ class TestFieldSerialization:
         class MySchema(Schema):
             greeting = fields.FormattedString('Hello {name}')
         user = User(name='Monty')
-        assert MySchema().dump(user).data['greeting'] == 'Hello Monty'
+        assert MySchema().dump(user)['greeting'] == 'Hello Monty'
 
     def test_string_field_default_to_empty_string(self, user):
         field = fields.String(default='')
@@ -792,15 +792,15 @@ class TestFieldSerialization:
             foo = fields.Constant(42)
 
         sch = MySchema()
-        assert sch.dump({'bar': 24}).data['foo'] == 42
-        assert sch.dump({'foo': 24}).data['foo'] == 42
+        assert sch.dump({'bar': 24})['foo'] == 42
+        assert sch.dump({'foo': 24})['foo'] == 42
 
     def test_constant_field_serialize_when_omitted(self):
         class MiniUserSchema(Schema):
             name = fields.Constant('bill')
 
         s = MiniUserSchema()
-        assert s.dump({}).data['name'] == 'bill'
+        assert s.dump({})['name'] == 'bill'
 
     @pytest.mark.parametrize('FieldClass', ALL_FIELDS)
     def test_all_fields_serialize_none_to_none(self, FieldClass):
@@ -835,8 +835,8 @@ def test_serializing_named_tuple_with_meta():
             fields = ('x', 'y')
 
     serialized = PointSerializer().dump(p)
-    assert serialized.data['x'] == 4
-    assert serialized.data['y'] == 2
+    assert serialized['x'] == 4
+    assert serialized['y'] == 2
 
 
 def test_serializing_slice():
@@ -846,5 +846,5 @@ def test_serializing_slice():
     class ValueSchema(Schema):
         value = fields.Int()
 
-    serialized = ValueSchema(many=True).dump(slice).data
+    serialized = ValueSchema(many=True).dump(slice)
     assert serialized == values


### PR DESCRIPTION
I started to work on https://github.com/marshmallow-code/marshmallow/issues/377 (_Strict Schema Validation should be enabled by default_).

This deprecates `strict`. A `ValidationError` is raised every time an error is encountered.

Note that this does not implement https://github.com/marshmallow-code/marshmallow/issues/598 (_Return deserialized data when strict=True_), and dump/load still returns data and errors.

The error in the tests is due to https://github.com/marshmallow-code/marshmallow/pull/710. I'll rebase this branch when this issue is fixed in `dev` branch.

Feedback welcome.