### PR TITLE
Make UUIDs valid if input is string representation or 16 byte rep (continued)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,3 +84,4 @@ Contributors (chronological)
 - Vlad Frolov `@frol <https://github.com/frol>`_
 - Erling Børresen `@erlingbo <https://github.com/erlingbo>`_
 - Jérôme Lafréchoux  `@lafrech <https://github.com/lafrech>`_
+- Jeffrey Berger `@JeffBerger <https://github.com/JeffBerger>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,14 @@
 Changelog
 ---------
 
-3.0.0b3 (unreleaased)
-+++++++++++++++++++++
+3.0.0b3 (unreleased)
+++++++++++++++++++++
 
 Features:
 
 - Add ``valid_data`` attribute to ``ValidationError``.
+- ``fields.UUID`` deserializes ``bytes`` strings using ``UUID(bytes=b'...')`` (:issue:`625`). 
+  Thanks :user:`JeffBerger` for the suggestion and the PR.
 
 Deprecations/Removals:
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,7 +623,10 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            return uuid.UUID(value)
+            if isinstance(value, bytes) or len(value) == 16:
+                return uuid.UUID(bytes=value)
+            else:
+                return uuid.UUID(value)
         except (ValueError, AttributeError):
             self.fail('invalid_uuid')
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,11 +623,11 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            if isinstance(value, bytes):
+            if isinstance(value, bytes) and len(value) == 16:
                 return uuid.UUID(bytes=value)
             else:
                 return uuid.UUID(value)
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
             self.fail('invalid_uuid')
 
     def _serialize(self, value, attr, obj):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,7 +623,7 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            if isinstance(value, bytes) and len(value) == 16:
+            if isinstance(value, bytes):
                 return uuid.UUID(bytes=value)
             else:
                 return uuid.UUID(value)

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -623,8 +623,11 @@ class UUID(String):
         if isinstance(value, uuid.UUID):
             return value
         try:
-            return uuid.UUID(value)
-        except (ValueError, AttributeError):
+            if isinstance(value, bytes) and len(value) == 16:
+                return uuid.UUID(bytes=value)
+            else:
+                return uuid.UUID(value)
+        except (TypeError, ValueError, AttributeError):
             self.fail('invalid_uuid')
 
     def _serialize(self, value, attr, obj):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -574,11 +574,17 @@ class TestFieldDeserialization:
         assert isinstance(result, uuid.UUID)
         assert result == uuid4
 
+        uuid_bytes = b']\xc7wW\x132O\xf9\xa5\xbe\x13\x1f\x02\x18\xda\xbf'
+        result = field.deserialize(uuid_bytes)
+        assert isinstance(result, uuid.UUID)
+        assert result.bytes == uuid_bytes
+
     @pytest.mark.parametrize('in_value',
     [
         'malformed',
         123,
         [],
+        b'tooshort',
     ])
     def test_invalid_uuid_deserialization(self, in_value):
         field = fields.UUID()


### PR DESCRIPTION
Same as #625 , with added tests.