### PR TITLE
Make Travis config easier to read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,14 @@ jobs:
   fast_finish: true
 
   include:
-  - python: '3.6'
-    env: TOXENV=lint
-  - python: '2.6'
-    env: TOXENV=py26
-  - python: '2.7'
-    env: TOXENV=py27
-  - python: '3.4'
-    env: TOXENV=py34
-  - python: '3.5'
-    env: TOXENV=py35
-  - python: '3.6'
-    env: TOXENV=py36
-  - python: 'pypy'
-    env: TOXENV=pypy
-  - python: '3.6'
-    env: TOXENV=docs
+  - { python: '3.6', env: TOXENV=lint }
+  - { python: '2.6', env: TOXENV=py26 }
+  - { python: '2.7', env: TOXENV=py27 }
+  - { python: '3.4', env: TOXENV=py34 }
+  - { python: '3.5', env: TOXENV=py35 }
+  - { python: '3.6', env: TOXENV=py36 }
+  - { python: 'pypy', env: TOXENV=pypy }
+  - { python: '3.6', env: TOXENV=docs }
 
   - stage: PyPI Release
     if: tag IS present


### PR DESCRIPTION
Visually align the Python versions and TOXENV names

As seen in
https://github.com/encode/django-rest-framework/pull/5519
and https://github.com/jcassee/django-analytical/blob/master/.travis.yml