### PR TITLE
Update docstring to `post_load` from `make_object`

### DIFF
--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -503,8 +503,7 @@ class BaseSchema(base.SchemaABC):
         return self.opts.render_module.dumps(serialized, *args, **kwargs)
 
     def load(self, data, many=None, partial=None, unknown=None):
-        """Deserialize a data structure to an object defined by this Schema's
-        fields and :meth:`post_load` decorated method.
+        """Deserialize a data structure to an object defined by this Schema's fields.
 
         :param dict data: The data to deserialize.
         :param bool many: Whether to deserialize `data` as a collection. If `None`, the

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -504,7 +504,7 @@ class BaseSchema(base.SchemaABC):
 
     def load(self, data, many=None, partial=None, unknown=None):
         """Deserialize a data structure to an object defined by this Schema's
-        fields and :meth:`make_object`.
+        fields and :meth:`post_load` decorated method.
 
         :param dict data: The data to deserialize.
         :param bool many: Whether to deserialize `data` as a collection. If `None`, the


### PR DESCRIPTION
`make_object` was deprecated

https://marshmallow.readthedocs.io/en/3.0/upgrading.html?highlight=make_object#use-post-load-instead-of-make-object