### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+For the marshmallow code of conduct, see:
+    https://marshmallow.readthedocs.io/en/latest/code_of_conduct.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,10 +1,16 @@
 Contributing Guidelines
 =======================
 
-Questions, Feature Requests, Bug Reports, and Feedback. . .
------------------------------------------------------------
+So you're interested in contributing to marshmallow or `one of our associated
+projects <https://github.com/marshmallow-code>`__? That's awesome! We
+welcome contributions from anyone willing to work in good faith with
+other contributors and the community (see also our
+:ref:`code-of-conduct`).
 
-. . .should all be reported on the `Github Issue Tracker`_ .
+Questions, Feature Requests, Bug Reports, and Feedback…
+-------------------------------------------------------
+
+…should all be reported on the `Github Issue Tracker`_ .
 
 .. _`Github Issue Tracker`: https://github.com/marshmallow-code/marshmallow/issues?state=open
 
@@ -12,7 +18,7 @@ Ways to Contribute
 ------------------
 
 - Comment on some of marshmallow's `open issues <https://github.com/marshmallow-code/marshmallow/issues>`_ (especially those `labeled "feedback welcome" <https://github.com/marshmallow-code/marshmallow/issues?q=is%3Aopen+is%3Aissue+label%3A%22feedback+welcome%22>`_). Share a solution or workaround. Make a suggestion for how a feature can be made better. Opinions are welcome!
