### PR TITLE
WIP - Fix 'error on Nested field is stored under "_field" key'

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1941,9 +1941,10 @@ class TestNestedSchema:
         assert errors['inner']['_schema'] == ['Invalid input type.']
 
     # regression test for https://github.com/marshmallow-code/marshmallow/issues/298
-    def test_all_errors_on_many_nested_field_with_validates_decorator(self):
+    @pytest.mark.parametrize('required', (True, False))
+    def test_all_errors_on_many_nested_field_with_validates_decorator(self, required):
         class Inner(Schema):
-            req = fields.Field(required=True)
+            req = fields.Field(required=required)
 
         class Outer(Schema):
             inner = fields.Nested(Inner, many=True)


### PR DESCRIPTION
This is just a failing test case for the issue I described in https://github.com/marshmallow-code/marshmallow/pull/299#issuecomment-401607834.

> The required constraint triggers an error inside the Nested field, and `errors` is equal to:
> 
> ```python
> {'inner': {0: {'req': ['Missing data for required field.']}, '_field': ['not a chance']}}
> ```
> 
> This is the behaviour that is tested.
> 
> However, if the `required` constraint is removed from `Inner.req`, no error is raised from inside the Nested field, then we don't pass in 
> 
> ```python
>             elif isinstance(errors.get(field_name), dict):
>                 errors[field_name].setdefault(FIELD, []).extend(err.messages)
> ```
> 
> and error is :
> 
> ```python
> {'inner': ['not a chance']}
> ```
> 
> This is inconsistent.

The usage of `_field` seems like a good idea, but we need a more reliable way to determine that the field is a Nested field, or that `_field` should be used.

I didn't see any obvious solution. This could be part of a larger reflection about the error structure (including https://github.com/marshmallow-code/marshmallow/issues/441).