### PR TITLE
Fix Pluck with Dump To

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -449,10 +449,12 @@ class Nested(Field):
         ret, errors = schema.dump(nested_obj, many=self.many,
                 update_fields=not self.__updated_fields)
         if isinstance(self.only, basestring):  # self.only is a field name
+            only_field = self.schema.fields[self.only]
+            key = ''.join([self.schema.prefix or '', only_field.dump_to or self.only])
             if self.many:
-                return utils.pluck(ret, key=self.only)
+                return utils.pluck(ret, key=key)
             else:
-                return ret[self.only]
+                return ret[key]
         if errors:
             raise ValidationError(errors, data=ret)
         return ret

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1574,6 +1574,21 @@ class TestNestedSchema:
         for i, name in enumerate(data['collaborators']):
             assert name == blog.collaborators[i].name
 
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/800
+    def test_flat_nested_with_dump_to(self, blog):
+        class UserSchema(Schema):
+            name = fields.String(dump_to='username')
+            age = fields.Int()
+        class FlatBlogSchema(Schema):
+            name = fields.String()
+            user = fields.Nested(UserSchema, only='name')
+            collaborators = fields.Nested(UserSchema, only='name', many=True)
+        s = FlatBlogSchema()
+        data, _ = s.dump(blog)
+        assert data['user'] == blog.user.name
+        for i, name in enumerate(data['collaborators']):
+            assert name == blog.collaborators[i].name
+
     # regression test for https://github.com/marshmallow-code/marshmallow/issues/64
     def test_nested_many_with_missing_attribute(self, user):
         class SimpleBlogSchema(Schema):


### PR DESCRIPTION
Rebuild the key that the marshaller used during to serialization so that the `only` argument of a `Nested` field can reference a field using `dump_to` without erroring.

Part of #800 