### PR TITLE
Rework validation error structure

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -202,7 +202,7 @@ When validating a collection, the errors dictionary will be keyed on the indices
 You can perform additional validation for a field by passing it a ``validate`` callable (function, lambda, or object with ``__call__`` defined).
 
 .. code-block:: python
-    :emphasize-lines: 4
+    :emphasize-lines: 6
 
     from marshmallow import ValidationError
 
@@ -218,7 +218,7 @@ You can perform additional validation for a field by passing it a ``validate`` c
         err.messages  # => {'age': ['Validator <lambda>(71.0) is False']}
 
 
-Validation functions either return a boolean or raise a :exc:`ValidationError`. If a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` is raised, its message is stored when validation fails.
+If validation fails, validation functions raise a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` with an error message.
 
 .. code-block:: python
     :emphasize-lines: 7,10,14

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -146,6 +146,55 @@ them from ``schema.fields``.
         field = schema.fields['foo']
         # ...
 
+
+``ValidationError`` expects a single field name
+***********************************************
+
+:exc:`ValidationError <marshmallow.exceptions.ValidationError>` no
+longer accepts a list of field names. It expects a single field name. If none
+is passed, the error refers to the schema.
+
+To return an error for several fields at once, a `dict` must be used.
+
+.. code-block:: python
+
+    from marshmallow import Schema, fields, validates_schema, ValidationError
+
+    class NumberSchema(Schema):
+        field_a = fields.Integer()
+        field_b = fields.Integer()
+
+        # 2.x
+        @validates_schema
+        def validate_numbers(self, data):
+            if data['field_b'] >= data['field_a']:
+                raise ValidationError(
+                    'field_a must be greater than field_b',
+                    ['field_a', 'field_b']
+                )
+
+        # 3.x
+        @validates_schema
+        def validate_numbers(self, data):
+            if data['field_b'] >= data['field_a']:
+                raise ValidationError({
+                    'field_a': ['field_a must be greater than field_b']
+                    'field_b': ['field_a must be greater than field_b']
+                })
+
+``ValidationError`` error messages are deep-merged
+**************************************************
+
+When multiple :exc:`ValidationError <marshmallow.exceptions.ValidationError>`
+are raised, the error structures are merged in the final :exc:`ValidationError`
+raised at the end of the process.
+
+When reporting error messages as `dict`, the keys should refer to subitems
+of the item the message refers to, and the values should be error messages.
+
+See the "Schema-level Validation" section of :doc:`Extending Schemas <extending>`
+page for an example.
+
 Schemas raise ``ValidationError`` when deserializing data with unknown keys
 ***************************************************************************
 

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -2,6 +2,10 @@
 """Exception classes for marshmallow-related errors."""
 
 
+# Key used for schema-level validation errors
+SCHEMA = '_schema'
+
+
 class MarshmallowError(Exception):
     """Base class for all marshmallow-related errors."""
 
@@ -13,7 +17,7 @@ class ValidationError(MarshmallowError):
     :param message: An error message, list of error messages, or dict of
         error messages.
     :param list field_name: Field name to store the error on.
-        If `None`, the error is stored in its default location.
+        If `None`, the error is stored as schema-level error.
     :param list fields: `Field` objects to which the error applies.
     """
     def __init__(self, message, field_name=None, data=None, valid_data=None, **kwargs):
@@ -33,10 +37,10 @@ class ValidationError(MarshmallowError):
         self.kwargs = kwargs
         MarshmallowError.__init__(self, message)
 
-    def normalized_messages(self, no_field_name='_schema'):
+    def normalized_messages(self):
         if isinstance(self.messages, dict):
             return self.messages
-        return {self.field_name or no_field_name: self.messages}
+        return {self.field_name or SCHEMA: self.messages}
 
 
 class RegistryError(NameError):

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Exception classes for marshmallow-related errors."""
 
+from marshmallow.compat import basestring
+
 
 # Key used for schema-level validation errors
 SCHEMA = '_schema'
@@ -11,28 +13,22 @@ class MarshmallowError(Exception):
 
 
 class ValidationError(MarshmallowError):
