### PR TITLE
Merge load_from and dump_to into data_key

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -371,50 +371,35 @@ By default, `Schemas` will marshal the object attributes that are identical to t
     #  'date_created': '2014-08-17T14:58:57.600623+00:00'}
 
 
-Specifying Deserialization Keys
--------------------------------
+Specifying Serializarion/Deserialization Keys
+---------------------------------------------
 
-By default `Schemas` will unmarshal an input dictionary to an output dictionary whose keys are identical to the field names.  However, if you are consuming data that does not exactly match your schema, you can specify additional keys to load values by passing the `load_from` argument.
+By default `Schemas` will marshal/unmarshal an input dictionary from/to an output dictionary whose keys are identical to the field names.  However, if you are producing/consuming data that does not exactly match your schema, you can specify additional keys to dump/load values by passing the `data_key` argument.
 
 .. code-block:: python
-    :emphasize-lines: 2,3,11,12
+    :emphasize-lines: 3,9,13,17,21
 
     class UserSchema(Schema):
         name = fields.String()
-        email = fields.Email(load_from='emailAddress')
+        email = fields.Email(data_key='emailAddress')
 
-    data = {
-        'name': 'Mike',
-        'emailAddress': 'foo@bar.com'
-    }
     s = UserSchema()
-    result = s.load(data)
-    #{'name': u'Mike',
-    # 'email': 'foo@bar.com'}
-
-.. _meta_options:
-
-
-Specifying Serialization Keys
--------------------------------
-
-If you want to marshal a field to a different key than the field name you can use `dump_to`, which is analogous to `load_from`.
-
-.. code-block:: python
-    :emphasize-lines: 2,3,11,12
-
-    class UserSchema(Schema):
-        name = fields.String(dump_to='TheName')
-        email = fields.Email(load_from='CamelCasedEmail', dump_to='CamelCasedEmail')
 
     data = {
         'name': 'Mike',
         'email': 'foo@bar.com'
     }
-    s = UserSchema()
     result = s.dump(data)
-    #{'TheName': u'Mike',
-    # 'CamelCasedEmail': 'foo@bar.com'}
+    #{'name': u'Mike',
+    # 'emailAddress': 'foo@bar.com'}
+
+    data = {
+        'name': 'Mike',
+        'emailAddress': 'foo@bar.com'
+    }
+    result = s.load(data)
+    #{'name': u'Mike',
+    # 'email': 'foo@bar.com'}
 
 
 Refactoring: Implicit Field Creation

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -417,10 +417,24 @@ more consistent with the other fields and improves serialization
 performance.
 
 
-Field name is not checked when ``load_from`` is specified
-*********************************************************
+``load_from`` and ``dump_to`` are merged into ``data_key``
+**********************************************************
 
-When ``load_from`` is specified on a field, only ``load_from`` is checked in the input data. The field name is no longer checked.
+The same key is used for serialization and deserialization.
+
+.. code-block:: python
+
+    # 2.x
+    class UserSchema(Schema):
+        email = fields.Email(load_from='CamelCasedEmail', dump_to='CamelCasedEmail')
+
+    # 3.x
+    class UserSchema(Schema):
+        email = fields.Email(data_key='CamelCasedEmail')
+
+It is not possible to specify a different key for serialization and deserialization. This use case can be covered by using two different `Schema`.
+
+Also, when ``data_key`` is specified on a field, only ``data_key`` is checked in the input data. In marshmallow 2.x the field name is checked if ``load_from`` is missing from the input data.
 
 
 Upgrading to 2.3

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -62,10 +62,10 @@ class Field(FieldABC):
     :param default: If set, this value will be used during serialization if the input value
         is missing. If not set, the field will be excluded from the serialized output if the
         input value is missing. May be a value or a callable.
-    :param str attribute: The name of the attribute to get the value from. If
-        `None`, assumes the attribute has the same name as the field.
-    :param str load_from: Key to look for when deserializing.
-    :param str dump_to: Field name to use as a key when serializing.
+    :param str attribute: The name of the attribute to get the value from when serializing.
+        If `None`, assumes the attribute has the same name as the field.
+    :param str data_key: The name of the key to get the value from when deserializing.
+        If `None`, assumes the key has the same name as the field.
     :param callable validate: Validator or collection of validators that are called
         during deserialization. Validator takes a field's input value as
         its only parameter and returns a boolean.
