### PR TITLE
Fix Python 3.3 Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ python:
   - "pypy"
 
 before_install:
-  - pip install -U pip
+  # pip>=18.0 does not support Python 3.3
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3* ]] ; then pip install 'pip<18.0'; fi
   # Workaround for travis issue: https://github.com/marshmallow-code/marshmallow/issues/681
   - pip install -U six
 


### PR DESCRIPTION
Use system-installed pip rather than upgrading.
Newer versions of pip don't support Python 3.3