-    """Raised when validation fails on a field. Validators and custom fields should
-    raise this exception.
+    """Raised when validation fails on a field or schema.
 
-    :param message: An error message, list of error messages, or dict of
-        error messages.
-    :param list field_name: Field name to store the error on.
+    Validators and custom fields should raise this exception.
+
+    :param str|list|dict message: An error message, list of error messages, or dict of
+        error messages. If a dict, the keys are subitems and the values are error messages.
+    :param str field_name: Field name to store the error on.
         If `None`, the error is stored as schema-level error.
     :param list fields: `Field` objects to which the error applies.
+    :param dict data: Raw input data.
+    :param dict valid_data: Valid (de)serialized data.
     """
-    def __init__(self, message, field_name=None, data=None, valid_data=None, **kwargs):
-        if not isinstance(message, dict) and not isinstance(message, list):
-            messages = [message]
-        else:
-            messages = message
-        #: String, list, or dictionary of error messages.
-        #: If a `dict`, the keys will be field names and the values will be lists of
-        #: messages.
-        self.messages = messages
-        self.field_name = field_name or SCHEMA
-        #: The raw input data.
+    def __init__(self, message, field_name=SCHEMA, data=None, valid_data=None, **kwargs):
+        self.messages = [message] if isinstance(message, basestring) else message
+        self.field_name = field_name
         self.data = data
-        #: The valid, (de)serialized data.
         self.valid_data = valid_data
         self.kwargs = kwargs
         MarshmallowError.__init__(self, message)

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -29,7 +29,7 @@ class ValidationError(MarshmallowError):
         #: If a `dict`, the keys will be field names and the values will be lists of
         #: messages.
         self.messages = messages
-        self.field_name = field_name
+        self.field_name = field_name or SCHEMA
         #: The raw input data.
         self.data = data
         #: The valid, (de)serialized data.
@@ -38,9 +38,9 @@ class ValidationError(MarshmallowError):
         MarshmallowError.__init__(self, message)
 
     def normalized_messages(self):
-        if isinstance(self.messages, dict):
+        if self.field_name == SCHEMA and isinstance(self.messages, dict):
             return self.messages
-        return {self.field_name or SCHEMA: self.messages}
+        return {self.field_name: self.messages}
 
 
 class RegistryError(NameError):

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Exception classes for marshmallow-related errors."""
 
-from marshmallow.compat import basestring
 
 class MarshmallowError(Exception):
     """Base class for all marshmallow-related errors."""
@@ -13,11 +12,11 @@ class ValidationError(MarshmallowError):
 
     :param message: An error message, list of error messages, or dict of
         error messages.
