### PR TITLE
 Add require_tld argument to the Url field

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -327,9 +327,11 @@ class Field(FieldABC):
             ret = ret.parent
         return ret if isinstance(ret, SchemaABC) else None
 
+
 class Raw(Field):
     """Field that applies no formatting or validation."""
     pass
+
 
 class Nested(Field):
     """Allows you to nest a :class:`Schema <marshmallow.Schema>`
@@ -401,23 +403,26 @@ class Nested(Field):
                 self.__schema.context.update(context)
             elif isinstance(self.nested, type) and \
                     issubclass(self.nested, SchemaABC):
-                self.__schema = self.nested(many=self.many,
-                        only=only, exclude=self.exclude, context=context,
-                        load_only=self._nested_normalized_option('load_only'),
-                        dump_only=self._nested_normalized_option('dump_only'))
+                self.__schema = self.nested(
+                    many=self.many,
+                    only=only, exclude=self.exclude, context=context,
+                    load_only=self._nested_normalized_option('load_only'),
+                    dump_only=self._nested_normalized_option('dump_only'))
             elif isinstance(self.nested, basestring):
                 if self.nested == 'self':
                     parent_class = self.parent.__class__
-                    self.__schema = parent_class(many=self.many, only=only,
-                            exclude=self.exclude, context=context,
-                            load_only=self._nested_normalized_option('load_only'),
-                            dump_only=self._nested_normalized_option('dump_only'))
+                    self.__schema = parent_class(
+                        many=self.many, only=only,
+                        exclude=self.exclude, context=context,
+                        load_only=self._nested_normalized_option('load_only'),
+                        dump_only=self._nested_normalized_option('dump_only'))
                 else:
                     schema_class = class_registry.get_class(self.nested)
-                    self.__schema = schema_class(many=self.many,
-                            only=only, exclude=self.exclude, context=context,
-                            load_only=self._nested_normalized_option('load_only'),
-                            dump_only=self._nested_normalized_option('dump_only'))
+                    self.__schema = schema_class(
+                        many=self.many,
+                        only=only, exclude=self.exclude, context=context,
+                        load_only=self._nested_normalized_option('load_only'),
+                        dump_only=self._nested_normalized_option('dump_only'))
             else:
                 raise ValueError('Nested fields must be passed a '
                                  'Schema, not {0}.'.format(self.nested.__class__))
@@ -441,7 +446,7 @@ class Nested(Field):
             self.__updated_fields = True
         try:
             ret = schema.dump(nested_obj, many=self.many,
-                update_fields=not self.__updated_fields)
+                              update_fields=not self.__updated_fields)
         except ValidationError as exc:
             raise ValidationError(exc.messages, data=obj, valid_data=exc.valid_data)
         finally:
@@ -493,14 +498,14 @@ class List(Field):
         if isinstance(cls_or_instance, type):
             if not issubclass(cls_or_instance, FieldABC):
                 raise ValueError('The type of the list elements '
-                                           'must be a subclass of '
-                                           'marshmallow.base.FieldABC')
+                                 'must be a subclass of '
+                                 'marshmallow.base.FieldABC')
             self.container = cls_or_instance()
         else:
             if not isinstance(cls_or_instance, FieldABC):
                 raise ValueError('The instances of the list '
-                                           'elements must be of type '
-                                           'marshmallow.base.FieldABC')
+                                 'elements must be of type '
+                                 'marshmallow.base.FieldABC')
             self.container = cls_or_instance
 
     def get_value(self, obj, attr, accessor=None):
@@ -544,6 +549,7 @@ class List(Field):
             raise ValidationError(errors, data=result)
 
         return result
+
 
 class String(Field):
     """A string field.
@@ -814,6 +820,7 @@ class Boolean(Field):
                 pass
         self.fail('invalid')
 
