### PR TITLE
Handle unknown fields with EXCLUDE, INCLUDE or RAISE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,17 @@ Changelog
 3.0.0b12 (unreleased)
 +++++++++++++++++++++
 
+Features:
+
+- The behavior to apply when encountering unknown fields while deserializing can be controlled with the ``unknown`` option (:issue:`524`).
+  It makes it possible to either "include", "exclude" or "raise".
+
+Other changes:
+
 - *Backwards-incompatible*: Pre/Post-processors MUST return modified data.
   Returning ``None`` does not imply data were mutated (:issue:`347`). Thanks
   :user:`tdevelioglu` for reporting.
+
 
 3.0.0b11 (2018-05-20)
 +++++++++++++++++++++

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -37,6 +37,36 @@ By default, pre- and post-processing methods receive one object/datum at a time,
 In cases where your pre- and post-processing methods need to receive the input collection  when ``many=True``, add ``pass_many=True`` to the method decorators. The method will receive the input data (which may be a single datum or a collection) and the boolean value of ``many``.
 
 
+Using Original Input Data
++++++++++++++++++++++++++
+
+By default, unspecified field names are ignored by the validator. If you want to use the original, unprocessed input, you can add ``pass_original=True`` to your call to `post_load <marshmallow.decorators.post_load>`.
+
+.. code-block:: python
+    :emphasize-lines: 7
+
+    from marshmallow import Schema, fields, validates_schema, ValidationError
+
+    class MySchema(Schema):
+        foo = fields.Int()
+        bar = fields.Int()
+
+        @post_load(pass_original=True)
+        def add_baz_to_bar(self, data, original_data):
+            baz = original_data.get('baz')
+            if baz:
+                data['bar'] = data['bar'] + baz
+            return data
+
+    schema = MySchema()
+    schema.load({'foo': 1, 'bar': 2, 'baz': 3})
+    # {'foo': 1, 'bar': 5}
+
+.. seealso::
+
+   The default behavior for unspecified fields can be controlled with the ``unknown`` option, see :ref:`Handling Unknown Fields <unknown>` for more information.
+
+
 Example: Enveloping
 +++++++++++++++++++
 
@@ -263,34 +293,6 @@ You can register schema-level validation functions for a :class:`Schema` using t
     except ValidationError as err:
         err.messages['_schema']
     # => ["field_a must be greater than field_b"]
-
-
-Validating Original Input Data
-++++++++++++++++++++++++++++++
-
-Normally, unspecified field names are ignored by the validator. If you would like access to the original, raw input (e.g. to fail validation if an unknown field name is sent), add ``pass_original=True`` to your call to `validates_schema <marshmallow.decorators.validates_schema>`.
-
-.. code-block:: python
-    :emphasize-lines: 7
-
-    from marshmallow import Schema, fields, validates_schema, ValidationError
-
-    class MySchema(Schema):
-        foo = fields.Int()
-        bar = fields.Int()
-
-        @validates_schema(pass_original=True)
-        def check_unknown_fields(self, data, original_data):
-            unknown = set(original_data) - set(self.fields)
-            if unknown:
-                raise ValidationError('Unknown field', unknown)
-
-    schema = MySchema()
-    try:
-        schema.load({'foo': 1, 'bar': 2, 'baz': 3, 'bu': 4})
-    except ValidationError as err:
-        err.messages
-    # {'baz': 'Unknown field', 'bu': 'Unknown field'}
 
 
 Storing Errors on Specific Fields

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -338,6 +338,45 @@ Or you can ignore missing fields entirely by setting ``partial=True``.
     # OR UserSchema(partial=True).load({'age': 42})
     result  # => ({'age': 42}, {})
 
