### PR TITLE
Documents attribute retrieval

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,3 +105,4 @@ Contributors (chronological)
 - Prasanjit Prakash `@ikilledthecat <https://github.com/ikilledthecat>`_
 - Guillaume Gelin `@ramnes <https://github.com/ramnes>`_
 - Maxim Novikov `@m-novikov <https://github.com/m-novikov>`_
+- James Remeika `@remeika <https://github.com/remeika>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -181,7 +181,13 @@ class Field(FieldABC):
                 .format(ClassName=self.__class__.__name__, self=self))
 
     def get_value(self, obj, attr, accessor=None, default=missing_):
-        """Return the value for a given key from an object."""
+        """Return the value for a given key from an object.
+
+        :param object obj: The object to get the value from
+        :param str attr: The attribute/key in `obj` to get the value from.
+        :param callable accessor: A callable used to retrieve the value of `attr` from
+            the object `obj`. Defaults to `marshmallow.utils.get_value`.
+        """
         # NOTE: Use getattr instead of direct attribute access here so that
         # subclasses aren't required to define `attribute` member
         attribute = getattr(self, 'attribute', None)

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -327,7 +327,16 @@ def pluck(dictlist, key):
 # Various utilities for pulling keyed values from objects
 
 def get_value(obj, key, default=missing):
-    """Helper for pulling a keyed value off various types of objects"""
+    """Helper for pulling a keyed value off various types of objects. Fields use
+    this method by default to access attributes of the source object. For object `x`
+    and attribute `i`, this method first tries to access `x[i]`, and then falls back to
+    `x.i` if an exception is raised.
+
+    .. warning::
+        If an object `x` does not raise an exception when `x[i]` does not exist,
+        `get_value` will never check the value `x.i`. Consider overriding
+        `marshmallow.fields.Field.get_value` in this case.
+    """
     if not isinstance(key, int) and '.' in key:
         return _get_value_for_keys(obj, key.split('.'), default)
     else:


### PR DESCRIPTION
- Documents how attributes are retrieved from objects by default during serialization.
- Warn users that objects must raise an exception on missing key (`x[‘I’]` before the default accessor will try to retrieve an object attribute (`x.i`).

Fixes #776 