### PR TITLE
Timestamp field added

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1153,11 +1153,12 @@ class Timestamp(Field):
     """Timestamp field, converts to datetime.
 
     :param timezone: Timezone of timestamp (defaults to UTC), should be tzinfo object.
+        Timezone-aware datetimes will be converted to this before serialization,
+        timezone-naive datetimes will be serialized as is (in timestamp timezone).
     :param bool ms: Milliseconds instead of seconds, defaults to `False`. For javascript
         compatibility.
     :param bool naive: Should deserialize to timezone-naive or timezone-aware datetime.
         Defaults to `False`, so all datetimes will be timezone-aware with `timezone`.
-        On `True` timezone-naive datetimes will be converted to `timezone` on serialization.
     :param bool as_int: If `True`, timestamp will be serialized to int instead of float,
         so datetime microseconds precision can be lost. Note that this affects milliseconds also,
         because 1 millisecond is 1000 microseconds.  Defaults to `False`.

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -1152,7 +1152,7 @@ class TimeDelta(Field):
 class Timestamp(Field):
     """Timestamp field, converts to datetime.
 
-    :param timezone: Timezone of timestamp (defaults to UTC), should be tzinfo object.
+    :param timezone: Timezone of timestamp (defaults to UTC).
         Timezone-aware datetimes will be converted to this before serialization,
         timezone-naive datetimes will be serialized as is (in timestamp timezone).
     :param bool ms: Milliseconds instead of seconds, defaults to `False`. For javascript
@@ -1165,7 +1165,7 @@ class Timestamp(Field):
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
     def __init__(self, timezone=utils.UTC, ms=False, naive=False, as_int=False, **kwargs):
-        self.timezone = timezone
+        self.timezone = utils.get_tzinfo(timezone)
         self.ms = ms
         self.naive = naive
         self.as_int = as_int

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -317,6 +317,9 @@ def to_iso_date(date, *args, **kwargs):
     return datetime.date.isoformat(date)
 
 
+_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=UTC)
+
+
 def from_timestamp(value, tzinfo=UTC, ms=False):
     return (datetime.datetime.utcfromtimestamp((float(value) / 1000) if ms else float(value))
             .replace(tzinfo=tzinfo))
@@ -325,8 +328,8 @@ def from_timestamp(value, tzinfo=UTC, ms=False):
 def to_timestamp(dt, tzinfo=UTC, ms=False):
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tzinfo)
-    return (dt.astimezone(tzinfo).replace(tzinfo=UTC).timestamp() *
-            (1000 if ms else 1))
+    return ((dt.astimezone(tzinfo).replace(tzinfo=UTC) - _EPOCH)
+            .total_seconds() * (1000 if ms else 1))
 
 
 def get_tzinfo(value):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -318,7 +318,7 @@ def to_iso_date(date, *args, **kwargs):
 
 
 def from_timestamp(value, tzinfo=UTC, ms=False):
-    return (datetime.utcfromtimestamp((float(value) * 1000) if ms else float(value))
+    return (datetime.datetime.utcfromtimestamp((float(value) / 1000) if ms else float(value))
             .replace(tzinfo=tzinfo))
 
 

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -332,13 +332,16 @@ def to_timestamp(dt, tzinfo=UTC, ms=False):
     return (dt - _EPOCH).total_seconds() * (1000 if ms else 1)
 
 
-def get_tzinfo(value):
+def get_tzinfo(value, use_dateutil=True):
     if isinstance(value, datetime.tzinfo):
         return value
     elif value == 'UTC':
         return UTC
-    elif dateutil_available:
-        return tz.gettz(value)
+    elif dateutil_available and use_dateutil:
+        tzinfo = tz.gettz(value)
+        if tzinfo is None:
+            raise ValueError('Unknown timezone', value)
+        return tzinfo
     raise ValueError('Unknown timezone and dateutil not available')
 
 

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -317,19 +317,19 @@ def to_iso_date(date, *args, **kwargs):
     return datetime.date.isoformat(date)
 
 
-_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=UTC)
+_EPOCH = datetime.datetime(1970, 1, 1)
 
 
 def from_timestamp(value, tzinfo=UTC, ms=False):
-    return (datetime.datetime.utcfromtimestamp((float(value) / 1000) if ms else float(value))
+    value = float(value)
+    return (datetime.datetime.utcfromtimestamp((value / 1000) if ms else value)
             .replace(tzinfo=tzinfo))
 
 
 def to_timestamp(dt, tzinfo=UTC, ms=False):
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=tzinfo)
-    return ((dt.astimezone(tzinfo).replace(tzinfo=UTC) - _EPOCH)
-            .total_seconds() * (1000 if ms else 1))
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(tzinfo).replace(tzinfo=None)
+    return (dt - _EPOCH).total_seconds() * (1000 if ms else 1)
 
 
 def get_tzinfo(value):

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -317,6 +317,18 @@ def to_iso_date(date, *args, **kwargs):
     return datetime.date.isoformat(date)
 
 