+
 class FormattedString(Field):
     """Interpolate other values from the object into this field. The syntax for
     the source string is the same as the string `str.format` method
@@ -983,6 +990,7 @@ class Time(Field):
             return utils.from_iso_time(value)
         except (AttributeError, TypeError, ValueError):
             self.fail('invalid')
+
 
 class Date(Field):
     """ISO8601-formatted date string.

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1188,15 +1188,17 @@ class Url(String):
     """
     default_error_messages = {'invalid': 'Not a valid URL.'}
 
-    def __init__(self, relative=False, schemes=None, **kwargs):
+    def __init__(self, relative=False, schemes=None, require_tld=True, **kwargs):
         String.__init__(self, **kwargs)
 
         self.relative = relative
+        self.require_tld = require_tld
         # Insert validation into self.validators so that multiple errors can be
         # stored.
         self.validators.insert(0, validate.URL(
             relative=self.relative,
             schemes=schemes,
+            require_tld=self.require_tld,
             error=self.error_messages['invalid']
         ))
 
@@ -1205,6 +1207,7 @@ class Url(String):
             return None
         return validate.URL(
             relative=self.relative,
+            require_tld=self.require_tld,
             error=self.error_messages['invalid']
         )(value)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,7 @@ from marshmallow.marshalling import missing
 
 from tests.base import ALL_FIELDS, User
 
+
 class TestFieldAliases:
 
     def test_int_is_integer(self):
@@ -20,18 +21,19 @@ class TestFieldAliases:
     def test_URL_is_Url(self):  # flake8: noqa
         assert fields.URL is fields.Url
 
+
 class TestField:
 
     def test_repr(self):
         default = u'œ∑´'
         field = fields.Field(default=default, attribute=None)
         assert repr(field) == (u'<fields.Field(default={0!r}, attribute=None, '
-                                'validate=None, required=False, '
-                                'load_only=False, dump_only=False, '
-                                'missing={missing}, allow_none=False, '
-                                'error_messages={error_messages})>'
-                                .format(default, missing=missing,
-                                        error_messages=field.error_messages))
+                               'validate=None, required=False, '
+                               'load_only=False, dump_only=False, '
+                               'missing={missing}, allow_none=False, '
+                               'error_messages={error_messages})>'
+                               .format(default, missing=missing,
+                                       error_messages=field.error_messages))
         int_field = fields.Integer(validate=lambda x: True)
         assert '<fields.Integer' in repr(int_field)
 
@@ -137,7 +139,7 @@ class TestMetadata:
         field = FieldClass(description='Just a normal field.')
         assert field.metadata['description'] == 'Just a normal field.'
         field = FieldClass(required=True, default=None, validate=lambda v: True,
-                            description='foo', widget='select')
+                           description='foo', widget='select')
         assert field.metadata == {'description': 'foo', 'widget': 'select'}
 
     def test_metadata_may_be_added_to_formatted_string_field(self):
@@ -152,9 +154,9 @@ class TestErrorMessages:
             'custom': 'Custom error message.'
         }
 
-    def test_default_error_messages_get_merged_with_parent_error_messages(self):
+    def test_default_error_messages_get_merged_with_parent_error_messages_cstm_msg(self):
         field = self.MyField()
-        assert field.error_messages['custom'] == 'Custom error message'
+        assert field.error_messages['custom'] == 'Custom error message.'
         assert 'required' in field.error_messages
 
     def test_default_error_messages_get_merged_with_parent_error_messages(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2248,3 +2248,14 @@ class TestLoadOnly:
         assert 'str_dump_only' not in result
         assert 'str_load_only' in result
         assert 'str_regular' in result
+
+    # regression test for https://github.com/marshmallow-code/marshmallow/pull/765
+    def test_url_field_requre_tld_false(self):
+
+        class NoTldTestSchema(Schema):
+            url = fields.Url(require_tld=False, schemes=['marshmallow'])
+
+        schema = NoTldTestSchema()
+        data_with_no_top_level_domain = {'url': 'marshmallow://app/discounts'}
+        result = schema.load(data_with_no_top_level_domain)
+        assert result == data_with_no_top_level_domain


### PR DESCRIPTION
I saw the issue #749, but I cannot understand the problem out there with adding an optional argument `require_tld` to the Url field. It's already there in the URL validator initialiser so if we add it to the Url field's initialiser it will be only more convenient.

This fix helped me so I hope it can help other people