### PR TITLE
Backport #982: Allow username without password in basic auth part of the url.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -85,3 +85,4 @@ Contributors (chronological)
 - `@sduthil <https://github.com/sduthil>`_
 - Alisson Silveira `@4lissonsilveira <https://github.com/4lissonsilveira>`_
 - Maxim Novikov `@m-novikov <https://github.com/m-novikov>`_
+- Viktor Kerkez `@alefnula<https://github.com/alefnula>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 2.16.0 (unreleased)
 +++++++++++++++++++
 
+Bug fixes:
+
+- Allow username without password in basic auth part of the url in
+  ``fields.Url`` (:pr:`982`). Thanks user:`alefnula` for the PR.
+
+
+Other changes:
+
 - Drop support for Python 3.3.
 
 2.15.6 (2018-09-20)

--- a/marshmallow/validate.py
+++ b/marshmallow/validate.py
@@ -55,7 +55,7 @@ class URL(Validator):
                 r'^',
                 r'(' if relative else r'',
                 r'(?:[a-z0-9\.\-\+]*)://',  # scheme is validated separately
-                r'(?:[^:@]+?:[^:@]*?@|)',  # basic auth
+                r'(?:[^:@]+?(:[^:@]*?)?@|)',  # basic auth
                 r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+',
                 r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|',  # domain...
                 r'localhost|',  # localhost...

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -23,6 +23,8 @@ from marshmallow import validate, ValidationError
     'http://123.45.67.8/',
     'http://2001:db8::ff00:42:8329',
     'http://www.example.com:8000/foo',
+    'http://user@example.com',
+    'http://user:pass@example.com',
 ])
 def test_url_absolute_valid(valid_url):
     validator = validate.URL(relative=False)


### PR DESCRIPTION
Backport #982