### PR TITLE
:bug: Fix pass_original for validate_schema on nested many

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -838,9 +838,9 @@ class BaseSchema(base.SchemaABC):
             if many and not pass_many:
                 for idx, item in enumerate(data):
                     try:
-                        self._unmarshal.run_validator(validator,
-                                                  item, original_data, self.fields, many=many,
-                                                  index=idx, pass_original=pass_original)
+                        self._unmarshal.run_validator(
+                            validator, item, original_data[idx], self.fields,
+                            many=many, index=idx, pass_original=pass_original)
                     except ValidationError as err:
                         errors.update(err.messages)
             else:

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -836,11 +836,11 @@ class BaseSchema(base.SchemaABC):
             if pass_many:
                 validator = functools.partial(validator, many=many)
             if many and not pass_many:
-                for idx, item in enumerate(data):
+                for idx, (item, orig) in enumerate(zip(data, original_data)):
                     try:
                         self._unmarshal.run_validator(
-                            validator, item, original_data[idx], self.fields,
-                            many=many, index=idx, pass_original=pass_original)
+                            validator, item, orig, self.fields, many=many,
+                            index=idx, pass_original=pass_original)
                     except ValidationError as err:
                         errors.update(err.messages)
             else:


### PR DESCRIPTION
Resolve #315 Pass the correct `original_data` for decorated `validate_schema` method
when dealing with a `Nested(many=True)` field.