### PR TITLE
Fix getting values from dicts with properties

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -362,12 +362,13 @@ def _get_value_for_keys(obj, keys, default):
 
 
 def _get_value_for_key(obj, key, default):
+    if not hasattr(obj, '__getitem__'):
+        return getattr(obj, key, default)
+
     try:
         return obj[key]
-    except (TypeError, AttributeError):
+    except (KeyError, IndexError, TypeError, AttributeError):
         return getattr(obj, key, default)
-    except (KeyError, IndexError):
-        return default
 
 
 def set_value(dct, key, value):
@@ -392,6 +393,7 @@ def set_value(dct, key, value):
         set_value(target, rest, value)
     else:
         dct[key] = value
+
 
 def callable_or_raise(obj):
     """Check that an object is callable, else raise a :exc:`ValueError`.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,18 +48,22 @@ class PointClass(object):
         self.x = x
         self.y = y
 
+class PointDict(dict):
+    def __init__(self, x, y):
+        super(PointDict, self).__init__({'x': x})
+        self.y = y
+
 @pytest.mark.parametrize(
     'obj', [
         PointNT(24, 42),
         PointClass(24, 42),
+        PointDict(24, 42),
         {'x': 24, 'y': 42},
     ],
 )
 def test_get_value_from_object(obj):
-    result = utils.get_value(obj, 'x')
-    assert result == 24
-    result2 = utils.get_value(obj, 'y')
-    assert result2 == 42
+    assert utils.get_value(obj, 'x') == 24
+    assert utils.get_value(obj, 'y') == 42
 
 def test_get_value_from_namedtuple_with_default():
     p = PointNT(x=42, y=None)


### PR DESCRIPTION
Fixes #1060

The `hasattr` check shortcut also speeds up the benchmark by another 10% or so. Python exception handling is sort of slow, given how much this sort of pattern is recommended.