### PR TITLE
 Raise StringNotCollectionError if only or exclude is passed as string

### DIFF
--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -50,3 +50,7 @@ class RegistryError(NameError):
     """Raised when an invalid operation is performed on the serializer
     class registry.
     """
+
+
+class StringNotCollectionError(MarshmallowError, TypeError):
+    """Raised when a string is passed while a list of string is expected."""

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -5,7 +5,6 @@ from marshmallow.compat import basestring
 
 class MarshmallowError(Exception):
     """Base class for all marshmallow-related errors."""
-    pass
 
 
 class ValidationError(MarshmallowError):
@@ -18,11 +17,7 @@ class ValidationError(MarshmallowError):
         If `None`, the error is stored in its default location.
     :param list fields: `Field` objects to which the error applies.
     """
-
-    def __init__(
-        self, message, field_names=None,
-        data=None, valid_data=None, **kwargs
-    ):
+    def __init__(self, message, field_names=None, data=None, valid_data=None, **kwargs):
         if not isinstance(message, dict) and not isinstance(message, list):
             messages = [message]
         else:
@@ -50,8 +45,8 @@ class ValidationError(MarshmallowError):
             return {no_field_name: self.messages}
         return dict((name, self.messages) for name in self.field_names)
 
+
 class RegistryError(NameError):
     """Raised when an invalid operation is performed on the serializer
     class registry.
     """
-    pass

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -20,7 +20,7 @@ from marshmallow.compat import (
     text_type,
     with_metaclass,
 )
-from marshmallow.exceptions import ValidationError
+from marshmallow.exceptions import ValidationError, StringNotCollectionError
 from marshmallow.orderedset import OrderedSet
 from marshmallow.decorators import (
     POST_DUMP,
@@ -30,7 +30,7 @@ from marshmallow.decorators import (
     VALIDATES,
     VALIDATES_SCHEMA,
 )
-from marshmallow.utils import RAISE, missing
+from marshmallow.utils import RAISE, missing, is_collection
 
 
 def _get_fields(attrs, field_class, pop=False, ordered=False):
@@ -337,6 +337,11 @@ class BaseSchema(base.SchemaABC):
         context=None, load_only=(), dump_only=(), partial=False,
         unknown=None,
     ):
+        # Raise error if only or exclude is passed as string, not list of strings
+        if only is not None and not is_collection(only):
+            raise StringNotCollectionError('"only" should be a list of strings')
+        if exclude is not None and not is_collection(exclude):
+            raise StringNotCollectionError('"exclude" should be a list of strings')
         # copy declared fields from metaclass
         self.declared_fields = copy.deepcopy(self._declared_fields)
         self.many = many

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,7 +10,7 @@ from collections import namedtuple, OrderedDict
 import pytest
 
 from marshmallow import Schema, fields, utils, validates, validates_schema, EXCLUDE
-from marshmallow.exceptions import ValidationError
+from marshmallow.exceptions import ValidationError, StringNotCollectionError
 
 from tests.base import (
     assert_almost_equal,
@@ -1383,6 +1383,14 @@ def test_only_empty():
     sch = MySchema(only=())
     assert 'foo' not in sch.dump({'foo': 'bar'})
 
+
+@pytest.mark.parametrize('param', ('only', 'exclude'))
+def test_only_and_exclude_as_string(param):
+    class MySchema(Schema):
+        foo = fields.Field()
+
+    with pytest.raises(StringNotCollectionError):
+        MySchema(**{param: 'foo'})
 
 def test_nested_with_sets():
     class Inner(Schema):


### PR DESCRIPTION
Closes https://github.com/marshmallow-code/marshmallow/issues/316.

This only deals with `only`/`exclude` as `Schema` parameters.

I realized afterwards that we should raise the same error when passing `only`/`exclude` as strings in `Nested` but I can't do it right now as we need @deckar01's `Pluck` (https://github.com/marshmallow-code/marshmallow/pull/823) finalized first.