### PR TITLE
Rework schema errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,19 @@ Changelog
 3.0.0b13 (unreleased)
 +++++++++++++++++++++
 
+Bug fixes:
+
+- Errors reported by a schema-level validator for a field in a ``Nested`` field
+are stored under corresponding field name, not ``_schema `` key (:issue: `862`).
+
 Other changes:
 
 - *Backwards-incompatible*: The ``unknown`` option now defaults to ``RAISE``
   (`#524 (comment) <https://github.com/marshmallow-code/marshmallow/issues/524#issuecomment-397165731>`_,
   :issue:`851`).
+- *Backwards-incompatible*: When a schema error is raised with a ``dict`` as
+  payload, the ``dict`` overwrites any existing error list. Before this change,
+  it would be appended to the list.
 
 3.0.0b12 (2018-07-04)
 +++++++++++++++++++++

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -251,7 +251,6 @@ class Unmarshaller(ErrorStore):
             errors = self.get_errors(index=index)
             msg = 'Invalid input type.'
             self.error_field_names = [SCHEMA]
-            errors = self.get_errors()
             errors.setdefault(SCHEMA, []).append(msg)
         else:
             for attr_name, field_obj in iteritems(fields_dict):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -375,14 +375,10 @@ class TestValidatesDecorator:
 
 class TestValidatesSchemaDecorator:
 
-    def test_validator_nested_many(self):
+    def test_validator_nested_many_invalid_data(self):
 
         class NestedSchema(Schema):
             foo = fields.Int(required=True)
-
-            @validates_schema
-            def validate_schema(self, data):
-                raise ValidationError('This will never work', 'foo')
 
         class MySchema(Schema):
             nested = fields.Nested(NestedSchema, required=True, many=True)
@@ -392,8 +388,45 @@ class TestValidatesSchemaDecorator:
         assert errors
         assert 'nested' in errors
         assert 0 in errors['nested']
-        assert '_schema' in errors['nested']
-        assert 'foo' not in errors['nested']
+        assert errors['nested'][0] == {'_schema': ['Invalid input type.']}
+
+    def test_validator_nested_many_schema_error(self):
+
+        class NestedSchema(Schema):
+            foo = fields.Int(required=True)
+
+            @validates_schema
+            def validate_schema(self, data):
+                raise ValidationError('This will never work.')
+
+        class MySchema(Schema):
+            nested = fields.Nested(NestedSchema, required=True, many=True)
+
+        schema = MySchema()
+        errors = schema.validate({'nested': [{'foo': 1}]})
+        assert errors
+        assert 'nested' in errors
+        assert 0 in errors['nested']
+        assert errors['nested'][0] == {'_schema': ['This will never work.']}
+
+    def test_validator_nested_many_field_error(self):
+
+        class NestedSchema(Schema):
+            foo = fields.Int(required=True)
+
+            @validates_schema
+            def validate_schema(self, data):
+                raise ValidationError('This will never work.', 'foo')
+
+        class MySchema(Schema):
+            nested = fields.Nested(NestedSchema, required=True, many=True)
+
+        schema = MySchema()
+        errors = schema.validate({'nested': [{'foo': 1}]})
+        assert errors
+        assert 'nested' in errors
+        assert 0 in errors['nested']
+        assert errors['nested'][0] == {'foo': ['This will never work.']}
 
     @pytest.mark.parametrize('data', ([{'foo': 1, 'bar': 2}],))
     @pytest.mark.parametrize(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -556,19 +556,16 @@ class TestValidatesSchemaDecorator:
         schema = MySchema(unknown=EXCLUDE)
         errors = schema.validate({'foo': 4, 'baz': 42})
         assert '_schema' in errors
-        assert len(errors['_schema']) == 1
-        assert errors['_schema'][0] == {'code': 'invalid_field'}
+        assert errors['_schema'] == {'code': 'invalid_field'}
 
         errors = schema.validate({'foo': '4'})
         assert '_schema' in errors
-        assert len(errors['_schema']) == 1
-        assert errors['_schema'][0] == 'foo cannot be a string'
+        assert errors['_schema'] == ['foo cannot be a string']
 
         schema = MySchema(unknown=EXCLUDE)
         errors = schema.validate([{'foo': 4, 'baz': 42}], many=True)
         assert '_schema' in errors
-        assert len(errors['_schema']) == 1
-        assert errors['_schema'][0] == {'code': 'invalid_field'}
+        assert errors['_schema'] == {'code': 'invalid_field'}
 
     # https://github.com/marshmallow-code/marshmallow/issues/273
     def test_allow_arbitrary_field_names_in_error(self):


### PR DESCRIPTION
I tried to address issues raised in https://github.com/marshmallow-code/marshmallow/pull/857#issuecomment-400737110 by refactoring the code.

The first commit (https://github.com/marshmallow-code/marshmallow/pull/862/commits/9f84247bad8693ec8e357252aa35d9b4e07093a8) changes the error structure in a corner case, but in a good way. It could be considered a bugfix. I can send a separate PR for this one if needed.

The other commits are about factorizing the code that stores schema errors by adapting `store_error` (that normally stores field errors) while it is currently duplicated in `Unmarshaller`. I'm happy with this rework (not "this is so perfect" happy, but rather "this is much better" happy), except one test is broken.

When `store_error` receives a `dict` as message, it does not merge it, nor does it append it to the current error messages list. It just uses it as error message.

```python
        if isinstance(messages, dict):
            errors[field_name] = messages
```

Hence the test I had to modify:

```python
-        assert errors['_schema'][0] == {'code': 'invalid_field'}
+        assert errors['_schema'] == {'code': 'invalid_field'}
```

This differs from the behaviour of the code duplicated in `Unmarshaller`. And changing this in `store_error` would break a lot of field errors tests.

While working on this, I ended up facing the issues described in https://github.com/marshmallow-code/marshmallow/issues/441. I think I'll either follow-up there or create a separate issue.