### PR TITLE
field_b must be greater or equal field_a

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -261,7 +261,7 @@ You can register schema-level validation functions for a :class:`Schema` using t
 
     schema = NumberSchema()
     try:
-        schema.load({'field_a': 2, 'field_b': 1})
+        schema.load({'field_a': 1, 'field_b': 2})
     except ValidationError as err:
         err.messages['_schema']
     # => ["field_a must be greater than field_b"]


### PR DESCRIPTION
On "Storing Errors on Specific Fields": to raise an error field_b must be greater or equal field_a, not the inverse.