-- Improve `the docs <https://marshmallow.readthedocs.io>`_. For simple edits, click the ReadTheDocs menu button in the bottom-right corner of the page and click "Edit".  See the :ref:`Documentation <contributing_documentation>` section of this page if you want to build the docs locally.
+- Improve `the docs <https://marshmallow.readthedocs.io>`_. For straightforward edits, click the ReadTheDocs menu button in the bottom-right corner of the page and click "Edit".  See the :ref:`Documentation <contributing_documentation>` section of this page if you want to build the docs locally.
 - If you think you've found a bug, `open an issue <https://github.com/marshmallow-code/marshmallow/issues>`_.
 - Contribute an :ref:`example usage <contributing_examples>` of marshmallow.
 - Send a PR for an open issue (especially one `labeled "please help" <https://github.com/marshmallow-code/marshmallow/issues?q=is%3Aissue+is%3Aopen+label%3A%22please+help%22>`_). The next section details how to contribute code.

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -1,0 +1,276 @@
+.. _code-of-conduct:
+
+Code of Conduct
+===============
+
+This code of conduct applies to the marshmallow project and all associated
+projects in the `marshmallow-code <https://github.com/marshmallow-code>`__
+organization.
+
+
+.. _coc-when-something-happens:
+
+When Something Happens
+----------------------
+
+If you see a Code of Conduct violation, follow these steps:
+
+1. Let the person know that what they did is not appropriate and ask
+   them to stop and/or edit their message(s) or commits.
+2. That person should immediately stop the behavior and correct the
+   issue.
+3. If this doesn’t happen, or if you're uncomfortable speaking up,
+   :ref:`contact the maintainers <coc-contacting-maintainers>`.
+4. As soon as possible, a maintainer will look into the issue, and take
+   :ref:`further action (see below) <coc-further-enforcement>`, starting with
+   a warning, then temporary block, then long-term repo or organization
+   ban.
+
+When reporting, please include any relevant details, links, screenshots,
+context, or other information that may be used to better understand and
+resolve the situation.
+
+**The maintainer team will prioritize the well-being and comfort of the
+recipients of the violation over the comfort of the violator.** See
+:ref:`some examples below <coc-enforcement-examples>`.
+
+Our Pledge
+----------
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers of this project pledge to making
+participation in our community a harassment-free experience for
+everyone, regardless of age, body size, disability, ethnicity, gender
+identity and expression, level of experience, technical preferences,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+Our Standards
+-------------
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+-  Using welcoming and inclusive language.
+-  Being respectful of differing viewpoints and experiences.
+-  Gracefully accepting constructive feedback.
+-  Focusing on what is best for the community.
+-  Showing empathy and kindness towards other community members.
+-  Encouraging and raising up your peers in the project so you can all
+   bask in hacks and glory.
+
+Examples of unacceptable behavior by participants include:
+
+-  The use of sexualized language or imagery and unwelcome sexual
+   attention or advances, including when simulated online. The only
+   exception to sexual topics is channels/spaces specifically for topics
+   of sexual identity.
+-  Casual mention of slavery or indentured servitude and/or false
+   comparisons of one's occupation or situation to slavery. Please
+   consider using or asking about alternate terminology when referring
+   to such metaphors in technology.
+-  Making light of/making mocking comments about trigger warnings and
+   content warnings.
+-  Trolling, insulting/derogatory comments, and personal or political
+   attacks.
+-  Public or private harassment, deliberate intimidation, or threats.
+-  Publishing others' private information, such as a physical or
+   electronic address, without explicit permission. This includes any
+   sort of "outing" of any aspect of someone's identity without their
+   consent.
+-  Publishing private screenshots or quotes of interactions in the
+   context of this project without all quoted users' *explicit* consent.
+-  Publishing of private communication that doesn't have to do with
+   reporting harrassment.
+-  Any of the above even when `presented as "ironic" or
+   "joking" <https://en.wikipedia.org/wiki/Hipster_racism>`__.
+-  Any attempt to present "reverse-ism" versions of the above as
+   violations. Examples of reverse-isms are "reverse racism", "reverse
+   sexism", "heterophobia", and "cisphobia".
+-  Unsolicited explanations under the assumption that someone doesn't
+   already know it. Ask before you teach! Don't assume what people's
+   knowledge gaps are.
+-  `Feigning or exaggerating
+   surprise <https://www.recurse.com/manual#no-feigned-surprise>`__ when
+   someone admits to not knowing something.
+-  "`Well-actuallies <https://www.recurse.com/manual#no-well-actuallys>`__"
+-  Other conduct which could reasonably be considered inappropriate in a
+   professional or community setting.
+
+Scope
+-----
+
+This Code of Conduct applies both within spaces involving this project
+and in other spaces involving community members. This includes the
+repository, its Pull Requests and Issue tracker, its Twitter community,
+private email communications in the context of the project, and any
+events where members of the project are participating, as well as
+adjacent communities and venues affecting the project's members.
+
+Depending on the violation, the maintainers may decide that violations
+of this code of conduct that have happened outside of the scope of the
+community may deem an individual unwelcome, and take appropriate action
+to maintain the comfort and safety of its members.
+
+.. _coc-other-community-standards:
+
+Other Community Standards
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As a project on GitHub, this project is additionally covered by the
+`GitHub Community
+Guidelines <https://help.github.com/articles/github-community-guidelines/>`__.
+
+Enforcement of those guidelines after violations overlapping with the
+above are the responsibility of the entities, and enforcement may happen
+in any or all of the services/communities.
+
+Maintainer Enforcement Process
+------------------------------
+
+Once the maintainers get involved, they will follow a documented series
+of steps and do their best to preserve the well-being of project
+members. This section covers actual concrete steps.
+
+
+.. _coc-contacting-maintainers:
+
+Contacting Maintainers
+~~~~~~~~~~~~~~~~~~~~~~
+
+As a small and young project, we don't yet have a Code of Conduct
+enforcement team. Hopefully that will be addressed as we grow, but for
+now, any issues should be addressed to `Steven Loria
+<https://github.com/sloria>`__, via `email <mailto:sloria1@gmail.com>`__
+or any other medium that you feel comfortable with. Using words like
+"marshmallow code of conduct" in your subject will help make sure your
+message is noticed quickly.
+
+
+.. _coc-further-enforcement:
+
+Further Enforcement
+~~~~~~~~~~~~~~~~~~~
+
+If you've already followed the :ref:`initial enforcement steps
+<coc-when-something-happens>`, these are the steps maintainers will
+take for further enforcement, as needed:
+
+1. Repeat the request to stop.
+2. If the person doubles down, they will be given an official warning. The PR or Issue
+   may be locked.
+3. If the behavior continues or is repeated later, the person will be
+   blocked from participating for 24 hours.
+4. If the behavior continues or is repeated after the temporary block, a
+   long-term (6-12mo) ban will be used.
+5. If after this the behavior still continues, a permanent ban may be
+   enforced.
+
+On top of this, maintainers may remove any offending messages, images,
+contributions, etc, as they deem necessary.
+
+Maintainers reserve full rights to skip any of these steps, at their
+discretion, if the violation is considered to be a serious and/or
+immediate threat to the health and well-being of members of the
+community. These include any threats, serious physical or verbal
+attacks, and other such behavior that would be completely unacceptable
+in any social setting that puts our members at risk.
+
+Members expelled from events or venues with any sort of paid attendance
+will not be refunded.
+
+Who Watches the Watchers?
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maintainers and other leaders who do not follow or enforce the Code of
+Conduct in good faith may face temporary or permanent repercussions as
+determined by other members of the project's leadership. These may
+include anything from removal from the maintainer team to a permanent
+ban from the community.
+
+Additionally, as a project hosted on GitHub, :ref:`their Code of
+Conduct may be applied against maintainers of this project
+<coc-other-community-standards>`, externally of this project's
+procedures.
+
+
+.. _coc-enforcement-examples:
+
+Enforcement Examples
+--------------------
+
+The Best Case
+~~~~~~~~~~~~~
+
+The vast majority of situations work out like this. This interaction is
+common, and generally positive.
+
+    Alex: "Yeah I used X and it was really crazy!"
+
+    Patt (not a maintainer): "Hey, could you not use that word? What
+    about 'ridiculous' instead?"
+
+    Alex: "oh sorry, sure." -> edits old comment to say "it was really
+    confusing!"
+
+The Maintainer Case
+~~~~~~~~~~~~~~~~~~~
+
+Sometimes, though, you need to get maintainers involved. Maintainers
+will do their best to resolve conflicts, but people who were harmed by
+something **will take priority**.
+
+    Patt: "Honestly, sometimes I just really hate using $library and
+    anyone who uses it probably sucks at their job."
+
+    Alex: "Whoa there, could you dial it back a bit? There's a CoC thing
+    about attacking folks' tech use like that."
+
+    Patt: "I'm not attacking anyone, what's your problem?"
+
+    Alex: "@maintainers hey uh. Can someone look at this issue? Patt is
+    getting a bit aggro. I tried to nudge them about it, but nope."
+
+    KeeperOfCommitBits: (on issue) "Hey Patt, maintainer here. Could you
+    tone it down? This sort of attack is really not okay in this space."
+
+    Patt: "Leave me alone I haven't said anything bad wtf is wrong with
+    you."
+
+    KeeperOfCommitBits: (deletes user's comment), "@patt I mean it.
+    Please refer to the CoC over at (URL to this CoC) if you have
+    questions, but you can consider this an actual warning. I'd
+    appreciate it if you reworded your messages in this thread, since
+    they made folks there uncomfortable. Let's try and be kind, yeah?"
+
+    Patt: "@keeperofbits Okay sorry. I'm just frustrated and I'm kinda
+    burnt out and I guess I got carried away. I'll DM Alex a note
+    apologizing and edit my messages. Sorry for the trouble."
+
+    KeeperOfCommitBits: "@patt Thanks for that. I hear you on the
+    stress. Burnout sucks :/. Have a good one!"
+
+The Nope Case
+~~~~~~~~~~~~~
+
+    PepeTheFrog🐸: "Hi, I am a literal actual nazi and I think white
+    supremacists are quite fashionable."
+
+    Patt: "NOOOOPE. OH NOPE NOPE."
+
+    Alex: "JFC NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
+
+    KeeperOfCommitBits: "👀 Nope. NOPE NOPE NOPE. 🔥"
+
+    PepeTheFrog🐸 has been banned from all organization or user
+    repositories belonging to KeeperOfCommitBits.
+
+Attribution
+-----------
+
+This Code of Conduct is based on `Trio's Code of Conduct <https://trio.readthedocs.io/en/latest/code-of-conduct.html>`_, which is based on the
+`WeAllJS Code of Conduct <https://wealljs.org/code-of-conduct>`__, which
+is itself based on `Contributor
+Covenant <http://contributor-covenant.org>`__, version 1.4, available at
+http://contributor-covenant.org/version/1/4, and the LGBTQ in Technology
+Slack `Code of Conduct <http://lgbtq.technology/coc.html>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,5 @@ Project Info
     license
     authors
     contributing
+    code_of_conduct
     kudos


### PR DESCRIPTION
Add Code of conduct based on Trio's COC, which is based on the
WeAllJS COC, which is excellent. This COC will apply to all
marshmallow-code projects.

Attn people with commit bits, @deckar01 @lafrech : For now, I will take lead on enforcement when necessary. I encourage you to also take part as you see fit.