+.. _unknown:
+
+Handling Unknown Fields
++++++++++++++++++++++++
+
+By default, :meth:`load <Schema.load>` will exclude any field that has not been defined in the schema.
+
+This behavior can be modified with the ``unknown`` option, which accepts three values:
+
+- `EXCLUDE <marshmallow.utils.EXCLUDE>`, which is the default
+- `INCLUDE <marshmallow.utils.INCLUDE>`, to accept and include the unknown fields inside the returned data
+- `RAISE <marshmallow.utils.RAISE>`, to raise a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` if there is any unknown field
+
+There are several places where you can apply that option. You can define it in the *class Meta* of your :class:`Schema`:
+
+.. code-block:: python
+    :emphasize-lines: 2,3
+
+    class UserSchema(Schema):
+        class Meta:
+            unknown = INCLUDE
+
+You can apply it at instantiation time:
+
+.. code-block:: python
+
+    schema = UserSchema(unknown=INCLUDE)
+
+Or you can force it directly when loading the data:
+
+.. code-block:: python
+
+    UserSchema().load(data, unknown=INCLUDE)
+
+The ``unknown`` option value set in :meth:`load <Schema.load>` will always override the value applied at instantiation time, which itself will override the value defined in the *class Meta*.
+
+This order of precedence allows you to change the behavior of a schema for different contexts.
+
+
 Schema.validate
 +++++++++++++++
 

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -7,12 +7,15 @@ from . import fields
 from marshmallow.decorators import (
     pre_dump, post_dump, pre_load, post_load, validates, validates_schema
 )
-from marshmallow.utils import pprint, missing
+from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, pprint, missing
 from marshmallow.exceptions import ValidationError
 
 __version__ = '3.0.0b11'
 __author__ = 'Steven Loria'
 __all__ = [
+    'EXCLUDE',
+    'INCLUDE',
+    'RAISE',
     'Schema',
     'SchemaOpts',
     'fields',

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -12,6 +12,7 @@ import decimal
 
 from marshmallow import validate, utils, class_registry
 from marshmallow.base import FieldABC, SchemaABC
+from marshmallow.utils import EXCLUDE
 from marshmallow.utils import missing as missing_
 from marshmallow.compat import text_type, basestring
 from marshmallow.exceptions import ValidationError
@@ -370,6 +371,8 @@ class Nested(Field):
         value will be returned as output instead of a dictionary.
         This parameter takes precedence over ``exclude``.
     :param bool many: Whether the field is a collection of objects.
+    :param unknown: Whether to exclude, include, or raise an error for unknown
+        fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
@@ -382,6 +385,7 @@ class Nested(Field):
         self.only = only
         self.exclude = exclude
         self.many = kwargs.get('many', False)
+        self.unknown = kwargs.get('unknown', EXCLUDE)
         self.__schema = None  # Cached Schema instance
         self.__updated_fields = False
         super(Nested, self).__init__(default=default, **kwargs)
@@ -473,7 +477,7 @@ class Nested(Field):
             else:
                 value = {self.only: value}
         try:
-            valid_data = self.schema.load(value)
+            valid_data = self.schema.load(value, unknown=self.unknown)
         except ValidationError as exc:
             raise ValidationError(exc.messages, data=data, valid_data=exc.valid_data)
         return valid_data

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -18,6 +18,9 @@ from pprint import pprint as py_pprint
 
 from marshmallow.compat import binary_type, text_type
 
+EXCLUDE = 'exclude'
+INCLUDE = 'include'
+RAISE = 'raise'
 
 dateutil_available = False
 try:


### PR DESCRIPTION
This is a rework of #595 so that it supports the API discussed in #524.

By default, only the fields described in the schema are returned when data is deserialized.

This commit implements an `unknown` option, so that `Schema(unknown=ALLOW)` or `Schema().load(data, unknown=ALLOW)` permit users to receive the unknown fields from the data.

`Schema(unknown=RAISE)` or `Schema().load(data, unknown=RAISE)` will raise a `ValidationError` for each unknown field.

`Schema(unknown=IGNORE)` or `Schema().load(data, unknown=IGNORE)` keep the original behavior.

Edit: `ALLOW` will finally be `INCLUDE`, and `IGNORE` will be `EXCLUDE`.