### PR TITLE
Remove from_datestring dead code from DateTime and utils

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -8,7 +8,6 @@ import copy
 import datetime as dt
 import numbers
 import uuid
-import warnings
 import decimal
 import math
 
@@ -1005,23 +1004,11 @@ class DateTime(Field):
                 return func(value)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid', obj_type=self.OBJ_TYPE)
-        elif data_format:
+        else:
             try:
                 return dt.datetime.strptime(value, data_format)
             except (TypeError, AttributeError, ValueError):
                 raise self.fail('invalid', obj_type=self.OBJ_TYPE)
-        elif utils.dateutil_available:
-            try:
-                parsed = utils.from_datestring(value)
-                return self._create_data_object_from_parsed_value(parsed)
-            except (TypeError, ValueError):
-                raise self.fail('invalid', obj_type=self.OBJ_TYPE)
-        else:
-            warnings.warn(
-                'It is recommended that you install python-dateutil '
-                'for improved datetime deserialization.',
-            )
-            raise self.fail('invalid', obj_type=self.OBJ_TYPE)
 
 
 class LocalDateTime(DateTime):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -245,15 +245,6 @@ def isoformat(dt, localtime=False, *args, **kwargs):
     return localized.isoformat(*args, **kwargs)
 
 
-def from_datestring(datestring):
-    """Parse an arbitrary datestring and return a datetime object using
-    dateutils' parser.
-    """
-    if dateutil_available:
-        return parser.parse(datestring)
-    else:
-        raise RuntimeError('from_datestring requires the python-dateutil library')
-
 def from_rfc(datestring, use_dateutil=True):
     """Parse a RFC822-formatted datetime string and return a datetime object.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -174,13 +174,6 @@ def test_isoformat_localtime():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
     assert utils.isoformat(d, localtime=True) == '2013-11-10T01:23:45-06:00'
 
-def test_from_datestring():
-    d = dt.datetime.now()
-    rfc = utils.rfcformat(d)
-    iso = d.isoformat()
-    assert_date_equal(utils.from_datestring(rfc), d)
-    assert_date_equal(utils.from_datestring(iso), d)
-
 @pytest.mark.parametrize('use_dateutil', [True, False])
 def test_from_rfc(use_dateutil):
     d = dt.datetime.now()


### PR DESCRIPTION
Closes #758, #619.

This is dead code, as pointed out in https://github.com/marshmallow-code/marshmallow/issues/758 and https://github.com/marshmallow-code/marshmallow/pull/619.

As I wrote in https://github.com/marshmallow-code/marshmallow/issues/899#issuecomment-418042719, I'm leaning towards removing all `dateutil` use in the code. It should still be possible to use it by subclassing `DateTime`.

In any case, we can ship 3.0 with this code removed, it is not like we're removing a feature: it is already long broken. If someone comes up with a nice implementation, it's never too late to add it back.