### PR TITLE
Fix Collection Root Inheritance

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import collections
+import copy
 import datetime as dt
 import numbers
 import uuid
@@ -568,6 +569,7 @@ class List(Field):
 
     def _add_to_schema(self, field_name, schema):
         super(List, self)._add_to_schema(field_name, schema)
+        self.container = copy.deepcopy(self.container)
         self.container.parent = self
         self.container.name = field_name
 
@@ -1207,9 +1209,11 @@ class Dict(Field):
     def _add_to_schema(self, field_name, schema):
         super(Dict, self)._add_to_schema(field_name, schema)
         if self.value_container:
+            self.value_container = copy.deepcopy(self.value_container)
             self.value_container.parent = self
             self.value_container.name = field_name
         if self.key_container:
+            self.key_container = copy.deepcopy(self.key_container)
             self.key_container.parent = self
             self.key_container.name = field_name
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -129,6 +129,28 @@ class TestParentAndName:
     def test_list_field_inner_root(self, schema):
         assert schema.fields['bar'].container.root == schema
 
+    def test_list_root_inheritance(self, schema):
+        class OtherSchema(TestParentAndName.MySchema):
+            pass
+
+        schema2 = OtherSchema()
+        assert schema.fields['bar'].container.root == schema
+        assert schema2.fields['bar'].container.root == schema2
+
+    def test_dict_root_inheritance(self):
+        class MySchema(Schema):
+            foo = fields.Dict(keys=fields.Str(), values=fields.Int())
+
+        class OtherSchema(MySchema):
+            pass
+
+        schema = MySchema()
+        schema2 = OtherSchema()
+        assert schema.fields['foo'].key_container.root == schema
+        assert schema.fields['foo'].value_container.root == schema
+        assert schema2.fields['foo'].key_container.root == schema2
+        assert schema2.fields['foo'].value_container.root == schema2
+
 
 class TestMetadata:
 


### PR DESCRIPTION
Fixes #956 

The schema uses `copy.deepcopy()` to fork field instances before mutating them, but that operation does not fork a collection field's container attribute. This causes the attribute to be overwritten when the forked fields mutate the shared container instance.

`Field._add_to_schema()` is called after copying the parent schema's fields and is where the containers are mutated, so the containers must be forked there.