### PR TITLE
Don't raise ValidationError in Unmarshaller.serialize

### DIFF
--- a/marshmallow/marshalling.py
+++ b/marshmallow/marshalling.py
@@ -115,12 +115,6 @@ class Marshaller(ErrorStore):
                 for idx, d in enumerate(obj)
             ]
             self._pending = False
-            if self.errors:
-                raise ValidationError(
-                    self.errors,
-                    field_names=self.error_field_names,
-                    data=ret,
-                )
             return ret
         items = []
         for attr_name, field_obj in iteritems(fields_dict):
@@ -138,12 +132,6 @@ class Marshaller(ErrorStore):
                 continue
             items.append((key, value))
         ret = dict_class(items)
-        if self.errors and not self._pending:
-            raise ValidationError(
-                self.errors,
-                field_names=self.error_field_names,
-                data=ret,
-            )
         return ret
 
     # Make an instance callable

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -426,18 +426,15 @@ class BaseSchema(base.SchemaABC):
             processed_obj = obj
 
         if not errors:
-            try:
-                result = marshal(
-                    processed_obj,
-                    self.fields,
-                    many=many,
-                    accessor=self.get_attribute,
-                    dict_class=self.dict_class,
-                    index_errors=self.opts.index_errors,
-                )
-            except ValidationError as error:
-                errors = marshal.errors
-                result = error.data
+            result = marshal(
+                processed_obj,
+                self.fields,
+                many=many,
+                accessor=self.get_attribute,
+                dict_class=self.dict_class,
+                index_errors=self.opts.index_errors,
+            )
+            errors = marshal.errors
 
         if not errors and self._has_processors(POST_DUMP):
             try:


### PR DESCRIPTION
We did the same for deserialization in #961.

No use raising/catching.

Besides, I think there was an error as we used `data` instead of `valid_data`. Since the error was made consistently in both `Marshaller` and `Schema`, there was no impact.