### PR TITLE
Fix Unfiltered Fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+2.15.5
++++++++++++++++++++
+
+Bug fixes:
+
+- Handle empty SQAlchemy lazy lists gracefully when dumping (:issue:`948`).
+  Thanks :user:`vke-code` for the catch and :user:`YuriHeupa` for the patch.
+
 2.15.4 (2018-08-04)
 +++++++++++++++++++
 

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -819,7 +819,7 @@ class BaseSchema(base.SchemaABC):
                 else:
                     obj_prototype = next(iter(obj))
             except (StopIteration, IndexError):  # Nothing to serialize
-                return self.declared_fields
+                return {k: v for k, v in self.declared_fields.items() if k in field_names}
             obj = obj_prototype
         ret = self.dict_class()
         for key in field_names:

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -819,7 +819,7 @@ class BaseSchema(base.SchemaABC):
                 else:
                     obj_prototype = next(iter(obj))
             except (StopIteration, IndexError):  # Nothing to serialize
-                return {k: v for k, v in self.declared_fields.items() if k in field_names}
+                return dict((k, v) for k, v in self.declared_fields.items() if k in field_names)
             obj = obj_prototype
         ret = self.dict_class()
         for key in field_names:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -694,6 +694,36 @@ def test_error_raised_if_additional_option_is_not_list():
                 additional = 'email'
 
 
+def test_nested_custom_set_in_exclude_reusing_schema():
+
+    class CustomSet(object):
+        # This custom set is to allow the obj check in BaseSchema.__filter_fields
+        # to pass, since it'll be a valid instance, and this class overrides
+        # getitem method to allow the hasattr check to pass too, which will try
+        # to access the first obj index and will simulate a IndexError throwing.
+        # e.g. SqlAlchemy.Query is a valid use case for this "obj".
+
+        def __getitem__(self, item):
+            return [][item]
+
+    class ChildSchema(Schema):
+        foo = fields.Field(required=True)
+        bar = fields.Field()
+
+        class Meta:
+            only = ('bar', )
+
+    class ParentSchema(Schema):
+        child = fields.Nested(ChildSchema, many=True, exclude=('foo',))
+
+    sch = ParentSchema(strict=True)
+    obj = dict(child=CustomSet())
+    sch.dumps(obj)
+    data = dict(child=[{'bar': 1}])
+    result = sch.load(data, partial=True)
+    assert not result.errors
+
+
 def test_nested_only():
     class ChildSchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Fixes #948

Cherry picked from v3. See #618.

This fixes an error in the corner case where a collection without `len` support is empty and `exclude`/`only` is used to filter the fields.

Note: The unit test did not have to be modified, because the commit occurred before the v3 branch was strict by default.