-    :param list field_names: Field names to store the error on.
+    :param list field_name: Field name to store the error on.
         If `None`, the error is stored in its default location.
     :param list fields: `Field` objects to which the error applies.
     """
-    def __init__(self, message, field_names=None, data=None, valid_data=None, **kwargs):
+    def __init__(self, message, field_name=None, data=None, valid_data=None, **kwargs):
         if not isinstance(message, dict) and not isinstance(message, list):
             messages = [message]
         else:
@@ -26,11 +25,7 @@ class ValidationError(MarshmallowError):
         #: If a `dict`, the keys will be field names and the values will be lists of
         #: messages.
         self.messages = messages
-        if isinstance(field_names, basestring):
-            #: List of field_names which failed validation.
-            self.field_names = [field_names]
-        else:  # fields is a list or None
-            self.field_names = field_names or []
+        self.field_name = field_name
         #: The raw input data.
         self.data = data
         #: The valid, (de)serialized data.
@@ -41,9 +36,7 @@ class ValidationError(MarshmallowError):
     def normalized_messages(self, no_field_name='_schema'):
         if isinstance(self.messages, dict):
             return self.messages
-        if len(self.field_names) == 0:
-            return {no_field_name: self.messages}
-        return dict((name, self.messages) for name in self.field_names)
+        return {self.field_name or no_field_name: self.messages}
 
 
 class RegistryError(NameError):

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -14,7 +14,7 @@ from marshmallow.utils import (
     EXCLUDE, INCLUDE, RAISE, is_collection, missing, set_value,
 )
 from marshmallow.compat import iteritems, Mapping
-from marshmallow.exceptions import ValidationError
+from marshmallow.exceptions import ValidationError, SCHEMA
 from marshmallow.fields import Nested
 
 __all__ = [
@@ -22,10 +22,6 @@ __all__ = [
     'Unmarshaller',
 ]
 
-# Key used for schema-level validation errors
-SCHEMA = '_schema'
-# Key used for field-level validation errors on nested fields
-FIELD = '_field'
 
 class ErrorStore(object):
 
@@ -46,7 +42,7 @@ class ErrorStore(object):
         if isinstance(messages, dict):
             errors[field_name] = messages
         elif isinstance(errors.get(field_name), dict):
-            errors[field_name].setdefault(FIELD, []).extend(messages)
+            errors[field_name].setdefault(SCHEMA, []).extend(messages)
         else:
             errors.setdefault(field_name, []).extend(messages)
 

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -43,12 +43,11 @@ class ErrorStore(object):
             self.errors[index] = errors
 
     def store_error(self, messages, field_name=SCHEMA, index=None):
+        errors = self.get_errors(index=index)
         if field_name != SCHEMA:
-            messages = {field_name: messages}
-        self.set_errors(
-            merge_errors(self.get_errors(index=index), messages),
-            index=index
-        )
+            errors[field_name] = merge_errors(errors.get(field_name), messages)
+        else:
+            self.set_errors(merge_errors(errors, messages), index=index)
 
     def call_and_store(self, getter_func, data, field_name, index=None):
         """Call ``getter_func`` with ``data`` as its argument, and store any `ValidationErrors`.

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -254,3 +254,53 @@ class Unmarshaller(ErrorStore):
 
     # Make an instance callable
     __call__ = deserialize
+
+
+def merge_errors(errors1, errors2):
+    """Deeply merge two error messages
+
+    Error messages can be string, list of strings or dict of error messages
+    (recursively). Format is the same as accepted by :exc:`ValidationError`.
+    Returns new error messages.
+    """
+    if errors1 is None:
+        return errors2
+    if errors2 is None:
+        return errors1
+    if isinstance(errors1, list):
+        if not errors1:
+            return errors2
+        if isinstance(errors2, list):
+            return errors1 + errors2
+        if isinstance(errors2, dict):
+            return dict(
+                errors2,
+                **{SCHEMA: merge_errors(errors1, errors2.get(SCHEMA))}
+            )
+        return errors1 + [errors2]
+    if isinstance(errors1, dict):
+        if isinstance(errors2, list):
+            return dict(
+                errors1,
+                **{SCHEMA: merge_errors(errors1.get(SCHEMA), errors2)}
+            )
+        if isinstance(errors2, dict):
+            errors = dict(errors1)
+            for key, val in iteritems(errors2):
+                if key in errors:
+                    errors[key] = merge_errors(errors[key], val)
+                else:
+                    errors[key] = val
+            return errors
+        return dict(
+            errors1,
+            **{SCHEMA: merge_errors(errors1.get(SCHEMA), errors2)}
+        )
+    if isinstance(errors2, list):
+        return [errors1] + errors2 if errors2 else errors1
+    if isinstance(errors2, dict):
+        return dict(
+            errors2,
+            **{SCHEMA: merge_errors(errors1, errors2.get(SCHEMA))}
+        )
+    return [errors1, errors2]

--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -97,6 +97,7 @@ class Marshaller(ErrorStore):
         .. versionchanged:: 1.0.0
             Renamed from ``marshal``.
         """
+        index = index if index_errors else None
         if many and obj is not None:
             self._pending = True
             ret = [
@@ -119,7 +120,7 @@ class Marshaller(ErrorStore):
                 getter_func=getter,
                 data=obj,
                 field_name=key,
-                index=(index if index_errors else None),
+                index=index,
             )
             if value is missing:
                 continue
@@ -173,6 +174,7 @@ class Unmarshaller(ErrorStore):
             serializing a collection, otherwise `None`.
         :return: A dictionary of the deserialized data.
         """
