### PR TITLE
Allow username without password in basic auth part of the url.

### DIFF
--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -56,7 +56,7 @@ class URL(Validator):
                     r'^',
                     r'(' if relative else r'',
                     r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-                    r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
+                    r'(?:[^:@]+?(:[^:@]*?)?@|)',  # basic auth
                     r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
                     r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
                     r'localhost|',  # localhost...

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -27,6 +27,8 @@ from marshmallow import validate, ValidationError
         'http://[2001:db8::ff00:42]:8329',
         'http://[2001::1]:8329',
         'http://www.example.com:8000/foo',
+        'http://user@example.com',
+        'http://user:pass@example.com',
     ],
 )
 def test_url_absolute_valid(valid_url):


### PR DESCRIPTION
Some URLs, for example gitlab ssh URLs (ssh://git@gitlab.domain.com:2222/user/project.git) don't have a password in itself. This pull request allows validating URLs with only user in basic auth part of the url.