### PR TITLE
Enforce consistent quoting

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ simplejson==3.15.0
 
 # Syntax checking
 flake8==3.5.0
+flake8-quotes==1.0.0

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -43,7 +43,7 @@ class ValidationError(MarshmallowError):
         self.kwargs = kwargs
         MarshmallowError.__init__(self, message)
 
-    def normalized_messages(self, no_field_name="_schema"):
+    def normalized_messages(self, no_field_name='_schema'):
         if isinstance(self.messages, dict):
             return self.messages
         if len(self.field_names) == 0:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -143,7 +143,7 @@ class Field(FieldABC):
             self.validators = []
         else:
             raise ValueError("The 'validate' parameter must be a callable "
-                             "or a collection of callables.")
+                             'or a collection of callables.')
 
         self.required = required
         # If missing=None, None should be considered valid by default

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -188,16 +188,16 @@ class SchemaOpts(object):
     def __init__(self, meta, ordered=False):
         self.fields = getattr(meta, 'fields', ())
         if not isinstance(self.fields, (list, tuple)):
-            raise ValueError("`fields` option must be a list or tuple.")
+            raise ValueError('`fields` option must be a list or tuple.')
         self.additional = getattr(meta, 'additional', ())
         if not isinstance(self.additional, (list, tuple)):
-            raise ValueError("`additional` option must be a list or tuple.")
+            raise ValueError('`additional` option must be a list or tuple.')
         if self.fields and self.additional:
-            raise ValueError("Cannot set both `fields` and `additional` options"
-                            " for the same Schema.")
+            raise ValueError('Cannot set both `fields` and `additional` options'
+                            ' for the same Schema.')
         self.exclude = getattr(meta, 'exclude', ())
         if not isinstance(self.exclude, (list, tuple)):
-            raise ValueError("`exclude` must be a list or tuple.")
+            raise ValueError('`exclude` must be a list or tuple.')
         self.dateformat = getattr(meta, 'dateformat', None)
         if hasattr(meta, 'json_module'):
             warnings.warn(

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -55,13 +55,13 @@ def is_generator(obj):
 def is_iterable_but_not_string(obj):
     """Return True if ``obj`` is an iterable object that isn't a string."""
     return (
-        (isinstance(obj, collections.Iterable) and not hasattr(obj, "strip")) or is_generator(obj)
+        (isinstance(obj, collections.Iterable) and not hasattr(obj, 'strip')) or is_generator(obj)
     )
 
 
 def is_indexable_but_not_string(obj):
     """Return True if ``obj`` is indexable but isn't a string."""
-    return not hasattr(obj, "strip") and hasattr(obj, "__getitem__")
+    return not hasattr(obj, 'strip') and hasattr(obj, '__getitem__')
 
 
 def is_collection(obj):
@@ -124,7 +124,7 @@ def to_marshallable_type(obj, field_names=None):
     else:
         attrs = set(dir(obj))
     return dict([(attr, getattr(obj, attr, None)) for attr in attrs
-                  if not attr.startswith("__") and not attr.endswith("__")])
+                  if not attr.startswith('__') and not attr.endswith('__')])
 
 
 def pprint(obj, *args, **kwargs):
