### PR TITLE
Refactor unmarshall: don't raise ValidationError in deserialize

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -226,12 +226,6 @@ class Unmarshaller(ErrorStore):
                     for idx, d in enumerate(data)
                 ]
                 self._pending = False
-            if self.errors:
-                raise ValidationError(
-                    self.errors,
-                    field_names=self.error_field_names,
-                    data=ret,
-                )
             return ret
         ret = dict_class()
         # Check data is a dict
@@ -279,13 +273,6 @@ class Unmarshaller(ErrorStore):
                             ValidationError('Unknown field.'),
                             (index if index_errors else None),
                         )
-
-        if self.errors and not self._pending:
-            raise ValidationError(
-                self.errors,
-                field_names=self.error_field_names,
-                data=ret,
-            )
         return ret
 
     # Make an instance callable

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -620,18 +620,15 @@ class BaseSchema(base.SchemaABC):
         else:
             processed_data = data
         if not errors:
-            try:
-                result = unmarshal(
-                    processed_data,
-                    self.fields,
-                    many=many,
-                    partial=partial,
-                    unknown=unknown,
-                    dict_class=self.dict_class,
-                    index_errors=self.opts.index_errors,
-                )
-            except ValidationError as error:
-                result = error.data
+            result = unmarshal(
+                processed_data,
+                self.fields,
+                many=many,
+                partial=partial,
+                unknown=unknown,
+                dict_class=self.dict_class,
+                index_errors=self.opts.index_errors,
+            )
             self._invoke_field_validators(unmarshal, data=result, many=many)
             errors = unmarshal.errors
             # Run schema-level validation.

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -634,28 +634,22 @@ class BaseSchema(base.SchemaABC):
             # Run schema-level validation.
             if self._has_processors(VALIDATES_SCHEMA):
                 field_errors = bool(errors)
-                try:
-                    self._invoke_schema_validators(
-                        unmarshal,
-                        pass_many=True,
-                        data=result,
-                        original_data=data,
-                        many=many,
-                        field_errors=field_errors,
-                    )
-                except ValidationError as err:
-                    errors.update(err.messages)
-                try:
-                    self._invoke_schema_validators(
-                        unmarshal,
-                        pass_many=False,
-                        data=result,
-                        original_data=data,
-                        many=many,
-                        field_errors=field_errors,
-                    )
-                except ValidationError as err:
-                    errors.update(err.messages)
+                self._invoke_schema_validators(
+                    unmarshal,
+                    pass_many=True,
+                    data=result,
+                    original_data=data,
+                    many=many,
+                    field_errors=field_errors,
+                )
+                self._invoke_schema_validators(
+                    unmarshal,
+                    pass_many=False,
+                    data=result,
+                    original_data=data,
+                    many=many,
+                    field_errors=field_errors,
+                )
         # Run post processors
         if not errors and postprocess and self._has_processors(POST_LOAD):
             try:

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from marshmallow import fields, EXCLUDE, INCLUDE, RAISE
+from marshmallow import fields, EXCLUDE, INCLUDE
 from marshmallow.marshalling import Marshaller, Unmarshaller, missing
 from marshmallow.exceptions import ValidationError
 
@@ -124,13 +124,6 @@ class TestUnmarshaller:
     @pytest.fixture
     def unmarshal(self):
         return Unmarshaller()
-
-    def test_extra_data_unknown_raise(self, unmarshal):
-        fields_ = {'name': fields.Str()}
-        with pytest.raises(ValidationError) as excinfo:
-            unmarshal({'extra': 42, 'name': 'Steve'}, fields_, unknown=RAISE)
-        errors = excinfo.value.messages
-        assert errors == {'extra': ['Unknown field.']}
 
     def test_extra_data_unknown_exclude(self, unmarshal):
         fields_ = {'name': fields.Str()}


### PR DESCRIPTION
As I said in #959 review comment, since `Schema._do_load` will raise on errors, we don't need to raise `ValidationError` in `Unmarshaller.deserialize`.

I removed what looks redundant and the only test that is broken tests `Unmarshaller` directly. Otherwise, the `Schema` interface is unchanged.

This is just a quick test I did out of curiosity. This looks like a design issue and maybe it calls for deeper reflection.