### PR TITLE
Add Tidelift links to README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,23 @@ Your logo will show up here with a link to your website. [`Become a sponsor`_]
     :target: https://opencollective.com/marshmallow/sponsor/0/website
     :alt: Sponsors
 
+
+Professional support
+====================
+
+Professionally-supported marshmallow is now available through the 
+`Tidelift Subscription <https://tidelift.com/subscription/pkg/pypi-marshmallow?utm_source=pypi-marshmallow&utm_medium=readme>`_.
+
+Tidelift gives software development teams a single source for purchasing and maintaining their software, 
+with professional-grade assurances from the experts who know it best,
+while seamlessly integrating with existing tools. [`Get professional support`_]
+
+.. _`Get professional support`: https://tidelift.com/subscription/pkg/pypi-marshmallow?utm_source=pypi-marshmallow&utm_medium=readme
+
+.. image:: https://user-images.githubusercontent.com/2379650/45126032-50b69880-b13f-11e8-9c2c-abd16c433495.png
+    :target: https://tidelift.com/subscription/pkg/pypi-marshmallow?utm_source=pypi-marshmallow&utm_medium=readme
+    :alt: Get supported marshmallow with Tidelift
+
 Project Links
 =============
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ html_theme_options = {
     'github_banner': True,
     'github_type': 'star',
     'opencollective': 'marshmallow',
+    'tidelift_url': 'https://tidelift.com/subscription/pkg/pypi-marshmallow?utm_source=pypi-marshmallow&utm_medium=docs',
     'code_font_size': '0.8em',
     'warn_bg': '#FFC',
     'warn_border': '#EEE',
@@ -94,8 +95,8 @@ html_theme_options = {
 
 html_sidebars = {
     'index': [
-        'about.html', 'useful-links.html', 'searchbox.html',
+        'about.html', 'donate.html', 'useful-links.html', 'searchbox.html',
     ],
-    '**': ['about.html', 'useful-links.html',
+    '**': ['about.html', 'donate.html', 'useful-links.html',
            'localtoc.html', 'relations.html', 'searchbox.html']
 }

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
     ],
     test_suite='tests',
     project_urls={
-        'Bug Reports': 'https://github.com/marshmallow-code/marshmallow/issues',
+        'Issues': 'https://github.com/marshmallow-code/marshmallow/issues',
         'Funding': 'https://opencollective.com/marshmallow',
+        'Tidelift': 'https://tidelift.com/subscription/pkg/pypi-marshmallow?utm_source=pypi-marshmallow&utm_medium=pypi',
     },
 )


### PR DESCRIPTION
In the README:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/2379650/45590345-56ad3600-b904-11e8-9c7c-eb4d9b95039f.png">

In the docs:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/2379650/45590327-0f26aa00-b904-11e8-9a9b-461264290d2c.png">