@@ -149,7 +149,7 @@ class UTC(datetime.tzinfo):
     Optimized UTC implementation. It unpickles using the single module global
     instance defined beneath this class declaration.
     """
-    zone = "UTC"
+    zone = 'UTC'
 
     _utcoffset = ZERO
     _dst = ZERO
@@ -164,19 +164,19 @@ class UTC(datetime.tzinfo):
         return ZERO
 
     def tzname(self, dt):
-        return "UTC"
+        return 'UTC'
 
     def dst(self, dt):
         return ZERO
 
     def localize(self, dt, is_dst=False):
-        '''Convert naive time to local time'''
+        """Convert naive time to local time"""
         if dt.tzinfo is not None:
             raise ValueError('Not naive datetime (tzinfo is already set)')
         return dt.replace(tzinfo=self)
 
     def normalize(self, dt, is_dst=False):
-        '''Correct the timezone information on the given datetime'''
+        """Correct the timezone information on the given datetime"""
         if dt.tzinfo is self:
             return dt
         if dt.tzinfo is None:
@@ -184,10 +184,10 @@ class UTC(datetime.tzinfo):
         return dt.astimezone(self)
 
     def __repr__(self):
-        return "<UTC>"
+        return '<UTC>'
 
     def __str__(self):
-        return "UTC"
+        return 'UTC'
 
 
 UTC = utc = UTC()  # UTC is a singleton
@@ -197,11 +197,11 @@ def local_rfcformat(dt):
     """Return the RFC822-formatted representation of a timezone-aware datetime
     with the UTC offset.
     """
-    weekday = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][dt.weekday()]
-    month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep",
-             "Oct", "Nov", "Dec"][dt.month - 1]
-    tz_offset = dt.strftime("%z")
-    return "%s, %02d %s %04d %02d:%02d:%02d %s" % (weekday, dt.day, month,
+    weekday = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][dt.weekday()]
+    month = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
+             'Oct', 'Nov', 'Dec'][dt.month - 1]
+    tz_offset = dt.strftime('%z')
+    return '%s, %02d %s %04d %02d:%02d:%02d %s' % (weekday, dt.day, month,
         dt.year, dt.hour, dt.minute, dt.second, tz_offset)
 
 

--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -33,7 +33,7 @@ class AuthorSchema(Schema):
         return obj.first + ' ' + obj.last
 
     def format_name(self, author):
-        return "{0}, {1}".format(author.last, author.first)
+        return '{0}, {1}'.format(author.last, author.first)
 
 
 class QuoteSchema(Schema):

--- a/tasks.py
+++ b/tasks.py
@@ -41,15 +41,15 @@ def benchmark(ctx):
 
 @task
 def clean(ctx):
-    ctx.run("rm -rf build")
-    ctx.run("rm -rf dist")
-    ctx.run("rm -rf marshmallow.egg-info")
+    ctx.run('rm -rf build')
+    ctx.run('rm -rf dist')
+    ctx.run('rm -rf marshmallow.egg-info')
     clean_docs(ctx)
-    print("Cleaned up.")
+    print('Cleaned up.')
 
 @task
 def clean_docs(ctx):
-    ctx.run("rm -rf %s" % build_dir)
+    ctx.run('rm -rf %s' % build_dir)
 
 @task
 def browse_docs(ctx):
@@ -57,7 +57,7 @@ def browse_docs(ctx):
     webbrowser.open_new_tab(path)
 
 def build_docs(ctx, browse):
-    ctx.run("sphinx-build %s %s" % (docs_dir, build_dir), echo=True)
+    ctx.run('sphinx-build %s %s' % (docs_dir, build_dir), echo=True)
     if browse:
         browse_docs(ctx)
 
@@ -86,6 +86,6 @@ def watch_docs(ctx, browse=False):
 
 @task
 def readme(ctx, browse=False):
-    ctx.run("rst2html.py README.rst > README.html")
+    ctx.run('rst2html.py README.rst > README.html')
     if browse:
         webbrowser.open_new_tab('README.html')

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,7 +11,7 @@ from marshmallow import Schema, fields, post_load, validate, missing
 from marshmallow.compat import text_type
 from marshmallow.exceptions import ValidationError
 
-central = pytz.timezone("US/Central")
+central = pytz.timezone('US/Central')
 
 
 ALL_FIELDS = [
@@ -63,7 +63,7 @@ def assert_time_equal(t1, t2, microseconds=True):
 
 
 class User(object):
-    SPECIES = "Homo sapiens"
+    SPECIES = 'Homo sapiens'
 
     def __init__(self, name, age=0, id_=None, homepage=None, email=None,
                  registered=True, time_registered=None, birthdate=None,
@@ -91,15 +91,15 @@ class User(object):
         self.employer = employer
         self.relatives = []
         self.various_data = various_data or {'pets': ['cat', 'dog'],
-                                             'address': "1600 Pennsylvania Ave\n"
-                                                        "Washington, DC 20006"}
+                                             'address': '1600 Pennsylvania Ave\n'
+                                                        'Washington, DC 20006'}
 
     @property
     def since_created(self):
         return dt.datetime(2013, 11, 24) - self.created
 
     def __repr__(self):
-        return "<User {0}>".format(self.name)
+        return '<User {0}>'.format(self.name)
 
 
 class Blog(object):
@@ -147,17 +147,17 @@ class UserSchema(Schema):
     name = fields.String()
     age = fields.Float()
     created = fields.DateTime()
-    created_formatted = fields.DateTime(format="%Y-%m-%d", attribute="created")
-    created_iso = fields.DateTime(format="iso", attribute="created")
+    created_formatted = fields.DateTime(format='%Y-%m-%d', attribute='created')
+    created_iso = fields.DateTime(format='iso', attribute='created')
     updated = fields.DateTime()
-    updated_local = fields.LocalDateTime(attribute="updated")
-    species = fields.String(attribute="SPECIES")
+    updated_local = fields.LocalDateTime(attribute='updated')
+    species = fields.String(attribute='SPECIES')
     id = fields.String(default='no-id')
     uppername = Uppercased(attribute='name')
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
-    is_old = fields.Method("get_is_old")
+    is_old = fields.Method('get_is_old')
     lowername = fields.Function(get_lowername)
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)
@@ -193,10 +193,10 @@ class UserMetaSchema(Schema):
     """The equivalent of the UserSchema, using the ``fields`` option."""
     uppername = Uppercased(attribute='name')
     balance = fields.Decimal()
-    is_old = fields.Method("get_is_old")
+    is_old = fields.Method('get_is_old')
     lowername = fields.Function(get_lowername)
-    updated_local = fields.LocalDateTime(attribute="updated")
-    species = fields.String(attribute="SPECIES")
+    updated_local = fields.LocalDateTime(attribute='updated')
+    species = fields.String(attribute='SPECIES')
     homepage = fields.Url()
     email = fields.Email()
     various_data = fields.Dict()
@@ -216,21 +216,21 @@ class UserMetaSchema(Schema):
     class Meta:
         fields = ('name', 'age', 'created', 'updated', 'id', 'homepage',
                   'uppername', 'email', 'balance', 'is_old', 'lowername',
-                  "updated_local", "species", 'registered', 'hair_colors',
-                  'sex_choices', "finger_count", 'uid', 'time_registered',
+                  'updated_local', 'species', 'registered', 'hair_colors',
+                  'sex_choices', 'finger_count', 'uid', 'time_registered',
                   'birthdate', 'since_created', 'various_data')
 
 
 class UserExcludeSchema(UserSchema):
     class Meta:
-        exclude = ("created", "updated", "field_not_found_but_thats_ok")
+        exclude = ('created', 'updated', 'field_not_found_but_thats_ok')
 
 
 class UserAdditionalSchema(Schema):
     lowername = fields.Function(lambda obj: obj.name.lower())
 
     class Meta:
-        additional = ("name", "age", "created", "email")
+        additional = ('name', 'age', 'created', 'email')
 
 
 class UserIntSchema(UserSchema):
@@ -263,38 +263,38 @@ class BlogUserMetaSchema(Schema):
 
 
 class BlogSchemaMeta(Schema):
-    '''Same as BlogSerializer but using ``fields`` options.'''
+    """Same as BlogSerializer but using ``fields`` options."""
     user = fields.Nested(UserSchema)
     collaborators = fields.Nested(UserSchema, many=True)
 
     class Meta:
-        fields = ('title', 'user', 'collaborators', 'categories', "id")
+        fields = ('title', 'user', 'collaborators', 'categories', 'id')
 
 
 class BlogOnlySchema(Schema):
     title = fields.String()
     user = fields.Nested(UserSchema)
-    collaborators = fields.Nested(UserSchema, only=("id", ), many=True)
+    collaborators = fields.Nested(UserSchema, only=('id', ), many=True)
 
 
 class BlogSchemaExclude(BlogSchema):
-    user = fields.Nested(UserSchema, exclude=("uppername", "species"))
+    user = fields.Nested(UserSchema, exclude=('uppername', 'species'))
 
 
 class BlogSchemaOnlyExclude(BlogSchema):
-    user = fields.Nested(UserSchema, only=("name", ), exclude=("name", "species"))
+    user = fields.Nested(UserSchema, only=('name', ), exclude=('name', 'species'))
 
 
 class BlogSchemaPrefixedUser(BlogSchema):
-    user = fields.Nested(UserSchema(prefix="usr_"))
-    collaborators = fields.Nested(UserSchema(prefix="usr_"), many=True)
+    user = fields.Nested(UserSchema(prefix='usr_'))
+    collaborators = fields.Nested(UserSchema(prefix='usr_'), many=True)
 
 
 class mockjson(object):  # noqa
 
     @staticmethod
     def dumps(val):
-        return '{"foo": 42}'.encode('utf-8')
+        return "{'foo': 42}".encode('utf-8')
 
     @staticmethod
     def loads(val):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,12 @@ from tests.base import User, UserSchema, Blog
 
 @pytest.fixture
 def user():
-    return User(name="Monty", age=42.3, homepage="http://monty.python.org/")
+    return User(name='Monty', age=42.3, homepage='http://monty.python.org/')
 
 @pytest.fixture
 def blog(user):
-    col1 = User(name="Mick", age=123)
-    col2 = User(name="Keith", age=456)
+    col1 = User(name='Mick', age=123)
+    col2 = User(name='Keith', age=456)
     return Blog("Monty's blog", user=user, categories=['humor', 'violence'],
                 collaborators=[col1, col2])
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -249,7 +249,7 @@ def test_pre_dump_is_invoked_before_implicit_field_generation():
             # Removing generated_field from here drops it from the output
             fields = ('field', 'generated_field')
 
-    assert Foo().dump({"field": 5}) == {'field': 5, 'generated_field': 7}
+    assert Foo().dump({'field': 5}) == {'field': 5, 'generated_field': 7}
 
 
 class ValidatesSchema(Schema):
@@ -391,12 +391,12 @@ class TestValidatesSchemaDecorator:
         assert '_schema' in errors['nested']
         assert 'foo' not in errors['nested']
 
-    @pytest.mark.parametrize("data", ([{"foo": 1, "bar": 2}],))
+    @pytest.mark.parametrize('data', ([{'foo': 1, 'bar': 2}],))
     @pytest.mark.parametrize(
-        "pass_many,expected_data,expected_original_data",
+        'pass_many,expected_data,expected_original_data',
         (
-            [True, [{"foo": 1}], [{"foo": 1, "bar": 2}]],
-            [False, {"foo": 1}, {"foo": 1, "bar": 2}],
+            [True, [{'foo': 1}], [{'foo': 1, 'bar': 2}]],
+            [False, {'foo': 1}, {'foo': 1, 'bar': 2}],
         ),
     )
     def test_validator_nested_many_pass_original_and_pass_many(
@@ -410,15 +410,15 @@ class TestValidatesSchemaDecorator:
                 assert data == expected_data
                 assert original_data == expected_original_data
                 assert many is pass_many
-                raise ValidationError("Method called")
+                raise ValidationError('Method called')
 
         class MySchema(Schema):
             nested = fields.Nested(NestedSchema, required=True, many=True)
 
         schema = MySchema()
-        errors = schema.validate({"nested": data})
-        error = errors["nested"] if pass_many else errors["nested"][0]
-        assert error["_schema"][0] == "Method called"
+        errors = schema.validate({'nested': data})
+        error = errors['nested'] if pass_many else errors['nested'][0]
+        assert error['_schema'][0] == 'Method called'
 
     def test_decorated_validators(self):
 
@@ -800,9 +800,9 @@ example = Example(nested=[Nested(x) for x in range(1)])
 
 
 @pytest.mark.parametrize(
-    "data,expected_data,expected_original_data",
+    'data,expected_data,expected_original_data',
     (
-        [example, {"foo": 0}, example.nested[0]],
+        [example, {'foo': 0}, example.nested[0]],
     ),
 )
 def test_decorator_post_dump_with_nested_pass_original_and_pass_many(
@@ -828,13 +828,13 @@ def test_decorator_post_dump_with_nested_pass_original_and_pass_many(
         nested = fields.Nested(NestedSchema, required=True, many=True)
 
     schema = ExampleSchema()
-    assert schema.dump(data) == {"nested": [{"foo": 0}]}
+    assert schema.dump(data) == {'nested': [{'foo': 0}]}
 
 
 @pytest.mark.parametrize(
-    "data,expected_data,expected_original_data",
+    'data,expected_data,expected_original_data',
     (
-        [{"nested": [{"foo": 0}]}, {"foo": 0}, {"foo": 0}],
+        [{'nested': [{'foo': 0}]}, {'foo': 0}, {'foo': 0}],
     ),
 )
 def test_decorator_post_load_with_nested_pass_original_and_pass_many(

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -537,16 +537,16 @@ class TestFieldDeserialization:
 
     def test_dict_field_deserialization(self):
         field = fields.Dict()
-        assert field.deserialize({"foo": "bar"}) == {"foo": "bar"}
+        assert field.deserialize({'foo': 'bar'}) == {'foo': 'bar'}
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize('baddict')
         assert excinfo.value.args[0] == 'Not a valid mapping type.'
 
     def test_structured_dict_value_deserialization(self):
         field = fields.Dict(values=fields.List(fields.Str))
-        assert field.deserialize({"foo": ["bar", "baz"]}) == {"foo": ["bar", "baz"]}
+        assert field.deserialize({'foo': ['bar', 'baz']}) == {'foo': ['bar', 'baz']}
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize({"foo": [1, 2], "bar": "baz", "ham": ["spam"]})
+            field.deserialize({'foo': [1, 2], 'bar': 'baz', 'ham': ['spam']})
         assert excinfo.value.args[0] == {
             'foo': {'value': {0: ['Not a valid string.'], 1: ['Not a valid string.']}},
             'bar': {'value': ['Not a valid list.']}, }
@@ -554,35 +554,35 @@ class TestFieldDeserialization:
 
     def test_structured_dict_key_deserialization(self):
         field = fields.Dict(keys=fields.Str)
-        assert field.deserialize({"foo": "bar"}) == {"foo": "bar"}
+        assert field.deserialize({'foo': 'bar'}) == {'foo': 'bar'}
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize({1: "bar", "foo": "baz"})
+            field.deserialize({1: 'bar', 'foo': 'baz'})
         assert excinfo.value.args[0] == {1: {'key': ['Not a valid string.']}}
-        assert excinfo.value.data == {'foo': 'baz', 1: "bar"}
+        assert excinfo.value.data == {'foo': 'baz', 1: 'bar'}
 
     def test_structured_dict_key_value_deserialization(self):
         field = fields.Dict(
             keys=fields.Str(validate=[validate.Email(), validate.Regexp(r'.*@test\.com$')]),
             values=fields.Decimal,
         )
-        assert field.deserialize({"foo@test.com": 1}) == {"foo@test.com": decimal.Decimal(1)}
+        assert field.deserialize({'foo@test.com': 1}) == {'foo@test.com': decimal.Decimal(1)}
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize({1: "bar"})
+            field.deserialize({1: 'bar'})
         assert excinfo.value.args[0] == {1: {
             'key': ['Not a valid string.'],
             'value': ['Not a valid number.'],
         }}
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize({"foo@test.com": "bar"})
-        assert excinfo.value.args[0] == {"foo@test.com": {'value': ['Not a valid number.']}}
+            field.deserialize({'foo@test.com': 'bar'})
+        assert excinfo.value.args[0] == {'foo@test.com': {'value': ['Not a valid number.']}}
         assert excinfo.value.data == {'foo@test.com': None}
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({1: 1})
         assert excinfo.value.args[0] == {1: {'key': ['Not a valid string.']}}
         assert excinfo.value.data == {1: 1}
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize({"foo": "bar"})
-        assert excinfo.value.args[0] == {"foo": {
+            field.deserialize({'foo': 'bar'})
+        assert excinfo.value.args[0] == {'foo': {
             'key': ['Not a valid email address.', 'String does not match expected pattern.'],
             'value': ['Not a valid number.'],
         }}
@@ -1388,22 +1388,22 @@ class TestSchemaDeserialization:
 
     def test_unknown_fields_deserialization_with_data_key(self):
         class MySchema(Schema):
-            foo = fields.Integer(data_key="Foo")
+            foo = fields.Integer(data_key='Foo')
 
-        data = MySchema().load({"Foo": 1})
-        assert data["foo"] == 1
-        assert "Foo" not in data
+        data = MySchema().load({'Foo': 1})
+        assert data['foo'] == 1
+        assert 'Foo' not in data
 
-        data = MySchema(unknown=RAISE).load({"Foo": 1})
-        assert data["foo"] == 1
-        assert "Foo" not in data
+        data = MySchema(unknown=RAISE).load({'Foo': 1})
+        assert data['foo'] == 1
+        assert 'Foo' not in data
 
         with pytest.raises(ValidationError):
-            MySchema(unknown=RAISE).load({"foo": 1})
+            MySchema(unknown=RAISE).load({'foo': 1})
 
-        data = MySchema(unknown=INCLUDE).load({"Foo": 1})
-        assert data["foo"] == 1
-        assert "Foo" not in data
+        data = MySchema(unknown=INCLUDE).load({'Foo': 1})
+        assert data['foo'] == 1
+        assert 'Foo' not in data
 
 
 validators_gen = (func for func in [lambda x: x <= 24, lambda x: 18 <= x])
@@ -1527,11 +1527,11 @@ FIELDS_TO_TEST = [f for f in ALL_FIELDS if f not in [fields.FormattedString]]
 def test_required_field_failure(FieldClass):  # noqa
     class RequireSchema(Schema):
         age = FieldClass(required=True)
-    user_data = {"name": "Phil"}
+    user_data = {'name': 'Phil'}
     with pytest.raises(ValidationError) as excinfo:
         RequireSchema().load(user_data)
     errors = excinfo.value.messages
-    assert "Missing data for required field." in errors['age']
+    assert 'Missing data for required field.' in errors['age']
 
 @pytest.mark.parametrize('message', ['My custom required message',
                                      {'error': 'something', 'code': 400},
@@ -1540,7 +1540,7 @@ def test_required_message_can_be_changed(message):
     class RequireSchema(Schema):
         age = fields.Integer(required=True, error_messages={'required': message})
 
-    user_data = {"name": "Phil"}
+    user_data = {'name': 'Phil'}
     with pytest.raises(ValidationError) as excinfo:
         RequireSchema().load(user_data)
     errors = excinfo.value.messages

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -18,15 +18,15 @@ class TestMarshaller:
         return Marshaller()
 
     def test_prefix(self):
-        u = User("Foo", email="foo@bar.com")
+        u = User('Foo', email='foo@bar.com')
         marshal = Marshaller(prefix='usr_')
-        result = marshal(u, {"email": fields.Email(), 'name': fields.String()})
+        result = marshal(u, {'email': fields.Email(), 'name': fields.String()})
         assert result['usr_name'] == u.name
         assert result['usr_email'] == u.email
 
     def test_marshalling_generator(self, marshal):
-        gen = (u for u in [User("Foo"), User("Bar")])
-        res = marshal(gen, {"name": fields.String()}, many=True)
+        gen = (u for u in [User('Foo'), User('Bar')])
+        res = marshal(gen, {'name': fields.String()}, many=True)
         assert len(res) == 2
 
     def test_default_to_missing(self, marshal):
@@ -75,9 +75,9 @@ class TestMarshaller:
         assert result['EmAiL'] == 'm@wazow.ski'
 
     def test_serialize_fields_with_data_key_and_prefix_params(self):
-        u = User("Foo", email="foo@bar.com")
+        u = User('Foo', email='foo@bar.com')
         marshal = Marshaller(prefix='usr_')
-        result = marshal(u, {"email": fields.Email(data_key='EmAiL'),
+        result = marshal(u, {'email': fields.Email(data_key='EmAiL'),
                              'name': fields.String(data_key='NaMe')})
         assert result['usr_NaMe'] == u.name
         assert result['usr_EmAiL'] == u.email
@@ -134,10 +134,10 @@ class TestUnmarshaller:
     def test_stores_errors(self, unmarshal):
         data = {'email': 'invalid-email'}
         try:
-            unmarshal(data, {"email": fields.Email()})
+            unmarshal(data, {'email': fields.Email()})
         except ValidationError:
             pass
-        assert "email" in unmarshal.errors
+        assert 'email' in unmarshal.errors
 
     def test_stores_indices_of_errors_when_many_equals_true(self, unmarshal):
         users = [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,7 +36,7 @@ from tests.base import (
 
 random.seed(1)
 
-# Run tests with both verbose serializer and "meta" option serializer
+# Run tests with both verbose serializer and 'meta' option serializer
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_serializing_basic_object(SchemaClass, user):
@@ -493,7 +493,7 @@ def test_naive_datetime_field(user, serialized_user):
 
 def test_datetime_formatted_field(user, serialized_user):
     result = serialized_user['created_formatted']
-    assert result == user.created.strftime("%Y-%m-%d")
+    assert result == user.created.strftime('%Y-%m-%d')
 
 def test_datetime_iso_field(user, serialized_user):
     assert serialized_user['created_iso'] == utils.isoformat(user.created)
@@ -513,13 +513,13 @@ def test_class_variable(serialized_user):
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_serialize_many(SchemaClass):
-    user1 = User(name="Mick", age=123)
-    user2 = User(name="Keith", age=456)
+    user1 = User(name='Mick', age=123)
+    user2 = User(name='Keith', age=456)
     users = [user1, user2]
     serialized = SchemaClass(many=True).dump(users)
     assert len(serialized) == 2
-    assert serialized[0]['name'] == "Mick"
-    assert serialized[1]['name'] == "Keith"
+    assert serialized[0]['name'] == 'Mick'
+    assert serialized[1]['name'] == 'Keith'
 
 def test_inheriting_schema(user):
     sch = ExtendedUserSchema()
@@ -546,33 +546,33 @@ def test_stores_invalid_url_error(SchemaClass):
     with pytest.raises(ValidationError) as excinfo:
         SchemaClass().load(user)
     errors = excinfo.value.messages
-    assert "homepage" in errors
+    assert 'homepage' in errors
     expected = ['Not a valid URL.']
     assert errors['homepage'] == expected
 
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_email_field(SchemaClass):
-    u = User("John", email="john@example.com")
+    u = User('John', email='john@example.com')
     s = SchemaClass().dump(u)
-    assert s['email'] == "john@example.com"
+    assert s['email'] == 'john@example.com'
 
 def test_stored_invalid_email():
     u = {'name': 'John', 'email': 'johnexample.com'}
     with pytest.raises(ValidationError) as excinfo:
         UserSchema().load(u)
     errors = excinfo.value.messages
-    assert "email" in errors
+    assert 'email' in errors
     assert errors['email'][0] == 'Not a valid email address.'
 
 def test_integer_field():
-    u = User("John", age=42.3)
+    u = User('John', age=42.3)
     serialized = UserIntSchema().dump(u)
     assert type(serialized['age']) == int
     assert serialized['age'] == 42
 
 def test_as_string():
-    u = User("John", age=42.3)
+    u = User('John', age=42.3)
     serialized = UserFloatStringSchema().dump(u)
     assert type(serialized['age']) == str
     assert_almost_equal(float(serialized['age']), 42.3)
@@ -581,7 +581,7 @@ def test_as_string():
     [UserSchema, UserMetaSchema])
 def test_method_field(SchemaClass, serialized_user):
     assert serialized_user['is_old'] is False
-    u = User("Joe", age=81)
+    u = User('Joe', age=81)
     assert SchemaClass().dump(u)['is_old'] is True
 
 def test_function_field(serialized_user, user):
@@ -590,7 +590,7 @@ def test_function_field(serialized_user, user):
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_prefix(SchemaClass, user):
-    s = SchemaClass(prefix="usr_").dump(user)
+    s = SchemaClass(prefix='usr_').dump(user)
     assert s['usr_name'] == user.name
 
 def test_fields_must_be_declared_as_instances(user):
@@ -603,7 +603,7 @@ def test_fields_must_be_declared_as_instances(user):
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_serializing_generator(SchemaClass):
-    users = [User("Foo"), User("Bar")]
+    users = [User('Foo'), User('Bar')]
     user_gen = (u for u in users)
     s = SchemaClass(many=True).dump(user_gen)
     assert len(s) == 2
@@ -616,14 +616,14 @@ def test_serializing_empty_list_returns_empty_list():
 
 
 def test_serializing_dict():
-    user = {"name": "foo", "email": "foo@bar.com", "age": 'badage', "various_data": {"foo": "bar"}}
+    user = {'name': 'foo', 'email': 'foo@bar.com', 'age': 'badage', 'various_data': {'foo': 'bar'}}
     with pytest.raises(ValidationError) as excinfo:
         UserSchema().dump(user)
     data, errors = excinfo.value.valid_data, excinfo.value.messages
-    assert data['name'] == "foo"
+    assert data['name'] == 'foo'
     assert 'age' in errors
     assert 'age' not in data
-    assert data['various_data'] == {"foo": "bar"}
+    assert data['various_data'] == {'foo': 'bar'}
 
 
 def test_serializing_dict_with_meta_fields():
@@ -655,7 +655,7 @@ def test_only_in_init(SchemaClass, user):
 
 def test_invalid_only_param(user):
     with pytest.raises(AttributeError):
-        UserSchema(only=("_invalid", "name")).dump(user)
+        UserSchema(only=('_invalid', 'name')).dump(user)
 
 def test_can_serialize_uuid(serialized_user, user):
     assert serialized_user['uid'] == str(user.uid)
@@ -672,7 +672,7 @@ def test_invalid_time():
     assert '"foo" cannot be formatted as a time.' in errors['time_registered']
 
 def test_invalid_date():
-    u = User("Joe", birthdate='foo')
+    u = User('Joe', birthdate='foo')
     with pytest.raises(ValidationError) as excinfo:
         UserSchema().dump(u)
     errors = excinfo.value.messages
@@ -718,9 +718,9 @@ def test_custom_error_message():
     with pytest.raises(ValidationError) as excinfo:
         s.load(u)
     errors = excinfo.value.messages
-    assert "Bad balance." in errors['balance']
-    assert "Bad homepage." in errors['homepage']
-    assert "Invalid email" in errors['email']
+    assert 'Bad balance.' in errors['balance']
+    assert 'Bad homepage.' in errors['homepage']
+    assert 'Invalid email' in errors['email']
 
 
 def test_load_errors_with_many():
@@ -766,7 +766,7 @@ def test_nested_custom_set_in_exclude_reusing_schema():
         # to pass, since it'll be a valid instance, and this class overrides
         # getitem method to allow the hasattr check to pass too, which will try
         # to access the first obj index and will simulate a IndexError throwing.
-        # e.g. SqlAlchemy.Query is a valid use case for this "obj".
+        # e.g. SqlAlchemy.Query is a valid use case for this 'obj'.
 
         def __getitem__(self, item):
             return [][item]
@@ -1325,12 +1325,12 @@ def test_nested_with_sets():
 
 
 def test_meta_serializer_fields():
-    u = User("John", age=42.3, email="john@example.com",
-             homepage="http://john.com")
+    u = User('John', age=42.3, email='john@example.com',
+             homepage='http://john.com')
     result = UserMetaSchema().dump(u)
     assert result['name'] == u.name
     assert result['balance'] == decimal.Decimal('100.00')
-    assert result['uppername'] == "JOHN"
+    assert result['uppername'] == 'JOHN'
     assert result['is_old'] is False
     assert result['created'] == utils.isoformat(u.created)
     assert result['updated_local'] == utils.isoformat(u.updated, localtime=True)
@@ -1366,44 +1366,44 @@ def test_meta_field_not_on_obj_raises_attribute_error(user):
 
 def test_exclude_fields(user):
     s = UserExcludeSchema().dump(user)
-    assert "created" not in s
-    assert "updated" not in s
-    assert "name" in s
+    assert 'created' not in s
+    assert 'updated' not in s
+    assert 'name' in s
 
 def test_fields_option_must_be_list_or_tuple(user):
     with pytest.raises(ValueError):
         class BadFields(Schema):
             class Meta:
-                fields = "name"
+                fields = 'name'
 
 def test_exclude_option_must_be_list_or_tuple(user):
     with pytest.raises(ValueError):
         class BadExclude(Schema):
             class Meta:
-                exclude = "name"
+                exclude = 'name'
 
 def test_dateformat_option(user):
     fmt = '%Y-%m'
 
     class DateFormatSchema(Schema):
-        updated = fields.DateTime("%m-%d")
+        updated = fields.DateTime('%m-%d')
 
         class Meta:
             fields = ('created', 'updated')
             dateformat = fmt
     serialized = DateFormatSchema().dump(user)
     assert serialized['created'] == user.created.strftime(fmt)
-    assert serialized['updated'] == user.updated.strftime("%m-%d")
+    assert serialized['updated'] == user.updated.strftime('%m-%d')
 
 def test_default_dateformat(user):
     class DateFormatSchema(Schema):
-        updated = fields.DateTime(format="%m-%d")
+        updated = fields.DateTime(format='%m-%d')
 
         class Meta:
             fields = ('created', 'updated')
     serialized = DateFormatSchema().dump(user)
     assert serialized['created'] == utils.isoformat(user.created)
-    assert serialized['updated'] == user.updated.strftime("%m-%d")
+    assert serialized['updated'] == user.updated.strftime('%m-%d')
 
 def test_inherit_meta(user):
     class InheritedMetaSchema(UserMetaSchema):
@@ -1438,7 +1438,7 @@ def test_cant_set_both_additional_and_fields(user):
             name = fields.String()
 
             class Meta:
-                fields = ("name", 'email')
+                fields = ('name', 'email')
                 additional = ('email', 'homepage')
 
 def test_serializing_none_meta():
@@ -1624,13 +1624,13 @@ class TestNestedSchema:
 
     @pytest.fixture
     def user(self):
-        return User(name="Monty", age=81)
+        return User(name='Monty', age=81)
 
     @pytest.fixture
     def blog(self, user):
-        col1 = User(name="Mick", age=123)
-        col2 = User(name="Keith", age=456)
-        blog = Blog("Monty's blog", user=user, categories=["humor", "violence"],
+        col1 = User(name='Mick', age=123)
+        col2 = User(name='Keith', age=456)
+        blog = Blog("Monty's blog", user=user, categories=['humor', 'violence'],
                          collaborators=[col1, col2])
         return blog
 
@@ -1738,19 +1738,19 @@ class TestNestedSchema:
         assert serialized_blog['collaborators'] == expected
 
     def test_nested_only(self, blog):
-        col1 = User(name="Mick", age=123, id_="abc")
-        col2 = User(name="Keith", age=456, id_="def")
+        col1 = User(name='Mick', age=123, id_='abc')
+        col2 = User(name='Keith', age=456, id_='def')
         blog.collaborators = [col1, col2]
         serialized_blog = BlogOnlySchema().dump(blog)
-        assert serialized_blog['collaborators'] == [{"id": col1.id}, {"id": col2.id}]
+        assert serialized_blog['collaborators'] == [{'id': col1.id}, {'id': col2.id}]
 
     def test_exclude(self, blog):
         serialized = BlogSchemaExclude().dump(blog)
-        assert "uppername" not in serialized['user'].keys()
+        assert 'uppername' not in serialized['user'].keys()
 
     def test_list_field(self, blog):
         serialized = BlogSchema().dump(blog)
-        assert serialized['categories'] == ["humor", "violence"]
+        assert serialized['categories'] == ['humor', 'violence']
 
     def test_nested_load_many(self):
         in_data = {'title': 'Shine A Light', 'collaborators': [
@@ -1769,25 +1769,25 @@ class TestNestedSchema:
                 {'title': "Monty's blog", 'user': {'name': 'Monty', 'email': 'foo'}}
             )
         errors = excinfo.value.messages
-        assert "email" in errors['user']
+        assert 'email' in errors['user']
         assert len(errors['user']['email']) == 1
         assert 'Not a valid email address.' in errors['user']['email'][0]
         # No problems with collaborators
-        assert "collaborators" not in errors
+        assert 'collaborators' not in errors
 
     def test_nested_dump_errors(self, blog):
-        blog.user.age = "foo"
+        blog.user.age = 'foo'
         with pytest.raises(ValidationError) as excinfo:
             BlogSchema().dump(blog)
         errors = excinfo.value.messages
-        assert "age" in errors['user']
+        assert 'age' in errors['user']
         assert len(errors['user']['age']) == 1
         assert 'Not a valid number.' in errors['user']['age'][0]
         # No problems with collaborators
-        assert "collaborators" not in errors
+        assert 'collaborators' not in errors
 
     def test_nested_dump(self, blog):
-        blog.user.age = "foo"
+        blog.user.age = 'foo'
         with pytest.raises(ValidationError) as excinfo:
             BlogSchema().dump(blog)
         assert 'age' in str(excinfo)
@@ -1813,11 +1813,11 @@ class TestNestedSchema:
         assert data['collaborators'][0]['usr_name'] == blog.collaborators[0].name
 
     def test_invalid_float_field(self):
-        user = User("Joe", age="1b2")
+        user = User('Joe', age='1b2')
         with pytest.raises(ValidationError) as excinfo:
             UserSchema().dump(user)
         errors = excinfo.value.messages
-        assert "age" in errors
+        assert 'age' in errors
 
     def test_serializer_meta_with_nested_fields(self, blog, user):
         data = BlogSchemaMeta().dump(blog)
@@ -1917,11 +1917,11 @@ class TestSelfReference:
 
     @pytest.fixture
     def employer(self):
-        return User(name="Joe", age=59)
+        return User(name='Joe', age=59)
 
     @pytest.fixture
     def user(self, employer):
-        return User(name="Tom", employer=employer, age=28)
+        return User(name='Tom', employer=employer, age=28)
 
     def test_nesting_schema_within_itself(self, user, employer):
         class SelfSchema(Schema):
@@ -1946,7 +1946,7 @@ class TestSelfReference:
 
     def test_nesting_within_itself_meta(self, user, employer):
         class SelfSchema(Schema):
-            employer = fields.Nested("self", exclude=('employer', ))
+            employer = fields.Nested('self', exclude=('employer', ))
 
             class Meta:
                 additional = ('name', 'age')
@@ -1979,7 +1979,7 @@ class TestSelfReference:
                 fields = ('name', 'emp', 'rels')
 
         schema = MultipleSelfSchema()
-        user.relatives = [User(name="Bar", age=12), User(name='Baz', age=34)]
+        user.relatives = [User(name='Bar', age=12), User(name='Baz', age=34)]
         data = schema.dump(user)
         assert len(data['rels']) == len(user.relatives)
         relative = data['rels'][0]
@@ -1993,7 +1993,7 @@ class TestSelfReference:
                 additional = ('name', 'age')
 
         person = User(name='Foo')
-        person.relatives = [User(name="Bar", age=12), User(name='Baz', age=34)]
+        person.relatives = [User(name='Bar', age=12), User(name='Baz', age=34)]
         data = SelfManySchema().dump(person)
         assert data['name'] == person.name
         assert len(data['relatives']) == len(person.relatives)
@@ -2022,20 +2022,20 @@ def test_deserialization_with_required_field_and_custom_validator():
         color = fields.String(required=True,
                         validate=lambda x: x.lower() == 'red' or x.lower() == 'blue',
                         error_messages={
-                            'validator_failed': "Color must be red or blue"})
+                            'validator_failed': 'Color must be red or blue'})
 
     with pytest.raises(ValidationError) as excinfo:
         ValidatingSchema().load({'name': 'foo'})
     errors = excinfo.value.messages
     assert errors
     assert 'color' in errors
-    assert "Missing data for required field." in errors['color']
+    assert 'Missing data for required field.' in errors['color']
 
     with pytest.raises(ValidationError) as excinfo:
         ValidatingSchema().load({'color': 'green'})
     errors = excinfo.value.messages
     assert 'color' in errors
-    assert "Color must be red or blue" in errors['color']
+    assert 'Color must be red or blue' in errors['color']
 
 
 class UserContextSchema(Schema):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,7 +27,7 @@ class TestFieldSerialization:
 
     @pytest.fixture
     def user(self):
-        return User("Foo", email="foo@bar.com", age=42)
+        return User('Foo', email='foo@bar.com', age=42)
 
     @pytest.mark.parametrize(('value', 'expected'),
     [
@@ -52,7 +52,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_func(self, user):
         field = fields.Function(lambda obj: obj.name.upper())
-        assert "FOO" == field.serialize("key", user)
+        assert 'FOO' == field.serialize('key', user)
 
     def test_function_field_passed_serialize_only_is_dump_only(self, user):
         field = fields.Function(serialize=lambda obj: obj.name.upper())
@@ -67,7 +67,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_serialize(self, user):
         field = fields.Function(serialize=lambda obj: obj.name.upper())
-        assert "FOO" == field.serialize("key", user)
+        assert 'FOO' == field.serialize('key', user)
 
     # https://github.com/marshmallow-code/marshmallow/issues/395
     def test_function_field_does_not_swallow_attribute_error(self, user):
@@ -88,7 +88,7 @@ class TestFieldSerialization:
             serialize=lambda obj, context: obj.name.upper() + context['key']
         )
         field.parent = Parent(context={'key': 'BAR'})
-        assert "FOOBAR" == field.serialize("key", user)
+        assert 'FOOBAR' == field.serialize('key', user)
 
     def test_function_field_passed_uncallable_object(self):
         with pytest.raises(ValueError):
@@ -345,7 +345,7 @@ class TestFieldSerialization:
 
     def test_function_with_uncallable_param(self):
         with pytest.raises(ValueError):
-            fields.Function("uncallable")
+            fields.Function('uncallable')
 
     def test_email_field_serialize_none(self, user):
         user.email = None
@@ -364,33 +364,33 @@ class TestFieldSerialization:
         assert field.serialize('various_data', user) == 'okaydict'
 
     def test_dict_field_serialize(self, user):
-        user.various_data = {"foo": "bar"}
+        user.various_data = {'foo': 'bar'}
         field = fields.Dict()
-        assert field.serialize('various_data', user) == {"foo": "bar"}
+        assert field.serialize('various_data', user) == {'foo': 'bar'}
 
     def test_dict_field_serialize_ordereddict(self, user):
-        user.various_data = OrderedDict([("foo", "bar"), ("bar", "baz")])
+        user.various_data = OrderedDict([('foo', 'bar'), ('bar', 'baz')])
         field = fields.Dict()
         assert field.serialize('various_data', user) == \
-            OrderedDict([("foo", "bar"), ("bar", "baz")])
+            OrderedDict([('foo', 'bar'), ('bar', 'baz')])
 
     def test_structured_dict_value_serialize(self, user):
-        user.various_data = {"foo": decimal.Decimal('1')}
+        user.various_data = {'foo': decimal.Decimal('1')}
         field = fields.Dict(values=fields.Decimal)
-        assert field.serialize('various_data', user) == {"foo": 1}
+        assert field.serialize('various_data', user) == {'foo': 1}
 
     def test_structured_dict_key_serialize(self, user):
-        user.various_data = {1: "bar"}
+        user.various_data = {1: 'bar'}
         field = fields.Dict(keys=fields.Str)
-        assert field.serialize('various_data', user) == {"1": "bar"}
+        assert field.serialize('various_data', user) == {'1': 'bar'}
 
     def test_structured_dict_key_value_serialize(self, user):
         user.various_data = {1: decimal.Decimal('1')}
         field = fields.Dict(keys=fields.Str, values=fields.Decimal)
-        assert field.serialize('various_data', user) == {"1": 1}
+        assert field.serialize('various_data', user) == {'1': 1}
 
     def test_structured_dict_validates(self, user):
-        user.various_data = {"foo": "bar"}
+        user.various_data = {'foo': 'bar'}
         field = fields.Dict(values=fields.Decimal)
         with pytest.raises(ValidationError):
             field.serialize('various_data', user)
@@ -458,7 +458,7 @@ class TestFieldSerialization:
 
     def test_serialize_with_attribute_and_data_key_uses_data_key(self):
         class ConfusedDumpToAndAttributeSerializer(Schema):
-            name = fields.String(data_key="FullName")
+            name = fields.String(data_key='FullName')
             username = fields.String(attribute='uname', data_key='UserName')
             years = fields.Integer(attribute='le_wild_age', data_key='Years')
         data = {
@@ -497,28 +497,28 @@ class TestFieldSerialization:
     def test_datetime_field_rfc822(self, fmt, user):
         field = fields.DateTime(format=fmt)
         expected = utils.rfcformat(user.created, localtime=False)
-        assert field.serialize("created", user) == expected
+        assert field.serialize('created', user) == expected
 
     def test_localdatetime_rfc_field(self, user):
         field = fields.LocalDateTime(format='rfc')
         expected = utils.rfcformat(user.created, localtime=True)
-        assert field.serialize("created", user) == expected
+        assert field.serialize('created', user) == expected
 
     @pytest.mark.parametrize('fmt', ['iso', 'iso8601'])
     def test_datetime_iso8601(self, fmt, user):
         field = fields.DateTime(format=fmt)
         expected = utils.isoformat(user.created, localtime=False)
-        assert field.serialize("created", user) == expected
+        assert field.serialize('created', user) == expected
 
     def test_localdatetime_iso(self, user):
-        field = fields.LocalDateTime(format="iso")
+        field = fields.LocalDateTime(format='iso')
         expected = utils.isoformat(user.created, localtime=True)
-        assert field.serialize("created", user) == expected
+        assert field.serialize('created', user) == expected
 
     def test_datetime_format(self, user):
-        format = "%Y-%m-%d"
+        format = '%Y-%m-%d'
         field = fields.DateTime(format=format)
-        assert field.serialize("created", user) == user.created.strftime(format)
+        assert field.serialize('created', user) == user.created.strftime(format)
 
     def test_string_field(self):
         field = fields.String()
@@ -542,7 +542,7 @@ class TestFieldSerialization:
 
     def test_string_field_default_to_empty_string(self, user):
         field = fields.String(default='')
-        assert field.serialize("notfound", {}) == ''
+        assert field.serialize('notfound', {}) == ''
 
     def test_time_field(self, user):
         field = fields.Time()
@@ -713,7 +713,7 @@ class TestFieldSerialization:
 
     def test_list_field_work_with_generators_error(self):
         def custom_generator():
-            for dtime in [dt.datetime.utcnow(), "m", dt.datetime.now()]:
+            for dtime in [dt.datetime.utcnow(), 'm', dt.datetime.now()]:
                 yield dtime
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime)
@@ -735,7 +735,7 @@ class TestFieldSerialization:
         custom_set = set([1, 2, 3])
         obj = IntegerList(custom_set)
         field = fields.List(fields.Int)
-        result = field.serialize("ints", obj)
+        result = field.serialize('ints', obj)
         assert len(result) == 3
         assert 1 in result
         assert 2 in result
@@ -752,7 +752,7 @@ class TestFieldSerialization:
         ints = IteratorSupportingClass([1, 2, 3])
         obj = IntegerList(ints)
         field = fields.List(fields.Int)
-        result = field.serialize("ints", obj)
+        result = field.serialize('ints', obj)
         assert len(result) == 3
         assert result[0] == 1
         assert result[1] == 2
@@ -762,7 +762,7 @@ class TestFieldSerialization:
         class ASchema(Schema):
             id = fields.Int()
         with pytest.raises(ValueError):
-            fields.List("string")
+            fields.List('string')
         with pytest.raises(ValueError) as excinfo:
             fields.List(ASchema)
         expected_msg = ('The type of the list elements must be a subclass '

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,13 +135,13 @@ def test_to_marshallable_type_generator():
 
 def test_marshallable():
     class ObjContainer(object):
-        contained = {"foo": 1}
+        contained = {'foo': 1}
 
         def __marshallable__(self):
             return self.contained
 
     obj = ObjContainer()
-    assert utils.to_marshallable_type(obj) == {"foo": 1}
+    assert utils.to_marshallable_type(obj) == {'foo': 1}
 
 def test_is_collection():
     assert utils.is_collection([1, 'foo', {}]) is True
@@ -150,7 +150,7 @@ def test_is_collection():
 
 def test_rfcformat_gmt_naive():
     d = dt.datetime(2013, 11, 10, 1, 23, 45)
-    assert utils.rfcformat(d) == "Sun, 10 Nov 2013 01:23:45 -0000"
+    assert utils.rfcformat(d) == 'Sun, 10 Nov 2013 01:23:45 -0000'
 
 def test_rfcformat_central():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
@@ -158,7 +158,7 @@ def test_rfcformat_central():
 
 def test_rfcformat_central_localized():
     d = central.localize(dt.datetime(2013, 11, 10, 8, 23, 45), is_dst=False)
-    assert utils.rfcformat(d, localtime=True) == "Sun, 10 Nov 2013 08:23:45 -0600"
+    assert utils.rfcformat(d, localtime=True) == 'Sun, 10 Nov 2013 08:23:45 -0600'
 
 def test_isoformat():
     d = dt.datetime(2013, 11, 10, 1, 23, 45)
@@ -166,11 +166,11 @@ def test_isoformat():
 
 def test_isoformat_tzaware():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
-    assert utils.isoformat(d) == "2013-11-10T07:23:45+00:00"
+    assert utils.isoformat(d) == '2013-11-10T07:23:45+00:00'
 
 def test_isoformat_localtime():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
-    assert utils.isoformat(d, localtime=True) == "2013-11-10T01:23:45-06:00"
+    assert utils.isoformat(d, localtime=True) == '2013-11-10T01:23:45-06:00'
 
 def test_from_datestring():
     d = dt.datetime.now()


### PR DESCRIPTION
Use single quotes unless it requires escaping. Use triple
double quotes for docstrings