+        index = index if index_errors else None
         if many:
             if not is_collection(data):
                 self.store_error(['Invalid input type.'], index=index)
@@ -229,7 +231,7 @@ class Unmarshaller(ErrorStore):
                     getter_func=getter,
                     data=raw_value,
                     field_name=field_name,
-                    index=(index if index_errors else None),
+                    index=index,
                 )
                 if value is not missing:
                     key = fields_dict[attr_name].attribute or attr_name

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -449,7 +449,6 @@ class BaseSchema(base.SchemaABC):
         if errors:
             exc = ValidationError(
                 errors,
-                field_names=marshal.error_field_names,
                 data=obj,
                 valid_data=result,
                 **marshal.error_kwargs
@@ -645,7 +644,6 @@ class BaseSchema(base.SchemaABC):
         if errors:
             exc = ValidationError(
                 errors,
-                field_names=unmarshal.error_field_names,
                 data=data,
                 valid_data=result,
                 **unmarshal.error_kwargs

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -562,14 +562,18 @@ class TestValidatesSchemaDecorator:
                 raise ValidationError({'nested': {'foo': ['Invalid foo']}})
 
             @validates_schema
-            def validate_nested_bar(self, data):
-                raise ValidationError({'nested': {'bar': ['Invalid bar']}})
+            def validate_nested_bar_1(self, data):
+                raise ValidationError({'nested': {'bar': ['Invalid bar 1']}})
+
+            @validates_schema
+            def validate_nested_bar_2(self, data):
+                raise ValidationError({'nested': {'bar': ['Invalid bar 2']}})
 
         with pytest.raises(ValidationError) as excinfo:
             MySchema().load({'nested': {'foo': 1, 'bar': 2}})
 
         assert excinfo.value.messages == {
-            'nested': {'foo': ['Invalid foo'], 'bar': ['Invalid bar']},
+            'nested': {'foo': ['Invalid foo'], 'bar': ['Invalid bar 1', 'Invalid bar 2']},
         }
 
     def test_passing_original_data(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -795,13 +795,7 @@ def test_decorator_error_handling():
     assert len(errors['_schema']) == 1
     assert errors['_schema'][0] == 'preloadmsg1'
 
-@pytest.mark.parametrize(
-    'decorator',
-    [
-        pre_load,
-        post_load,
-    ],
-)
+@pytest.mark.parametrize('decorator', [pre_load, post_load])
 def test_decorator_error_handling_with_load(decorator):
     class ExampleSchema(Schema):
         @decorator
@@ -814,13 +808,20 @@ def test_decorator_error_handling_with_load(decorator):
     assert exc.value.messages == {'foo': 'error'}
     schema.dump(object())
 
-@pytest.mark.parametrize(
-    'decorator',
-    [
-        pre_dump,
-        post_dump,
-    ],
-)
+@pytest.mark.parametrize('decorator', [pre_load, post_load])
+def test_decorator_error_handling_with_load_dict_error(decorator):
+    class ExampleSchema(Schema):
+        @decorator
+        def raise_value_error(self, item):
+            raise ValidationError({'foo': 'error'}, 'nested_field')
+
+    schema = ExampleSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.load({})
+    assert exc.value.messages == {'nested_field': {'foo': 'error'}}
+    schema.dump(object())
+
+@pytest.mark.parametrize('decorator', [pre_dump, post_dump])
 def test_decorator_error_handling_with_dump(decorator):
     class ExampleSchema(Schema):
         @decorator
@@ -831,6 +832,19 @@ def test_decorator_error_handling_with_dump(decorator):
     with pytest.raises(ValidationError) as exc:
         schema.dump(object())
     assert exc.value.messages == {'foo': 'error'}
+    schema.load({})
+
+@pytest.mark.parametrize('decorator', [pre_dump, post_dump])
+def test_decorator_error_handling_with_dump_dict_error(decorator):
+    class ExampleSchema(Schema):
+        @decorator
+        def raise_value_error(self, item):
+            raise ValidationError({'foo': 'error'}, 'nested')
+
+    schema = ExampleSchema()
+    with pytest.raises(ValidationError) as exc:
+        schema.dump(object())
+    assert exc.value.messages == {'nested': {'foo': 'error'}}
     schema.load({})
 
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1755,4 +1755,4 @@ def test_deserialize_raises_exception_if_input_type_is_incorrect(data, unknown):
         MySchema(unknown=unknown).load(data)
     assert 'Invalid input type.' in str(excinfo)
     exc = excinfo.value
-    assert exc.field_names == ['_schema']
+    assert list(exc.messages.keys()) == ['_schema']

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,11 +17,9 @@ class TestValidationError:
         err = ValidationError(messages)
         assert err.messages == messages
 
-    def test_can_store_field_names(self):
-        err = ValidationError('invalid email', field_names='email')
-        assert err.field_names == ['email']
-        err = ValidationError('invalid email', field_names=['email'])
-        assert err.field_names == ['email']
+    def test_can_store_field_name(self):
+        err = ValidationError('invalid email', field_name='email')
+        assert err.field_name == 'email'
 
     def test_str(self):
         err = ValidationError('invalid email')

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from collections import namedtuple
+
 import pytest
 
 from marshmallow import fields, EXCLUDE, INCLUDE
-from marshmallow.marshalling import Marshaller, Unmarshaller, missing
+from marshmallow.marshalling import Marshaller, Unmarshaller, missing, merge_errors
 from marshmallow.exceptions import ValidationError
 
 from tests.base import User
@@ -254,3 +256,134 @@ class TestUnmarshaller:
         assert 'years' not in result
 
         assert 'always_invalid' not in unmarshal.errors
+
+
+CustomError = namedtuple('CustomError', ['code', 'message'])
+
+
+class TestMergeErrors:
+    def test_merging_none_and_string(self):
+        assert 'error1' == merge_errors(None, 'error1')
+
+    def test_merging_none_and_custom_error(self):
+        assert CustomError(123, 'error1') == merge_errors(None, CustomError(123, 'error1'))
+
+    def test_merging_none_and_list(self):
+        assert ['error1', 'error2'] == merge_errors(None, ['error1', 'error2'])
+
+    def test_merging_none_and_dict(self):
+        assert {'field1': 'error1'} == merge_errors(None, {'field1': 'error1'})
+
+    def test_merging_string_and_none(self):
+        assert 'error1' == merge_errors('error1', None)
+
+    def test_merging_custom_error_and_none(self):
+        assert CustomError(123, 'error1') == merge_errors(CustomError(123, 'error1'), None)
+
+    def test_merging_list_and_none(self):
+        assert ['error1', 'error2'] == merge_errors(['error1', 'error2'], None)
+
+    def test_merging_dict_and_none(self):
+        assert {'field1': 'error1'} == merge_errors({'field1': 'error1'}, None)
+
+    def test_merging_string_and_string(self):
+        assert ['error1', 'error2'] == merge_errors('error1', 'error2')
+
+    def test_merging_custom_error_and_string(self):
+        assert [CustomError(123, 'error1'), 'error2'] == merge_errors(
+            CustomError(123, 'error1'), 'error2',
+        )
+
+    def test_merging_string_and_custom_error(self):
+        assert ['error1', CustomError(123, 'error2')] == merge_errors(
+            'error1', CustomError(123, 'error2'),
+        )
+
+    def test_merging_custom_error_and_custom_error(self):
+        assert [CustomError(123, 'error1'), CustomError(456, 'error2')] == merge_errors(
+            CustomError(123, 'error1'),
+            CustomError(456, 'error2'),
+        )
+
+    def test_merging_string_and_list(self):
+        assert ['error1', 'error2'] == merge_errors('error1', ['error2'])
+
+    def test_merging_string_and_dict(self):
+        assert {'_schema': 'error1', 'field1': 'error2'} == merge_errors(
+            'error1', {'field1': 'error2'},
+        )
+
+    def test_merging_string_and_dict_with_schema_error(self):
+        assert {'_schema': ['error1', 'error2'], 'field1': 'error3'} == merge_errors(
+            'error1', {'_schema': 'error2', 'field1': 'error3'},
+        )
+
+    def test_merging_custom_error_and_list(self):
+        assert [CustomError(123, 'error1'), 'error2'] == merge_errors(
+            CustomError(123, 'error1'), ['error2'],
+        )
+
+    def test_merging_custom_error_and_dict(self):
+        assert {'_schema': CustomError(123, 'error1'), 'field1': 'error2'} == merge_errors(
+            CustomError(123, 'error1'), {'field1': 'error2'},
+        )
+
+    def test_merging_custom_error_and_dict_with_schema_error(self):
+        assert {
+            '_schema': [CustomError(123, 'error1'), 'error2'],
+            'field1': 'error3',
+        } == merge_errors(
+            CustomError(123, 'error1'), {'_schema': 'error2', 'field1': 'error3'},
+        )
+
+    def test_merging_list_and_string(self):
+        assert ['error1', 'error2'] == merge_errors(['error1'], 'error2')
+
+    def test_merging_list_and_custom_error(self):
+        assert ['error1', CustomError(123, 'error2')] == merge_errors(
+            ['error1'], CustomError(123, 'error2'),
+        )
+
+    def test_merging_list_and_list(self):
+        assert ['error1', 'error2'] == merge_errors(['error1'], ['error2'])
+
+    def test_merging_list_and_dict(self):
+        assert {'_schema': ['error1'], 'field1': 'error2'} == merge_errors(
+            ['error1'], {'field1': 'error2'},
+        )
+
+    def test_merging_list_and_dict_with_schema_error(self):
+        assert {'_schema': ['error1', 'error2'], 'field1': 'error3'} == merge_errors(
+            ['error1'], {'_schema': 'error2', 'field1': 'error3'},
+        )
+
+    def test_merging_dict_and_string(self):
+        assert {'_schema': 'error2', 'field1': 'error1'} == merge_errors(
+            {'field1': 'error1'}, 'error2',
+        )
+
+    def test_merging_dict_and_custom_error(self):
+        assert {'_schema': CustomError(123, 'error2'), 'field1': 'error1'} == merge_errors(
+            {'field1': 'error1'}, CustomError(123, 'error2'),
+        )
+
+    def test_merging_dict_and_list(self):
+        assert {'_schema': ['error2'], 'field1': 'error1'} == merge_errors(
+            {'field1': 'error1'}, ['error2'],
+        )
+
+    def test_merging_dict_and_dict(self):
+        assert {
+            'field1': 'error1',
+            'field2': ['error2', 'error3'],
+            'field3': 'error4',
+        } == merge_errors(
+            {'field1': 'error1', 'field2': 'error2'},
+            {'field2': 'error3', 'field3': 'error4'},
+        )
+
+    def test_deep_merging_dicts(self):
+        assert {'field1': {'field2': ['error1', 'error2']}} == merge_errors(
+            {'field1': {'field2': 'error1'}},
+            {'field1': {'field2': 'error2'}},
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2022,7 +2022,7 @@ class TestNestedSchema:
             outer.load({'inner': [{}]})
         errors = excinfo.value.messages
         assert 'inner' in errors
-        assert '_field' in errors['inner']
+        assert '_schema' in errors['inner']
 
     def test_dump_validation_error(self):
         class Child(object):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -78,7 +78,7 @@ def test_dump_mode_raises_error(SchemaClass):
     with pytest.raises(ValidationError) as excinfo:
         s.dump(bad_user)
     exc = excinfo.value
-    assert exc.field_names[0] == 'balance'
+    assert list(exc.messages.keys()) == ['balance']
 
     assert type(exc.messages) == dict
     assert exc.messages == {'balance': ['Not a valid number.']}
@@ -168,12 +168,12 @@ def test_dump_resets_error_fields():
     with pytest.raises(ValidationError) as excinfo:
         schema.dump(User('Joe', age='dummy'))
     exc = excinfo.value
-    assert len(exc.field_names) == 1
+    assert len(exc.messages.keys()) == 1
 
     with pytest.raises(ValidationError) as excinfo:
         schema.dump(User('Joe', age='__dummy'))
-
-    assert len(exc.field_names) == 1
+    exc = excinfo.value
+    assert len(exc.messages.keys()) == 1
 
 def test_load_resets_error_fields():
     class MySchema(Schema):
@@ -184,12 +184,12 @@ def test_load_resets_error_fields():
     with pytest.raises(ValidationError) as excinfo:
         schema.load({'name': 'Joe', 'email': 'not-valid'})
     exc = excinfo.value
-    assert len(exc.field_names) == 1
+    assert len(exc.messages.keys()) == 1
 
     with pytest.raises(ValidationError) as excinfo:
         schema.load({'name': 12, 'email': 'mick@stones.com'})
     exc = excinfo.value
-    assert len(exc.field_names) == 1
+    assert len(exc.messages.keys()) == 1
 
 def test_load_resets_error_kwargs():
     class MySchema(Schema):
@@ -1652,7 +1652,7 @@ class TestHandleError:
             def handle_error(self, error, data):
                 assert type(error) is ValidationError
                 assert 'email' in error.messages
-                assert error.field_names == ['email']
+                assert list(error.messages.keys()) == ['email']
                 assert data == in_data
                 raise CustomError('Something bad happened')
 
@@ -1669,7 +1669,7 @@ class TestHandleError:
             def handle_error(self, error, data):
                 assert type(error) is ValidationError
                 assert 'email' in error.messages
-                assert error.field_names == ['email']
+                assert list(error.messages.keys()) == ['email']
                 assert data == in_data
                 raise CustomError('Something bad happened')
 
@@ -1690,7 +1690,7 @@ class TestHandleError:
             def handle_error(self, error, data):
                 assert type(error) is ValidationError
                 assert 'num' in error.messages
-                assert error.field_names == ['num']
+                assert list(error.messages.keys()) == ['num']
                 assert data == in_data
                 raise CustomError('Something bad happened')
 
@@ -1709,8 +1709,7 @@ class TestHandleError:
 
             def handle_error(self, error, data):
                 assert type(error) is ValidationError
-                assert '_schema' in error.messages
-                assert error.field_names == ['_schema']
+                assert list(error.messages.keys()) == ['_schema']
                 assert data == in_data
                 raise CustomError('Something bad happened')
 


### PR DESCRIPTION
This PR implements #441 using the merge function implemented in #442, and it addresses a few of the concerns expressed in #441 and #879.

---------------------------------------------------------------------------------------------------------------------------------

New validation error specification:

- A `ValidationError` has a `message` and a `field_name`. If `field_name` is not specified, the error applies to the schema and is stored under the `_schema` key.

- `message` can be a `dict`, a `string` or a `list`. Passing a `string` is a shortcut for passing a `list` with that `string` as unique element. When `message` is a `dict`, its keys are supposed to be field names, or an equivalent hierarchy (like in the `dict` messages generated by `List` or `Field`), so that several `dict` messages can be deep-merged together.

- It is not possible anymore to raise a `ValidationError` with a message applying to several fields by passing a message as `string` and a list of filed names. This is a special case of a schema-level error with the messages expressed as a `dict`.

- When a `Nested` field has both errors in its fields and errors in itself, its own errors are not stored under `_field` but under `_schema`. From client perspective, schema or field is an implementation detail.

---------------------------------------------------------------------------------------------------------------------------------

Fixes:

- Fixes the case where a pre/post_dump/load validator returns an error as `dict`.
- Allows two schema-level validators to return errors as `dict` on the same field. The errors messages are merged.
- Rewrite `test_passing_original_data` to test only what it is meant to and not use a wrong error structure. There was a long argument  in #441/#442 about whether the `{'code': 'invalid_field'}` message was wrong or not, and whether forbidding such a message would be a breaking change. It is wrong according to the specifications described above, which may be a breaking change (we're changing the error structure, the values expected in a `ValidationError`) but that's fine, as it is "breaking changes" season.
- `index = index if index_errors else None` is factorized which should provide a ridiculously marginal performance gain in most cases but also ensure `index_errors` is respected all along, even in case of invalid input type error.
