### PR TITLE
Drop official support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ sudo: false
 python:
   - "3.6"
   - "3.5"
-  - "3.4"
   - "2.7"
   - "pypy"
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,7 +106,7 @@ To run all tests: ::
 
     $ invoke test
 
-To run tests on Python 2.7, 3.4, 3.5, and PyPy virtual environments (must have each interpreter installed): ::
+To run tests on Python 2.7, 3.5, 3.6, and PyPy virtual environments (must have each interpreter installed): ::
 
     $ tox
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Full documentation is available at http://marshmallow.readthedocs.io/ .
 Requirements
 ============
 
-- Python >= 2.7 or >= 3.4
+- Python >= 2.7 or >= 3.5
 
 marshmallow has no external dependencies outside of the Python standard library, although `python-dateutil <https://pypi.python.org/pypi/python-dateutil>`_ is recommended for robust datetime deserialization.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-**marshmallow** requires Python >= 2.7 or >= 3.4. It has no external dependencies other than the Python standard library.
+**marshmallow** requires Python >= 2.7 or >= 3.5. It has no external dependencies other than the Python standard library.
 
 .. note::
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -15,9 +15,9 @@ Upgrading to 3.0
 Python compatibility
 ********************
 
-The marshmallow 3.x series supports Python 2.7, 3.4, 3.5, and 3.6.
+The marshmallow 3.x series supports Python 2.7, 3.5, and 3.6.
 
-Python 2.6 and 3.3 are no longer supported.
+Python 2.6, 3.3, and 3.4 are no longer supported.
 
 
 Schemas are always strict

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,pypy
+envlist=py27,py35,py36,pypy
 [testenv]
 deps=
   -rdev-requirements.txt


### PR DESCRIPTION
3.4 is over 4 years old, and 3.7 is around the corner.
Let's move forward.