### PR TITLE
Fix Only/Exclude Inheritance

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -706,14 +706,14 @@ class BaseSchema(base.SchemaABC):
         """Apply then flatten nested schema options"""
         if self.only is not None:
             # Apply the only option to nested fields.
-            self.__apply_nested_option('only', self.only)
+            self.__apply_nested_option('only', self.only, 'intersection')
             # Remove the child field names from the only option.
             self.only = self.set_class(
                 [field.split('.', 1)[0] for field in self.only])
         excludes = set(self.opts.exclude) | set(self.exclude)
         if excludes:
             # Apply the exclude option to nested fields.
-            self.__apply_nested_option('exclude', excludes)
+            self.__apply_nested_option('exclude', excludes, 'union')
         if self.exclude:
             # Remove the parent field names from the exclude option.
             self.exclude = self.set_class(
@@ -723,7 +723,7 @@ class BaseSchema(base.SchemaABC):
             self.opts.exclude = self.set_class(
                 [field for field in self.opts.exclude if '.' not in field])
 
-    def __apply_nested_option(self, option_name, field_names):
+    def __apply_nested_option(self, option_name, field_names, set_operation):
         """Apply nested options to nested fields"""
         # Split nested field names on the first dot.
         nested_fields = [name.split('.', 1) for name in field_names if '.' in name]
@@ -733,7 +733,14 @@ class BaseSchema(base.SchemaABC):
             nested_options[parent].append(nested_names)
         # Apply the nested field options.
         for key, options in iter(nested_options.items()):
-            setattr(self.declared_fields[key], option_name, self.set_class(options))
+            new_options = self.set_class(options)
+            original_options = getattr(self.declared_fields[key], option_name, ())
+            if original_options:
+                if set_operation == 'union':
+                    new_options |= self.set_class(original_options)
+                if set_operation == 'intersection':
+                        new_options &= self.set_class(original_options)
+            setattr(self.declared_fields[key], option_name, new_options)
 
     def _update_fields(self, obj=None, many=False):
         """Update fields based on the passed in object."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -715,6 +715,27 @@ def test_nested_only():
     assert 'baz' not in child
 
 
+def test_nested_only_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, only=('foo', 'bar'))
+    sch = ParentSchema(only=('blubb.foo', 'blubb.baz'))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' not in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' in child
+    assert 'bar' not in child
+    assert 'baz' not in child
+
+
 def test_nested_exclude():
     class ChildSchema(Schema):
         foo = fields.Field()
@@ -732,6 +753,27 @@ def test_nested_exclude():
     assert 'bli' not in result.data
     child = result.data['blubb']
     assert 'foo' in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_nested_exclude_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, exclude=('baz',))
+    sch = ParentSchema(exclude=('blubb.foo',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
     assert 'bar' in child
     assert 'baz' not in child
 
@@ -755,6 +797,73 @@ def test_nested_only_and_exclude():
     assert 'foo' not in child
     assert 'bar' in child
     assert 'baz' not in child
+
+
+def test_nested_only_then_exclude_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, only=('foo', 'bar'))
+    sch = ParentSchema(exclude=('blubb.foo',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' in result.data
+    assert 'blubb' in result.data
+    assert 'bli' in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_nested_exclude_then_only_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, exclude=('foo',))
+    sch = ParentSchema(only=('blubb.bar',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' not in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' in child
+    assert 'baz' not in child
+
+
+def test_nested_exclude_and_only_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+        ban = fields.Field()
+        fuu = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, only=('foo', 'bar', 'baz', 'ban'), exclude=('foo',))
+    sch = ParentSchema(only=('blubb.foo', 'blubb.bar', 'blubb.baz'), exclude=('blubb.baz',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' not in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' in child
+    assert 'baz' not in child
+    assert 'ban' not in child
+    assert 'fuu' not in child
 
 
 def test_meta_nested_exclude():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -736,6 +736,27 @@ def test_nested_only_inheritance():
     assert 'baz' not in child
 
 
+def test_nested_only_empty_inheritance():
+    class ChildSchema(Schema):
+        foo = fields.Field()
+        bar = fields.Field()
+        baz = fields.Field()
+    class ParentSchema(Schema):
+        bla = fields.Field()
+        bli = fields.Field()
+        blubb = fields.Nested(ChildSchema, only=('bar',))
+    sch = ParentSchema(only=('blubb.foo',))
+    data = dict(bla=1, bli=2, blubb=dict(foo=42, bar=24, baz=242))
+    result = sch.dump(data)
+    assert 'bla' not in result.data
+    assert 'blubb' in result.data
+    assert 'bli' not in result.data
+    child = result.data['blubb']
+    assert 'foo' not in child
+    assert 'bar' not in child
+    assert 'baz' not in child
+
+
 def test_nested_exclude():
     class ChildSchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Fixes #728 

Allow nested `only` and `exclude` options to compose logically.