+def from_timestamp(value, tzinfo=UTC, ms=False):
+    return (datetime.utcfromtimestamp((float(value) * 1000) if ms else float(value))
+            .replace(tzinfo=tzinfo))
+
+
+def to_timestamp(dt, tzinfo=UTC, ms=False):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=tzinfo)
+    return (dt.astimezone(tzinfo).replace(tzinfo=UTC).timestamp() *
+            (1000 if ms else 1))
+
+
 def ensure_text_type(val):
     if isinstance(val, binary_type):
         val = val.decode('utf-8')

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -24,7 +24,7 @@ RAISE = 'raise'
 
 dateutil_available = False
 try:
-    from dateutil import parser
+    from dateutil import parser, tz
     dateutil_available = True
 except ImportError:
     dateutil_available = False
@@ -327,6 +327,16 @@ def to_timestamp(dt, tzinfo=UTC, ms=False):
         dt = dt.replace(tzinfo=tzinfo)
     return (dt.astimezone(tzinfo).replace(tzinfo=UTC).timestamp() *
             (1000 if ms else 1))
+
+
+def get_tzinfo(value):
+    if isinstance(value, datetime.tzinfo):
+        return value
+    elif value == 'UTC':
+        return UTC
+    elif dateutil_available:
+        return tz.gettz(value)
+    raise ValueError('Unknown timezone and dateutil not available')
 
 
 def ensure_text_type(val):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -253,14 +253,16 @@ class TestTimestamp:
             return dt.timedelta(0)
     UTC_plus_3 = UTC_plus_3()
 
-    @pytest.mark.parametrize('timestamp,datetime,kwargs', (
-        (-1.5, dt.datetime(1969, 12, 31, 23, 59, 58, 500000, tzinfo=UTC), {}),
-        (-1500, dt.datetime(1969, 12, 31, 23, 59, 58, 500000, tzinfo=UTC), {'ms': True}),
-        (0, dt.datetime(1970, 1, 1, tzinfo=UTC), {'timezone': 'UTC', 'ms': True}),
-        (0, dt.datetime(1970, 1, 1, tzinfo=None), {'naive': True}),
-        (0, dt.datetime(1969, 12, 31, 21, tzinfo=UTC), {'timezone': UTC_plus_3}),
-        (0, dt.datetime(1970, 1, 1, 3, tzinfo=UTC_plus_3), {'timezone': UTC}),
-    ))
+    @pytest.mark.parametrize(
+        'timestamp,datetime,kwargs', (
+            (-1.5, dt.datetime(1969, 12, 31, 23, 59, 58, 500000, tzinfo=UTC), {}),
+            (-1500, dt.datetime(1969, 12, 31, 23, 59, 58, 500000, tzinfo=UTC), {'ms': True}),
+            (0, dt.datetime(1970, 1, 1, tzinfo=UTC), {'timezone': 'UTC', 'ms': True}),
+            (0, dt.datetime(1970, 1, 1, tzinfo=None), {'naive': True}),
+            (0, dt.datetime(1969, 12, 31, 21, tzinfo=UTC), {'timezone': UTC_plus_3}),
+            (0, dt.datetime(1970, 1, 1, 3, tzinfo=UTC_plus_3), {'timezone': UTC}),
+        ),
+    )
     def test_load_dump(self, timestamp, datetime, kwargs):
         field = fields.Timestamp(**kwargs)
         assert not (field.deserialize(timestamp) - datetime).total_seconds()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -237,3 +237,14 @@ def test_get_func_args():
 
     for func in [f1, f2, f3]:
         assert utils.get_func_args(func) == ['foo', 'bar']
+
+@pytest.mark.parametrize('use_dateutil', [True, False])
+def test_get_tzinfo(use_dateutil):
+    if use_dateutil:
+        assert utils.get_tzinfo('Europe/Kiev', use_dateutil)
+        with pytest.raises(ValueError):
+            utils.get_tzinfo('Europe/Maaaskva', use_dateutil)
+    else:
+        assert utils.get_tzinfo('UTC', use_dateutil)
+        with pytest.raises(ValueError):
+            utils.get_tzinfo('Europe/Kiev', use_dateutil)


### PR DESCRIPTION
closes #612 
Actually in case of naive=True timezone is used only for timezone-aware datetimes conversion on serialization, maybe we should drop option naive=True and allow timezone=None instead? In this case on datetime-aware serialization we should throw ValueError, what do you think?