### PR TITLE
Differentiate between datetimeformat and dateformat

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,3 +105,4 @@ Contributors (chronological)
 - Prasanjit Prakash `@ikilledthecat <https://github.com/ikilledthecat>`_
 - Guillaume Gelin `@ramnes <https://github.com/ramnes>`_
 - Maxim Novikov `@m-novikov <https://github.com/m-novikov>`_
+- Karandeep Singh Nagra `@knagra <https://github.com/knagra>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -955,42 +955,46 @@ class DateTime(Field):
             self.DEFAULT_FORMAT
 
     def _serialize(self, value, attr, obj):
-        self.format = self.format or self.DEFAULT_FORMAT
+        data_format = self.format or self.DEFAULT_FORMAT
         if value is None:
             return None
-        format_func = self.SERIALIZATION_FUNCS.get(self.format, None)
+        format_func = self.SERIALIZATION_FUNCS.get(data_format, None)
         if format_func:
             try:
                 return format_func(value, localtime=self.localtime)
             except (TypeError, AttributeError, ValueError):
                 self.fail('format', input=value, obj_type=self.OBJ_TYPE)
         else:
-            return value.strftime(self.format)
+            return value.strftime(data_format)
+
+    def _create_data_object_from_parsed_value(self, parsed):
+        """
+        Return a datetime from a parsed object that contains the needed info.
+        """
+        return dt.datetime(
+            parsed.year, parsed.month, parsed.day, parsed.hour, parsed.minute,
+            parsed.second,
+        )
 
     def _deserialize(self, value, attr, data):
-        self.format = self.format or self.DEFAULT_FORMAT
+        data_format = self.format or self.DEFAULT_FORMAT
         if not value:  # Falsy values, e.g. '', None, [] are not valid
             raise self.fail('invalid', obj_type=self.OBJ_TYPE)
-        func = self.DESERIALIZATION_FUNCS.get(
-            self.format,
-        )
+        func = self.DESERIALIZATION_FUNCS.get(data_format)
         if func:
             try:
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid', obj_type=self.OBJ_TYPE)
-        elif self.format:
+        elif data_format:
             try:
-                return dt.datetime.strptime(value, self.format)
+                return dt.datetime.strptime(value, data_format)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid', obj_type=self.OBJ_TYPE)
         elif utils.dateutil_available:
             try:
                 parsed = utils.from_datestring(value)
-                return dt.datetime(
-                    parsed.year, parsed.month, parsed.day, parsed.hour,
-                    parsed.minute, parsed.second,
-                )
+                return self._create_data_object_from_parsed_value(parsed)
             except (TypeError, ValueError):
                 raise self.fail('invalid', obj_type=self.OBJ_TYPE)
         else:
@@ -1069,6 +1073,12 @@ class Date(DateTime):
     OBJ_TYPE = 'date'
 
     SCHEMA_OPTS_VAR_NAME = 'dateformat'
+
+    def _create_data_object_from_parsed_value(self, parsed):
+        """
+        Return a date from a parsed object that contains the need information.
+        """
+        return dt.date(parsed.year, parsed.month, parsed.day)
 
 
 class TimeDelta(Field):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -944,21 +944,23 @@ class DateTime(Field):
     def __init__(self, format=None, **kwargs):
         super(DateTime, self).__init__(**kwargs)
         # Allow this to be None. It may be set later in the ``_serialize``
-        # or ``_desrialize`` methods This allows a Schema to dynamically set the
+        # or ``_deserialize`` methods This allows a Schema to dynamically set the
         # format, e.g. from a Meta option
         self.format = format
 
     def _add_to_schema(self, field_name, schema):
         super(DateTime, self)._add_to_schema(field_name, schema)
-        self.format = self.format or \
-            getattr(schema.opts, self.SCHEMA_OPTS_VAR_NAME) or \
+        self.format = (
+            self.format or
+            getattr(schema.opts, self.SCHEMA_OPTS_VAR_NAME) or
             self.DEFAULT_FORMAT
+        )
 
     def _serialize(self, value, attr, obj):
-        data_format = self.format or self.DEFAULT_FORMAT
         if value is None:
             return None
-        format_func = self.SERIALIZATION_FUNCS.get(data_format, None)
+        data_format = self.format or self.DEFAULT_FORMAT
+        format_func = self.SERIALIZATION_FUNCS.get(data_format)
         if format_func:
             try:
                 return format_func(value, localtime=self.localtime)
@@ -977,9 +979,9 @@ class DateTime(Field):
         )
 
     def _deserialize(self, value, attr, data):
-        data_format = self.format or self.DEFAULT_FORMAT
         if not value:  # Falsy values, e.g. '', None, [] are not valid
             raise self.fail('invalid', obj_type=self.OBJ_TYPE)
+        data_format = self.format or self.DEFAULT_FORMAT
         func = self.DESERIALIZATION_FUNCS.get(data_format)
         if func:
             try:

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -915,14 +915,14 @@ class DateTime(Field):
 
     """
 
-    DATEFORMAT_SERIALIZATION_FUNCS = {
+    SERIALIZATION_FUNCS = {
         'iso': utils.isoformat,
         'iso8601': utils.isoformat,
         'rfc': utils.rfcformat,
         'rfc822': utils.rfcformat,
     }
 
-    DATEFORMAT_DESERIALIZATION_FUNCS = {
+    DESERIALIZATION_FUNCS = {
         'iso': utils.from_iso_datetime,
         'iso8601': utils.from_iso_datetime,
         'rfc': utils.from_rfc,
@@ -931,62 +931,74 @@ class DateTime(Field):
 
     DEFAULT_FORMAT = 'iso'
 
+    OBJ_TYPE = 'datetime'
+
+    SCHEMA_OPTS_VAR_NAME = 'datetimeformat'
+
     localtime = False
     default_error_messages = {
-        'invalid': 'Not a valid datetime.',
-        'format': '"{input}" cannot be formatted as a datetime.',
+        'invalid': 'Not a valid {obj_type}.',
+        'format': '"{input}" cannot be formatted as a {obj_type}.',
     }
 
     def __init__(self, format=None, **kwargs):
         super(DateTime, self).__init__(**kwargs)
         # Allow this to be None. It may be set later in the ``_serialize``
         # or ``_desrialize`` methods This allows a Schema to dynamically set the
-        # dateformat, e.g. from a Meta option
-        self.dateformat = format
+        # format, e.g. from a Meta option
+        self.format = format
 
     def _add_to_schema(self, field_name, schema):
         super(DateTime, self)._add_to_schema(field_name, schema)
-        self.dateformat = self.dateformat or schema.opts.dateformat
+        self.format = self.format or \
+            getattr(schema.opts, self.SCHEMA_OPTS_VAR_NAME) or \
+            self.DEFAULT_FORMAT
 
     def _serialize(self, value, attr, obj):
+        self.format = self.format or self.DEFAULT_FORMAT
         if value is None:
             return None
-        dateformat = self.dateformat or self.DEFAULT_FORMAT
-        format_func = self.DATEFORMAT_SERIALIZATION_FUNCS.get(dateformat, None)
+        format_func = self.SERIALIZATION_FUNCS.get(self.format, None)
         if format_func:
             try:
                 return format_func(value, localtime=self.localtime)
-            except (AttributeError, ValueError):
-                self.fail('format', input=value)
+            except (TypeError, AttributeError, ValueError):
+                self.fail('format', input=value, obj_type=self.OBJ_TYPE)
         else:
-            return value.strftime(dateformat)
+            return value.strftime(self.format)
 
     def _deserialize(self, value, attr, data):
+        self.format = self.format or self.DEFAULT_FORMAT
         if not value:  # Falsy values, e.g. '', None, [] are not valid
-            raise self.fail('invalid')
-        dateformat = self.dateformat or self.DEFAULT_FORMAT
-        func = self.DATEFORMAT_DESERIALIZATION_FUNCS.get(dateformat)
+            raise self.fail('invalid', obj_type=self.OBJ_TYPE)
+        func = self.DESERIALIZATION_FUNCS.get(
+            self.format,
+        )
         if func:
             try:
                 return func(value)
             except (TypeError, AttributeError, ValueError):
-                raise self.fail('invalid')
-        elif dateformat:
+                raise self.fail('invalid', obj_type=self.OBJ_TYPE)
+        elif self.format:
             try:
-                return dt.datetime.strptime(value, dateformat)
+                return dt.datetime.strptime(value, self.format)
             except (TypeError, AttributeError, ValueError):
-                raise self.fail('invalid')
+                raise self.fail('invalid', obj_type=self.OBJ_TYPE)
         elif utils.dateutil_available:
             try:
-                return utils.from_datestring(value)
-            except TypeError:
-                raise self.fail('invalid')
+                parsed = utils.from_datestring(value)
+                return dt.datetime(
+                    parsed.year, parsed.month, parsed.day, parsed.hour,
+                    parsed.minute, parsed.second,
+                )
+            except (TypeError, ValueError):
+                raise self.fail('invalid', obj_type=self.OBJ_TYPE)
         else:
             warnings.warn(
                 'It is recommended that you install python-dateutil '
                 'for improved datetime deserialization.',
             )
-            raise self.fail('invalid')
+            raise self.fail('invalid', obj_type=self.OBJ_TYPE)
 
 
 class LocalDateTime(DateTime):
@@ -1030,9 +1042,11 @@ class Time(Field):
             self.fail('invalid')
 
 
-class Date(Field):
+class Date(DateTime):
     """ISO8601-formatted date string.
 
+    :param format: Either ``"iso"`` (for ISO8601) or a date format string.
+        If `None`, defaults to "iso".
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
     default_error_messages = {
@@ -1040,25 +1054,21 @@ class Date(Field):
         'format': '"{input}" cannot be formatted as a date.',
     }
 
-    def _serialize(self, value, attr, obj):
-        if value is None:
-            return None
-        try:
-            return value.isoformat()
-        except AttributeError:
-            self.fail('format', input=value)
-        return value
+    SERIALIZATION_FUNCS = {
+        'iso': utils.to_iso_date,
+        'iso8601': utils.to_iso_date,
+    }
 
-    def _deserialize(self, value, attr, data):
-        """Deserialize an ISO8601-formatted date string to a
-        :class:`datetime.date` object.
-        """
-        if not value:  # falsy values are invalid
-            self.fail('invalid')
-        try:
-            return utils.from_iso_date(value)
-        except (AttributeError, TypeError, ValueError):
-            self.fail('invalid')
+    DESERIALIZATION_FUNCS = {
+        'iso': utils.from_iso_date,
+        'iso8601': utils.from_iso_date,
+    }
+
+    DEFAULT_FORMAT = 'iso'
+
+    OBJ_TYPE = "date"
+
+    SCHEMA_OPTS_VAR_NAME = 'dateformat'
 
 
 class TimeDelta(Field):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1066,7 +1066,7 @@ class Date(DateTime):
 
     DEFAULT_FORMAT = 'iso'
 
-    OBJ_TYPE = "date"
+    OBJ_TYPE = 'date'
 
     SCHEMA_OPTS_VAR_NAME = 'dateformat'
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -201,6 +201,7 @@ class SchemaOpts(object):
         if not isinstance(self.exclude, (list, tuple)):
             raise ValueError('`exclude` must be a list or tuple.')
         self.dateformat = getattr(meta, 'dateformat', None)
+        self.datetimeformat = getattr(meta, 'datetimeformat', None)
         if hasattr(meta, 'json_module'):
             warnings.warn(
                 'The json_module class Meta option is deprecated. Use render_module instead.',

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -309,6 +309,11 @@ def from_iso_date(datestring, use_dateutil=True):
     else:
         return datetime.datetime.strptime(datestring[:10], '%Y-%m-%d').date()
 
+
+def to_iso_date(date, *args, **kwargs):
+    return datetime.date.isoformat(date)
+
+
 def ensure_text_type(val):
     if isinstance(val, binary_type):
         val = val.decode('utf-8')

--- a/tests/base.py
+++ b/tests/base.py
@@ -89,6 +89,7 @@ class User(object):
         self.uid = uuid.uuid1()
         self.time_registered = time_registered or dt.time(1, 23, 45, 6789)
         self.birthdate = birthdate or dt.date(2013, 1, 23)
+        self.activation_date = dt.date(2013, 12, 11)
         self.sex = sex
         self.employer = employer
         self.relatives = []
@@ -170,6 +171,7 @@ class UserSchema(Schema):
     uid = fields.UUID()
     time_registered = fields.Time()
     birthdate = fields.Date()
+    activation_date = fields.Date()
     since_created = fields.TimeDelta()
     sex = fields.Str(validate=validate.OneOf(['male', 'female']))
     various_data = fields.Dict()

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -349,13 +349,14 @@ class TestFieldDeserialization:
             42,
             '',
             [],
+            '2018-01-01',
         ],
     )
     def test_invalid_datetime_deserialization(self, in_value):
         field = fields.DateTime()
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize(in_value)
-        msg = 'Not a valid datetime.'.format(in_value)
+        msg = 'Not a valid datetime.'
         assert msg in str(excinfo)
 
     def test_datetime_passed_year_is_invalid(self):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1468,18 +1468,31 @@ def test_exclude_option_must_be_list_or_tuple():
             class Meta:
                 exclude = 'name'
 
-def test_dateformat_option(user):
+def test_datetimeformat_option(user):
     fmt = '%Y-%m'
 
-    class DateFormatSchema(Schema):
+    class DateTimeFormatSchema(Schema):
         updated = fields.DateTime('%m-%d')
 
         class Meta:
             fields = ('created', 'updated')
-            dateformat = fmt
-    serialized = DateFormatSchema().dump(user)
+            datetimeformat = fmt
+    serialized = DateTimeFormatSchema().dump(user)
     assert serialized['created'] == user.created.strftime(fmt)
     assert serialized['updated'] == user.updated.strftime('%m-%d')
+
+def test_dateformat_option(user):
+    fmt = '%Y-%m'
+
+    class DateFormatSchema(Schema):
+        birthdate = fields.Date('%m-%d')
+
+        class Meta:
+            fields = ('birthdate', 'activation_date')
+            dateformat = fmt
+    serialized = DateFormatSchema().dump(user)
+    assert serialized['birthdate'] == user.birthdate.strftime('%m-%d')
+    assert serialized['activation_date'] == user.activation_date.strftime(fmt)
 
 def test_default_dateformat(user):
     class DateFormatSchema(Schema):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1469,29 +1469,31 @@ def test_exclude_option_must_be_list_or_tuple():
                 exclude = 'name'
 
 def test_datetimeformat_option(user):
-    fmt = '%Y-%m'
+    meta_fmt = '%Y-%m'
+    field_fmt = '%m-%d'
 
     class DateTimeFormatSchema(Schema):
-        updated = fields.DateTime('%m-%d')
+        updated = fields.DateTime(field_fmt)
 
         class Meta:
             fields = ('created', 'updated')
-            datetimeformat = fmt
+            datetimeformat = meta_fmt
     serialized = DateTimeFormatSchema().dump(user)
-    assert serialized['created'] == user.created.strftime(fmt)
-    assert serialized['updated'] == user.updated.strftime('%m-%d')
+    assert serialized['created'] == user.created.strftime(meta_fmt)
+    assert serialized['updated'] == user.updated.strftime(field_fmt)
 
 def test_dateformat_option(user):
     fmt = '%Y-%m'
+    field_fmt = '%m-%d'
 
     class DateFormatSchema(Schema):
-        birthdate = fields.Date('%m-%d')
+        birthdate = fields.Date(field_fmt)
 
         class Meta:
             fields = ('birthdate', 'activation_date')
             dateformat = fmt
     serialized = DateFormatSchema().dump(user)
-    assert serialized['birthdate'] == user.birthdate.strftime('%m-%d')
+    assert serialized['birthdate'] == user.birthdate.strftime(field_fmt)
     assert serialized['activation_date'] == user.activation_date.strftime(fmt)
 
 def test_default_dateformat(user):


### PR DESCRIPTION
Marshmallow currently uses `dateformat` in the `DateTime` field and does not support a custom format for `Date`. This PR changes `DateTime.dateformat` to `DateTime.DateTimeFormat` and adds `Date.dateformat`.

This is my first PR for this repo. Please let me know if I'm breaking any protocols or if other changes are necessary for this to be merged.