### PR TITLE
WIP - Add AwareDateTime and NaiveDateTime

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -24,7 +24,7 @@ RAISE = 'raise'
 
 dateutil_available = False
 try:
-    from dateutil import parser
+    from dateutil import parser, tz as dateutil_tz
     dateutil_available = True
 except ImportError:
     dateutil_available = False
@@ -308,6 +308,13 @@ def from_iso_date(datestring, use_dateutil=True):
         return parser.parse(datestring).date()
     else:
         return datetime.datetime.strptime(datestring[:10], '%Y-%m-%d').date()
+
+def str2tz(timezone):
+    if timezone == 'UTC':
+        return UTC
+    if dateutil_available:
+        return dateutil_tz.gettz(timezone)
+    raise ValueError('Invalid timezone or dateutil not installed.')
 
 def ensure_text_type(val):
     if isinstance(val, binary_type):

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,6 +50,11 @@ def assert_datetime_equal(dt1, dt2):
     assert dt1.hour == dt2.hour
     assert dt1.minute == dt2.minute
 
+def assert_datetime_tz_aware(dt):
+    return dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None
+
+def assert_datetime_tz_naive(dt):
+    return dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None
 
 def assert_time_equal(t1, t2, microseconds=True):
     assert t1.hour == t2.hour


### PR DESCRIPTION
Tackling https://github.com/marshmallow-code/marshmallow/issues/520.

This provides `AwareDateTime` and `NaiveDateTime` fields.

Currently, only deserialization is supported. Those fields enforce awareness/naiveness when deserializing (which IMHO is critical if application code only deals with one type of datetime, see #520).

They take a timezone as parameter to use as default, but `AwareDateTime` keeps input timezone if there is one and `NaiveDateTime` uses it only to convert a datetime expressed with a non-UTC timezone to UTC before removing the timezone.

Deserialization is only tested with iso8601, not rfc822.

Docstrings are drafts and should be reworded.

I've been using `AwareDateTime` for a while in my applications.

Serialization is a bit harder because it conflicts with utils functions `isoformat` and `rfcformat`. I didn't look into rfc but `isoformat`, for instance, forces serialization as aware. A greater refactor would be needed.

The whole datetime management is pretty complicated due to several formats, plus the fact that dateutil may be available or not.

Adding those fields with only deserialization would be quite useful already (I never needed serialization), but it looks like job half done.