### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ htmlcov
 .tox
 nosetests.xml
 .cache
+testresults.xml
+coverage.xml
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,24 @@ before_install:
   - pip install -U pip
   # Workaround for travis issue: https://github.com/marshmallow-code/marshmallow/issues/681
   - pip install -U six
-
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
+  
 install:
   - pip install -U .[reco]
   - pip install -U -r dev-requirements.txt
+  - pip install pytest-cov
 
-script: invoke test
+script: invoke test --ci
+
+after_script:
+  - if [[ "${TRAVIS_PYTHON_VERSION}" = "3.6" ]] ; then
+      testspace [Python-${TRAVIS_PYTHON_VERSION}]testresults.xml{tests} coverage.xml;
+    else
+      testspace [Python-${TRAVIS_PYTHON_VERSION}]testresults.xml{tests};
+    fi
+ 
 jobs:
   include:
   - stage: PyPI Release

--- a/tasks.py
+++ b/tasks.py
@@ -9,7 +9,7 @@ docs_dir = 'docs'
 build_dir = os.path.join(docs_dir, '_build')
 
 @task
-def test(ctx, watch=False, last_failing=False):
+def test(ctx, watch=False, last_failing=False, ci=False):
     """Run the tests.
 
     Note: --watch requires pytest-xdist to be installed.
@@ -17,6 +17,10 @@ def test(ctx, watch=False, last_failing=False):
     import pytest
     flake(ctx)
     args = []
+    if ci:
+        args.append('--junit-xml=testresults.xml')
+        args.append('--cov=marshmallow')
+        args.append('--cov-report=xml')
     if watch:
         args.append('-f')
     if last_failing:


### PR DESCRIPTION
Hi, `marshmallow` team. We’ve made a few minor changes to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/).
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:marshmallow from our fork.

A few of the **benefits** for your Contributors:
 * Move beyond the flat, endless console output. Results in Testspace mirror your matrix jobs, test folders, suites, and cases hierarchy.
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

And for Owners:
 * Monitor the status of all your repositories, their local branches, and pull requests from a single dashboard.
 * View historical tracking of all your important metrics; test case and coverage growth, static analysis issues, custom metrics, etc.

[Read more about our open source approach...](https://blog.testspace.com/testspace-and-open-source/)

----

**Want to Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users
