### PR TITLE
is_collection should test for collections.abc.Collection, as documented, not Mapping

### DIFF
--- a/marshmallow/compat.py
+++ b/marshmallow/compat.py
@@ -8,7 +8,7 @@ PY2 = int(sys.version_info[0]) == 2
 
 if PY2:
     import urlparse
-    from collections import Mapping, Iterable, MutableSet
+    from collections import Collection, Mapping, Iterable, MutableSet
 
     urlparse = urlparse
     text_type = unicode
@@ -22,7 +22,7 @@ if PY2:
     zip_longest = itertools.izip_longest
 else:
     import urllib.parse
-    from collections.abc import Mapping, Iterable, MutableSet
+    from collections.abc import Collection, Mapping, Iterable, MutableSet
 
     urlparse = urllib.parse
     text_type = str

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -17,7 +17,7 @@ from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
 from marshmallow.compat import binary_type, text_type
-from marshmallow.compat import Mapping, Iterable
+from marshmallow.compat import Collection, Iterable
 
 EXCLUDE = 'exclude'
 INCLUDE = 'include'
@@ -67,7 +67,7 @@ def is_indexable_but_not_string(obj):
 
 def is_collection(obj):
     """Return True if ``obj`` is a collection type, e.g list, tuple, queryset."""
-    return is_iterable_but_not_string(obj) and not isinstance(obj, Mapping)
+    return is_iterable_but_not_string(obj) and not isinstance(obj, Collection)
 
 
 def is_instance_or_subclass(val, class_):


### PR DESCRIPTION
I noticed the docstring of `is_collection` says "Return True if `obj` is a collection type, e.g list, tuple, queryset.", which is actually a lie since the implementation is actually testing `isinstance(obj, Mapping)`. This PR updates the implementation to match the docstring, assuming that is what is desired.

I think this might also improve interop with data structures such as [werkzeug's Headers](https://github.com/pallets/werkzeug/blob/master/werkzeug/datastructures.py#L909) type. Apparently due to this code using `Mapping`, @barakalon had to resort to wrapping the werkzeug Headers object in a shim here before it could be used with marshmallow:
https://github.com/plangrid/flask-rebar/pull/43/files#r237132730