### PR TITLE
Fix pass_original on nested many

### DIFF
--- a/marshmallow/decorators.py
+++ b/marshmallow/decorators.py
@@ -107,6 +107,9 @@ def post_dump(fn=None, pass_many=False, pass_original=False):
     By default, receives a single object at a time, transparently handling the ``many``
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
+
+    If ``pass_original=True``, the original data (before serializing) will be passed as
+    an additional argument to the method.
     """
     return tag_processor(POST_DUMP, fn, pass_many, pass_original=pass_original)
 
@@ -129,6 +132,9 @@ def post_load(fn=None, pass_many=False, pass_original=False):
     By default, receives a single datum at a time, transparently handling the ``many``
     argument passed to the Schema. If ``pass_many=True``, the raw data
     (which may be a collection) and the value for ``many`` is passed.
+
+    If ``pass_original=True``, the original data (before deserializing) will be passed as
+    an additional argument to the method.
     """
     return tag_processor(POST_LOAD, fn, pass_many, pass_original=pass_original)
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -869,8 +869,8 @@ class BaseSchema(base.SchemaABC):
                     data = utils.if_none(processor(data, many), data)
             elif many:
                 if pass_original:
-                    data = [utils.if_none(processor(item, original_data), item)
-                            for item in data]
+                    data = [utils.if_none(processor(item, original), item)
+                            for item, original in zip(data, original_data)]
                 else:
                     data = [utils.if_none(processor(item), item) for item in data]
             else:


### PR DESCRIPTION
Pass the correct `original_data` for decorated `post_load` and
`post_dump` methods when dealing with a `Nested(many=True)` field.

Resolve #315