@@ -120,13 +120,12 @@ class Field(FieldABC):
         'validator_failed': 'Invalid value.'
     }
 
-    def __init__(self, default=missing_, attribute=None, load_from=None, dump_to=None,
-                 error=None, validate=None, required=False, allow_none=None, load_only=False,
+    def __init__(self, default=missing_, attribute=None, data_key=None, error=None,
+                 validate=None, required=False, allow_none=None, load_only=False,
                  dump_only=False, missing=missing_, error_messages=None, **metadata):
         self.default = default
         self.attribute = attribute
-        self.load_from = load_from  # this flag is used by Unmarshaller
-        self.dump_to = dump_to  # this flag is used by Marshaller
+        self.data_key = data_key
         self.validate = validate
         if utils.is_iterable_but_not_string(validate):
             if not utils.is_generator(validate):

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -136,7 +136,7 @@ class Marshaller(ErrorStore):
             if getattr(field_obj, 'load_only', False):
                 continue
 
-            key = ''.join([self.prefix or '', field_obj.dump_to or attr_name])
+            key = ''.join([self.prefix or '', field_obj.data_key or attr_name])
 
             getter = lambda d: field_obj.serialize(attr_name, d, accessor=accessor)
             value = self.call_and_store(
@@ -254,8 +254,8 @@ class Unmarshaller(ErrorStore):
             if field_obj.dump_only:
                 continue
             field_name = attr_name
-            if field_obj.load_from:
-                field_name = field_obj.load_from
+            if field_obj.data_key:
+                field_name = field_obj.data_key
             try:
                 raw_value = data.get(field_name, missing)
             except AttributeError:  # Input data is not a dict

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1057,11 +1057,11 @@ class TestSchemaDeserialization:
         errors = excinfo.value.messages
         assert errors['username'] == ['Not a valid email address.']
 
-    def test_deserialize_with_attribute_param_error_returns_load_from_not_attribute_name(self):
+    def test_deserialize_with_attribute_param_error_returns_data_key_not_attribute_name(self):
         class AliasingUserSerializer(Schema):
-            name = fields.String(load_from='Name')
-            username = fields.Email(attribute='email', load_from='UserName')
-            years = fields.Integer(attribute='age', load_from='Years')
+            name = fields.String(data_key='Name')
+            username = fields.Email(attribute='email', data_key='UserName')
+            years = fields.Integer(attribute='age', data_key='Years')
         data = {
             'Name': 'Mick',
             'UserName': 'foobar.com',
@@ -1073,11 +1073,11 @@ class TestSchemaDeserialization:
         assert errors['UserName'] == [u'Not a valid email address.']
         assert errors['Years'] == [u'Not a valid integer.']
 
-    def test_deserialize_with_load_from_param(self):
+    def test_deserialize_with_data_key_param(self):
         class AliasingUserSerializer(Schema):
-            name = fields.String(load_from='Name')
-            username = fields.Email(attribute='email', load_from='UserName')
-            years = fields.Integer(load_from='Years')
+            name = fields.String(data_key='Name')
+            username = fields.Email(attribute='email', data_key='UserName')
+            years = fields.Integer(data_key='Years')
         data = {
             'Name': 'Mick',
             'UserName': 'foo@bar.com',

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -52,7 +52,7 @@ class TestField:
         result = MySchema().load({'name': 'Monty', 'foo': 42})
         assert result == {'name': 'Monty'}
 
-    def test_custom_field_receives_load_from_if_set(self, user):
+    def test_custom_field_receives_data_key_if_set(self, user):
         class MyField(fields.Field):
             def _deserialize(self, val, attr, data):
                 assert attr == 'name'
@@ -60,12 +60,12 @@ class TestField:
                 return val
 
         class MySchema(Schema):
-            Name = MyField(load_from='name')
+            Name = MyField(data_key='name')
 
         result = MySchema().load({'name': 'Monty', 'foo': 42})
         assert result == {'Name': 'Monty'}
 
-    def test_custom_field_follows_dump_to_if_set(self, user):
+    def test_custom_field_follows_data_key_if_set(self, user):
         class MyField(fields.Field):
             def _serialize(self, val, attr, data):
                 assert attr == 'name'
@@ -73,7 +73,7 @@ class TestField:
                 return val
 
         class MySchema(Schema):
-            name = MyField(dump_to='_NaMe')
+            name = MyField(data_key='_NaMe')
 
         result = MySchema().dump({'name': 'Monty', 'foo': 42})
         assert result == {'_NaMe': 'Monty'}

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -61,24 +61,24 @@ class TestMarshaller:
         marshal({'email': 'invalid'}, fields_dict)
         assert 'email' not in marshal.errors
 
-    def test_serialize_fields_with_dump_to_param(self, marshal):
+    def test_serialize_fields_with_data_key_param(self, marshal):
         data = {
             'name': 'Mike',
             'email': 'm@wazow.ski',
         }
         fields_dict = {
-            'name': fields.String(dump_to='NaMe'),
-            'email': fields.Email(attribute='email', dump_to='EmAiL'),
+            'name': fields.String(data_key='NaMe'),
+            'email': fields.Email(attribute='email', data_key='EmAiL'),
         }
         result = marshal.serialize(data, fields_dict)
         assert result['NaMe'] == 'Mike'
         assert result['EmAiL'] == 'm@wazow.ski'
 
-    def test_serialize_fields_with_dump_to_and_prefix_params(self):
+    def test_serialize_fields_with_data_key_and_prefix_params(self):
         u = User("Foo", email="foo@bar.com")
         marshal = Marshaller(prefix='usr_')
-        result = marshal(u, {"email": fields.Email(dump_to='EmAiL'),
-                             'name': fields.String(dump_to='NaMe')})
+        result = marshal(u, {"email": fields.Email(data_key='EmAiL'),
+                             'name': fields.String(data_key='NaMe')})
         assert result['usr_NaMe'] == u.name
         assert result['usr_EmAiL'] == u.email
 
@@ -238,16 +238,16 @@ class TestUnmarshaller:
         assert result['email'] == 'mick@stones.com'
         assert result['firstname'] == 'Mick'
 
-    def test_deserialize_fields_with_load_from_param(self, unmarshal):
+    def test_deserialize_fields_with_data_key_param(self, unmarshal):
         data = {
             'Name': 'Mick',
             'UserName': 'foo@bar.com',
             'years': '42'
         }
         fields_dict = {
-            'name': fields.String(load_from='Name'),
-            'username': fields.Email(attribute='email', load_from='UserName'),
-            'years': fields.Integer(load_from='Years')
+            'name': fields.String(data_key='Name'),
+            'username': fields.Email(attribute='email', data_key='UserName'),
+            'years': fields.Integer(data_key='Years')
         }
         result = unmarshal.deserialize(data, fields_dict)
         assert result['name'] == 'Mick'

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -450,10 +450,10 @@ class TestFieldSerialization:
 
         assert m.serialize('', '', '') is missing_
 
-    def test_serialize_with_dump_to_param(self):
+    def test_serialize_with_data_key_param(self):
         class DumpToSchema(Schema):
-            name = fields.String(dump_to='NamE')
-            years = fields.Integer(dump_to='YearS')
+            name = fields.String(data_key='NamE')
+            years = fields.Integer(data_key='YearS')
         data = {
             'name': 'Richard',
             'years': 11
@@ -464,11 +464,11 @@ class TestFieldSerialization:
             'YearS': 11
         }
 
-    def test_serialize_with_attribute_and_dump_to_uses_dump_to(self):
+    def test_serialize_with_attribute_and_data_key_uses_data_key(self):
         class ConfusedDumpToAndAttributeSerializer(Schema):
-            name = fields.String(dump_to="FullName")
-            username = fields.String(attribute='uname', dump_to='UserName')
-            years = fields.Integer(attribute='le_wild_age', dump_to='Years')
+            name = fields.String(data_key="FullName")
+            username = fields.String(attribute='uname', data_key='UserName')
+            years = fields.Integer(attribute='le_wild_age', data_key='Years')
         data = {
             'name': 'Mick',
             'uname': 'mick_the_awesome',


### PR DESCRIPTION
Working on https://github.com/marshmallow-code/marshmallow/issues/717.

- [x] Replace `load_from` with `key_xxx`
- [x] Replace `dump_to` with `key_xxx`
- [x] The name of the parameter is still to be determined, so I used `key_xxx` for easy find and replace.
- [x] Update docs