### PR TITLE
Nested: raise StringNotCollectionError if only or exclude is passed as string

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -12,10 +12,10 @@ import decimal
 
 from marshmallow import validate, utils, class_registry
 from marshmallow.base import FieldABC, SchemaABC
-from marshmallow.utils import EXCLUDE
+from marshmallow.utils import EXCLUDE, is_collection
 from marshmallow.utils import missing as missing_
 from marshmallow.compat import text_type, basestring
-from marshmallow.exceptions import ValidationError
+from marshmallow.exceptions import ValidationError, StringNotCollectionError
 from marshmallow.validate import Validator
 
 __all__ = [
@@ -384,6 +384,11 @@ class Nested(Field):
     }
 
     def __init__(self, nested, default=missing_, exclude=tuple(), only=None, **kwargs):
+        # Raise error if only or exclude is passed as string, not list of strings
+        if only is not None and not is_collection(only):
+            raise StringNotCollectionError('"only" should be a list of strings')
+        if exclude is not None and not is_collection(exclude):
+            raise StringNotCollectionError('"exclude" should be a list of strings')
         self.nested = nested
         self.only = only
         self.exclude = exclude

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -3,6 +3,7 @@ import pytest
 
 from marshmallow import fields, Schema, ValidationError, EXCLUDE
 from marshmallow.marshalling import missing
+from marshmallow.exceptions import StringNotCollectionError
 
 from tests.base import ALL_FIELDS, User
 
@@ -191,3 +192,11 @@ class TestErrorMessages:
 
         assert 'doesntexist' in excinfo.value.args[0]
         assert 'MyField' in excinfo.value.args[0]
+
+
+class TestNestedField:
+
+    @pytest.mark.parametrize('param', ('only', 'exclude'))
+    def test_nested_only_and_exclude_as_string(self, param):
+        with pytest.raises(StringNotCollectionError):
+            fields.Nested(Schema, **{param: 'foo'})


### PR DESCRIPTION
Same as #896 but for `Nested`.