### PR TITLE
Fix deprecated imports of collections.abc classes 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -86,3 +86,4 @@ Contributors (chronological)
 - Alisson Silveira `@4lissonsilveira <https://github.com/4lissonsilveira>`_
 - Maxim Novikov `@m-novikov <https://github.com/m-novikov>`_
 - Viktor Kerkez `@alefnula <https://github.com/alefnula>`_
+- Jan Margeta `@jmargeta <https://github.com/jmargeta>`_

--- a/marshmallow/compat.py
+++ b/marshmallow/compat.py
@@ -23,7 +23,11 @@ if PY2:
         from .ordereddict import OrderedDict
     else:
         from collections import OrderedDict
+    from collections import Mapping, Iterable, MutableSet
     OrderedDict = OrderedDict
+    Mapping = Mapping
+    Iterable = Iterable
+    MutableSet = MutableSet
     def get_func_args(func):
         if isinstance(func, functools.partial):
             return list(inspect.getargspec(func.func).args)
@@ -45,6 +49,13 @@ else:
     zip_longest = itertools.zip_longest
     from collections import OrderedDict
     OrderedDict = OrderedDict
+    try:
+        from collections import Mapping, Iterable, MutableSet
+    except ImportError:
+        from collections.abc import Mapping, Iterable, MutableSet
+    Mapping = Mapping
+    Iterable = Iterable
+    MutableSet = MutableSet
     def get_func_args(func):
         if isinstance(func, functools.partial):
             return list(inspect.signature(func.func).parameters)

--- a/marshmallow/compat.py
+++ b/marshmallow/compat.py
@@ -9,6 +9,12 @@ PY26 = PY2 and int(sys.version_info[1]) < 7
 
 if PY2:
     import urlparse
+    if PY26:
+        from .ordereddict import OrderedDict
+    else:
+        from collections import OrderedDict
+    from collections import Mapping, Iterable, MutableSet
+
     urlparse = urlparse
     text_type = unicode
     binary_type = str
@@ -19,15 +25,7 @@ if PY2:
     itervalues = lambda d: d.itervalues()
     iteritems = lambda d: d.iteritems()
     zip_longest = itertools.izip_longest
-    if PY26:
-        from .ordereddict import OrderedDict
-    else:
-        from collections import OrderedDict
-    from collections import Mapping, Iterable, MutableSet
-    OrderedDict = OrderedDict
-    Mapping = Mapping
-    Iterable = Iterable
-    MutableSet = MutableSet
+
     def get_func_args(func):
         if isinstance(func, functools.partial):
             return list(inspect.getargspec(func.func).args)
@@ -37,6 +35,9 @@ if PY2:
             return list(inspect.getargspec(func.__call__).args)
 else:
     import urllib.parse
+    from collections import OrderedDict
+    from collections.abc import Mapping, Iterable, MutableSet
+
     urlparse = urllib.parse
     text_type = str
     binary_type = bytes
@@ -47,15 +48,7 @@ else:
     itervalues = lambda d: d.values()
     iteritems = lambda d: d.items()
     zip_longest = itertools.zip_longest
-    from collections import OrderedDict
-    OrderedDict = OrderedDict
-    try:
-        from collections import Mapping, Iterable, MutableSet
-    except ImportError:
-        from collections.abc import Mapping, Iterable, MutableSet
-    Mapping = Mapping
-    Iterable = Iterable
-    MutableSet = MutableSet
+
     def get_func_args(func):
         if isinstance(func, functools.partial):
             return list(inspect.signature(func.func).parameters)

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import collections
 import copy
 import datetime as dt
 import uuid
@@ -14,7 +13,7 @@ from operator import attrgetter
 from marshmallow import validate, utils, class_registry
 from marshmallow.base import FieldABC, SchemaABC
 from marshmallow.utils import missing as missing_
-from marshmallow.compat import text_type, basestring
+from marshmallow.compat import text_type, basestring, Mapping
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Validator
 
@@ -1091,7 +1090,7 @@ class Dict(Field):
     }
 
     def _deserialize(self, value, attr, data):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, Mapping):
             return value
         else:
             self.fail('invalid')

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -2,7 +2,7 @@
 """The :class:`Schema` class, including its metaclass and options (class Meta)."""
 from __future__ import absolute_import, unicode_literals
 
-from collections import defaultdict, Mapping, namedtuple
+from collections import defaultdict, namedtuple
 import copy
 import datetime as dt
 import decimal
@@ -14,7 +14,7 @@ import functools
 
 from marshmallow import base, fields, utils, class_registry, marshalling
 from marshmallow.compat import (with_metaclass, iteritems, text_type,
-                                binary_type, OrderedDict)
+                                binary_type, Mapping, OrderedDict)
 from marshmallow.exceptions import ValidationError
 from marshmallow.orderedset import OrderedSet
 from marshmallow.decorators import (PRE_DUMP, POST_DUMP, PRE_LOAD, POST_LOAD,

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -2,7 +2,6 @@
 """Utility methods for marshmallow."""
 from __future__ import absolute_import, unicode_literals
 
-import collections
 import datetime
 import inspect
 import json
@@ -16,6 +15,7 @@ from pprint import pprint as py_pprint
 
 from marshmallow.compat import OrderedDict, binary_type, text_type
 from marshmallow.compat import get_func_args as compat_get_func_args
+from marshmallow.compat import Mapping, Iterable
 
 
 dateutil_available = False
@@ -51,7 +51,7 @@ def is_generator(obj):
 def is_iterable_but_not_string(obj):
     """Return True if ``obj`` is an iterable object that isn't a string."""
     return (
-        (isinstance(obj, collections.Iterable) and not hasattr(obj, "strip")) or is_generator(obj)
+        (isinstance(obj, Iterable) and not hasattr(obj, "strip")) or is_generator(obj)
     )
 
 
@@ -62,7 +62,7 @@ def is_indexable_but_not_string(obj):
 
 def is_collection(obj):
     """Return True if ``obj`` is a collection type, e.g list, tuple, queryset."""
-    return is_iterable_but_not_string(obj) and not isinstance(obj, collections.Mapping)
+    return is_iterable_but_not_string(obj) and not isinstance(obj, Mapping)
 
 
 def is_instance_or_subclass(val, class_):


### PR DESCRIPTION
This PR proposes to move all collections.abc imports into the compat module.

In Python 3.3, Collections Abstract Base Classes such as Mapping, Iterable, or MutableSet were moved to the collections.abc module.
For backwards compatibility, are still visible in the collections module through Python 3.7. In the following versions they will be entirely removed.

This should fix Issue https://github.com/marshmallow-code/marshmallow/issues/1027
See also: https://docs.python.org/3.7/library/collections.html