### PR TITLE
Don't validate Email and URL fields on serialization

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1228,18 +1228,7 @@ class Dict(Field):
         return result
 
 
-class ValidatedField(Field):
-    """A field that validates input on serialization."""
-
-    def _validated(self, value):
-        raise NotImplementedError('Must implement _validated method')
-
-    def _serialize(self, value, *args, **kwargs):
-        ret = super(ValidatedField, self)._serialize(value, *args, **kwargs)
-        return self._validated(ret)
-
-
-class Url(ValidatedField, String):
+class Url(String):
     """A validated URL field. Validation occurs during both serialization and
     deserialization.
 
@@ -1272,7 +1261,7 @@ class Url(ValidatedField, String):
         )(value)
 
 
-class Email(ValidatedField, String):
+class Email(String):
     """A validated email field. Validation occurs during both serialization and
     deserialization.
 

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -84,32 +84,32 @@ class TestMarshaller:
 
     def test_stores_indices_of_errors_when_many_equals_true(self, marshal):
         users = [
-            {'email': 'bar@example.com'},
-            {'email': 'foobar'},
-            {'email': 'invalid'},
+            {'age': 42},
+            {'age': 'dummy'},
+            {'age': '__dummy'},
         ]
         try:
-            marshal(users, {'email': fields.Email()}, many=True)
+            marshal(users, {'age': fields.Int()}, many=True, index_errors=True)
         except ValidationError:
             pass
         # 2nd and 3rd elements have an error
         assert 1 in marshal.errors
         assert 2 in marshal.errors
-        assert 'email' in marshal.errors[1]
-        assert 'email' in marshal.errors[2]
+        assert 'age' in marshal.errors[1]
+        assert 'age' in marshal.errors[2]
 
     def test_doesnt_store_errors_when_index_errors_equals_false(self, marshal):
         users = [
-            {'email': 'bar@example.com'},
-            {'email': 'foobar'},
-            {'email': 'invalid'},
+            {'age': 42},
+            {'age': 'dummy'},
+            {'age': '__dummy'},
         ]
         try:
-            marshal(users, {'email': fields.Email()}, many=True, index_errors=False)
+            marshal(users, {'age': fields.Int()}, many=True, index_errors=False)
         except ValidationError:
             pass
         assert 1 not in marshal.errors
-        assert 'email' in marshal.errors
+        assert 'age' in marshal.errors
 
 class TestUnmarshaller:
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -355,12 +355,6 @@ class TestFieldSerialization:
         with pytest.raises(ValueError):
             fields.Function("uncallable")
 
-    def test_email_field_validates(self, user):
-        user.email = 'bademail'
-        field = fields.Email()
-        with pytest.raises(ValidationError):
-            field.serialize('email', user)
-
     def test_email_field_serialize_none(self, user):
         user.email = None
         field = fields.Email()
@@ -413,12 +407,6 @@ class TestFieldSerialization:
         user.homepage = None
         field = fields.Url()
         assert field.serialize('homepage', user) is None
-
-    def test_url_field_validates(self, user):
-        user.homepage = 'badhomepage'
-        field = fields.URL()
-        with pytest.raises(ValidationError):
-            field.serialize('homepage', user)
 
     def test_method_field_with_method_missing(self):
         class BadSerializer(Schema):


### PR DESCRIPTION
Closes #608.

`email` was used to generate dump errors in tests not directly related to `Email` field. I replaced it with `age` except when using `age` broke the test (because the schema also has an `is_old` Method field depending on `age`), in which case I used `balance`.