### PR TITLE
Add possibility to pass whole object in method field

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -442,6 +442,19 @@ class TestFieldSerialization:
 
         assert m.serialize('', '', '') is missing_
 
+    def test_method_with_obj_passing(self):
+        class MethodSchema(Schema):
+            method = fields.Method(deserialize='deserialize', pass_obj=True)
+
+            def deserialize(self, value, obj):
+                return value, obj
+
+        obj = MethodSchema().load({
+            'foo': 'foo',
+            'method': 'abc',
+        })
+        assert obj["method"] == ('abc', {'foo': 'foo', 'method': 'abc'})
+
     def test_serialize_with_data_key_param(self):
         class DumpToSchema(Schema):
             name = fields.String(data_key='NamE')


### PR DESCRIPTION
Possible usecase of this feature is combining multiple fields during deserialization into a single one.

My exact use-case:
```python
class A(Schema):
  address = fields.Method(deserialize='get_address', pass_obj=True, data_key='address_1')
  def get_address(self, value, obj):
    return f"{obj.get('address_1'), obj.get('address_2')".strip()
```

Something like this seems to have been impossible before that.

Ideally the `pass_obj` would affect both serialize and deserialize, however the current implementation gives you the whole object in `serialize` already. I'm not sure why that happens, but that seems to be a different issue
