### PR TITLE
Fixes for #906 (TypeError with many=True) and #907 (return [] not {} on many=True error) and #930 (disallows strings and dicts on many=True)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Bug fixes:
 
 - Raise ``ValidationError`` instead of ``TypeError`` when non-iterable types are
   validated with ``many=True`` (:issue:`851`). Thanks :user:`tuukkamustonen`.
+- Return ``[]`` as ``ValidationError.valid_data`` instead of ``{}`` with
+  ``many=True`` (:issue:`907`). Thanks :user:`tuukkamustonen`.
 
 3.0.0b13 (2018-08-04)
 +++++++++++++++++++++

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Features:
 - Raise a `StringNotCollectionError` if ``only`` or ``exclude`` is
   passed as a string to ``fields.Nested`` (:pr:`931`).
 
+Bug fixes:
+
+- Raise ``ValidationError`` instead of ``TypeError`` when non-iterable types are
+  validated with ``many=True`` (:issue:`851`). Thanks :user:`tuukkamustonen`.
+
 3.0.0b13 (2018-08-04)
 +++++++++++++++++++++
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Bug fixes:
   validated with ``many=True`` (:issue:`851`). Thanks :user:`tuukkamustonen`.
 - Return ``[]`` as ``ValidationError.valid_data`` instead of ``{}`` with
   ``many=True`` (:issue:`907`). Thanks :user:`tuukkamustonen`.
+- ``many=True`` no longer iterates over ``str`` and ``collections.Mapping`` objects, and rather
+  raises ``{'_schema': ['Invalid input type.']}`` error directly (:issue:`930`).
+  Thanks :user:`tuukkamustonen`.
 
 3.0.0b13 (2018-08-04)
 +++++++++++++++++++++

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 import collections
 
 from marshmallow.utils import (
-    EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value,
+    EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value, is_iterable_but_not_string
 )
 from marshmallow.compat import iteritems, basestring
 from marshmallow.exceptions import (
@@ -210,7 +210,7 @@ class Unmarshaller(ErrorStore):
             serializing a collection, otherwise `None`.
         :return: A dictionary of the deserialized data.
         """
-        if many and data is not None:
+        if many and data is not None and is_iterable_but_not_string(data):
             self._pending = True
             ret = [
                 self.deserialize(

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 import collections
 
 from marshmallow.utils import (
-    EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value, is_iterable_but_not_string
+    EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value
 )
 from marshmallow.compat import iteritems, basestring
 from marshmallow.exceptions import (
@@ -211,7 +211,7 @@ class Unmarshaller(ErrorStore):
         :return: A dictionary of the deserialized data.
         """
         ret = dict_class() if not many else []
-        if many and data is not None and is_iterable_but_not_string(data):
+        if many and data is not None and is_collection(data):
             self._pending = True
             ret.extend([
                 self.deserialize(
@@ -231,7 +231,7 @@ class Unmarshaller(ErrorStore):
                     data=ret,
                 )
             return ret
-        if not isinstance(data, collections.Mapping):
+        if not isinstance(data, collections.Mapping) or many:
             self.store_error(SCHEMA, ('Invalid input type.', ), index=index)
         else:
             partial_is_collection = is_collection(partial)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1633,6 +1633,22 @@ class TestHandleError:
 
 class TestFieldValidation:
 
+    @pytest.mark.parametrize('val', (None, False, 1, 1.2, object()))
+    def test_non_iterables_with_many(self, val):
+        class Sch(Schema):
+            name = fields.Str()
+
+        with pytest.raises(ValidationError) as e:
+            Sch().load(val)
+        assert e.value.messages == {'_schema': ['Invalid input type.']}
+        assert e.value.valid_data == {}
+
+        with pytest.raises(ValidationError) as e:
+            # This was https://github.com/marshmallow-code/marshmallow/issues/906
+            Sch(many=True).load(val)
+        assert e.value.messages == {'_schema': ['Invalid input type.']}
+        assert e.value.valid_data == {}
+
     def test_errors_are_cleared_after_loading_collection(self):
         def always_fail(val):
             raise ValidationError('lol')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1647,7 +1647,7 @@ class TestFieldValidation:
             # This was https://github.com/marshmallow-code/marshmallow/issues/906
             Sch(many=True).load(val)
         assert e.value.messages == {'_schema': ['Invalid input type.']}
-        assert e.value.valid_data == {}
+        assert e.value.valid_data == []
 
     def test_errors_are_cleared_after_loading_collection(self):
         def always_fail(val):


### PR DESCRIPTION
See #906 and #907. In same PR, as latter one re-uses fix and test of the former.

Do you want me to move the test from `test_schema.py` to `test_marshalling.py` (as the fixes are in `marshalling` module?

Also, I wonder if these need to be reflected in `Marshaller.serialize()`, too? What is the intended behavior if you try to marshall a primitive, for example?

I took liberty to thank myself in changelog :)