### PR TITLE
Fix Pluck load with data_key

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -489,22 +489,24 @@ class Pluck(Nested):
         super(Pluck, self).__init__(nested, only=(field_name,), **kwargs)
         self.field_name = field_name
 
+    @property
+    def _field_data_key(self):
+        only_field = self.schema.fields[self.field_name]
+        return only_field.data_key or self.field_name
+
     def _serialize(self, nested_obj, attr, obj):
         ret = super(Pluck, self)._serialize(nested_obj, attr, obj)
-        only_field = self.schema.fields[self.field_name]
-        data_key = only_field.data_key or self.field_name
-        key = ''.join([self.schema.prefix or '', data_key])
+        key = ''.join([self.schema.prefix or '', self._field_data_key])
         if self.many:
             return utils.pluck(ret, key=key)
-        else:
-            return ret[key]
+        return ret[key]
 
     def _deserialize(self, value, attr, data):
         self._test_collection(value)
         if self.many:
-            value = [{self.field_name: v} for v in value]
+            value = [{self._field_data_key: v} for v in value]
         else:
-            value = {self.field_name: value}
+            value = {self._field_data_key: value}
         return self._load(value, data)
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2100,6 +2100,10 @@ class TestPluckSchema:
         assert data['user'] == blog.user.name
         for i, name in enumerate(data['collaborators']):
             assert name == blog.collaborators[i].name
+        assert s.load(data) == {
+            'user': {'name': 'Monty'},
+            'collaborators': [{'name': 'Mick'}, {'name': 'Keith'}],
+        }
 
 
 class TestSelfReference:


### PR DESCRIPTION
The `data_key` must be managed also when deserializing.

@deckar01 do you think you could check this is correct?