### PR TITLE
Officially support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
 script: invoke test
 jobs:
   include:
+  - python: 3.7
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
   - stage: PyPI Release
     if: tag IS present
     python: "3.6"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Other changes:
 - *Backwards-incompatible*: ``Nested`` field now defaults to ``unknown=RAISE``
   instead of ``EXCLUDE``. This harmonizes behavior with ``Schema`` that
   already defaults to ``RAISE`` (:issue:`908`). Thanks :user:`tuukkamustonen`.
+- Tested against Python 3.7.
 
 3.0.0b13 (2018-08-04)
 +++++++++++++++++++++

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,7 +103,7 @@ To run all tests: ::
 
     $ invoke test
 
-To run tests on Python 2.7, 3.5, 3.6, and PyPy virtual environments (must have each interpreter installed): ::
+To run tests on Python 2.7, 3.5, 3.6, 3.7, and PyPy virtual environments (must have each interpreter installed): ::
 
     $ tox
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,pypy
+envlist=py27,py35,py36,py37,pypy
 [testenv]
 deps=
   -rdev-requirements.txt


### PR DESCRIPTION
Tests against Python 3.7.

This can't be merged because Python 3.7 isn't supported by Travis yet: https://github.com/travis-ci/travis-ci/issues/9069