### PR TITLE
Pass render kwargs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,3 +106,4 @@ Contributors (chronological)
 - Guillaume Gelin `@ramnes <https://github.com/ramnes>`_
 - Maxim Novikov `@m-novikov <https://github.com/m-novikov>`_
 - James Remeika `@remeika <https://github.com/remeika>`_
+- Craig Holden `@Tecktron <https://github.com/Tecktron>`_

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,7 @@ import datetime as dt
 import uuid
 import decimal
 import json
+import math
 
 import simplejson
 
@@ -320,3 +321,15 @@ class DecimalAsFloatEncoder(json.JSONEncoder):
             return float(o)
         else:
             return super(DecimalAsFloatEncoder, self).default(o)
+
+
+class NaNAsZeroDecoder(json.JSONDecoder):
+    def __init__(self, *args, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.nan_to_zero, *args, **kwargs)
+
+    @staticmethod
+    def nan_to_zero(d):
+        for k in d.keys():
+            if type(d[k]) is float and math.isnan(d[k]):
+                d[k] = 0.0
+        return d

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,8 @@
 """Test utilities and fixtures."""
 import datetime as dt
 import uuid
+import decimal
+import json
 
 import simplejson
 
@@ -60,6 +62,11 @@ def assert_time_equal(t1, t2, microseconds=True):
 
 
 ##### Models #####
+
+class Item(object):
+    def __init__(self, name, cost='1.00'):
+        self.name = name
+        self.cost = decimal.Decimal(cost)
 
 
 class User(object):
@@ -305,3 +312,11 @@ class mockjson(object):  # noqa
     @staticmethod
     def loads(val):
         return {'foo': 42}
+
+
+class DecimalAsFloatEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return float(o)
+        else:
+            return super(DecimalAsFloatEncoder, self).default(o)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,7 +6,7 @@ import pytest
 
 from marshmallow import fields, Schema, EXCLUDE
 
-from tests.base import User
+from tests.base import User, Item, DecimalAsFloatEncoder
 
 
 class TestUnordered:
@@ -209,3 +209,22 @@ class TestIncludeOption:
         assert 'email' in s._declared_fields.keys()
         assert 'from' in s._declared_fields.keys()
         assert isinstance(s._declared_fields['from'], fields.Str)
+
+
+class TestJsonKwargs:
+
+    class SimpleSchema(Schema):
+        name = fields.Str()
+        cost = fields.Decimal(places=2)
+
+        class Meta:
+            render_dumps_kwargs = {
+                'cls': DecimalAsFloatEncoder,
+                'sort_keys': True,
+            }
+
+    def test_dump_returns_cost_as_float(self):
+        schema = self.SimpleSchema()
+        i = Item('Marshmallow', cost=3.50)
+        result = schema.dumps(i)
+        assert result == '{"cost": 3.5, "name": "Marshmallow"}'

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -211,7 +211,7 @@ class TestIncludeOption:
         assert isinstance(s._declared_fields['from'], fields.Str)
 
 
-class TestJsonKwargs:
+class TestRenderKwargs:
 
     class SimpleSchema(Schema):
         name = fields.Str()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -233,7 +233,7 @@ class TestRenderKwargs:
         result = schema.dumps(i)
         assert result == '{"cost": 3.5, "name": "Marshmallow"}'
 
-    def test_render_load_kwargs(self):
+    def test_render_loads_kwargs(self):
         schema = self.SimpleSchema()
         data = '{"name": "Freebee", "cost": NaN}'
         result = schema.loads(data)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import decimal
 from collections import OrderedDict
 import datetime as dt
 
@@ -6,7 +7,7 @@ import pytest
 
 from marshmallow import fields, Schema, EXCLUDE
 
-from tests.base import User, Item, DecimalAsFloatEncoder
+from tests.base import User, Item, DecimalAsFloatEncoder, NaNAsZeroDecoder
 
 
 class TestUnordered:
@@ -222,9 +223,19 @@ class TestRenderKwargs:
                 'cls': DecimalAsFloatEncoder,
                 'sort_keys': True,
             }
+            render_loads_kwargs = {
+                'cls': NaNAsZeroDecoder,
+            }
 
-    def test_dump_returns_cost_as_float(self):
+    def test_render_dumps_kwargs(self):
         schema = self.SimpleSchema()
         i = Item('Marshmallow', cost=3.50)
         result = schema.dumps(i)
         assert result == '{"cost": 3.5, "name": "Marshmallow"}'
+
+    def test_render_load_kwargs(self):
+        schema = self.SimpleSchema()
+        data = '{"name": "Freebee", "cost": NaN}'
+        result = schema.loads(data)
+        assert type(result['cost']) is decimal.Decimal
+        assert result['cost'] == decimal.Decimal('0.00')


### PR DESCRIPTION
This adds 2 new params to the Meta class, `render_dumps_kwargs` and `render_loads_kwargs`. These are then passed to the `render_module` when `.dumps()` or `.loads()` is invoked . 
Test and documentation included.