### PR TITLE
Specify minimal python-dateutil version (2.7.0) in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    'reco': ['python-dateutil', 'simplejson'],
+    'reco': ['python-dateutil>=2.7.0', 'simplejson'],
     'tests': [
         'pytest',
         'pytz',


### PR DESCRIPTION
We're using https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse, which was added in 2.7.0.