### PR TITLE
Fix Structured Dict Context

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1134,6 +1134,15 @@ class Dict(Field):
                                  'marshmallow.base.FieldABC')
             self.key_container = keys
 
+    def _add_to_schema(self, field_name, schema):
+        super(Dict, self)._add_to_schema(field_name, schema)
+        if self.value_container:
+            self.value_container.parent = self
+            self.value_container.name = field_name
+        if self.key_container:
+            self.key_container.parent = self
+            self.key_container.name = field_name
+
     def _serialize(self, value, attr, obj):
         if value is None:
             return None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2134,6 +2134,27 @@ class TestContext:
         outer.context['foo_context'] = 'foo'
         assert outer.load({'bars': [{'foo': 42}]})
 
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/820
+    def test_nested_dict_fields_inherit_context(self):
+        class InnerSchema(Schema):
+            foo = fields.Field()
+
+            @validates('foo')
+            def validate_foo(self, value):
+                if 'foo_context' not in self.context:
+                    raise ValidationError('Missing context')
+
+        class OuterSchema(Schema):
+            bars = fields.Dict(values=fields.Nested(InnerSchema()))
+
+        inner = InnerSchema()
+        inner.context['foo_context'] = 'foo'
+        assert inner.load({'foo': 42})
+
+        outer = OuterSchema()
+        outer.context['foo_context'] = 'foo'
+        assert outer.load({'bars': {'test': {'foo': 42}}})
+
 
 def test_serializer_can_specify_nested_object_as_attribute(blog):
     class BlogUsernameSchema(Schema):


### PR DESCRIPTION
Link the `Dict` field's containers to itself as the `parent` so that the schema context can propagate through.

Fixes #820 