### PR TITLE
Don't pass data to ValidationError in Nested._serialize and Nested._load

### DIFF
--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -462,7 +462,7 @@ class Nested(Field):
         try:
             return schema.dump(nested_obj, many=self.many)
         except ValidationError as exc:
-            raise ValidationError(exc.messages, data=obj, valid_data=exc.valid_data)
+            raise ValidationError(exc.messages, data=nested_obj, valid_data=exc.valid_data)
 
     def _test_collection(self, value):
         if self.many and not utils.is_collection(value):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -462,7 +462,7 @@ class Nested(Field):
         try:
             return schema.dump(nested_obj, many=self.many)
         except ValidationError as exc:
-            raise ValidationError(exc.messages, data=nested_obj, valid_data=exc.valid_data)
+            raise ValidationError(exc.messages, valid_data=exc.valid_data)
 
     def _test_collection(self, value):
         if self.many and not utils.is_collection(value):
@@ -475,7 +475,7 @@ class Nested(Field):
                 partial=partial,
             )
         except ValidationError as exc:
-            raise ValidationError(exc.messages, data=data, valid_data=exc.valid_data)
+            raise ValidationError(exc.messages, valid_data=exc.valid_data)
         return valid_data
 
     def _deserialize(self, value, attr, data, partial=None, **kwargs):


### PR DESCRIPTION
I think we should pass `nested_obj`, here.

I don't know how to test this. In fact, it is never used as it is swallowed by Marshaller.

(I stumbled upon this while investigating https://github.com/marshmallow-code/marshmallow/issues/1046.)