### PR TITLE
Fix propagation of options to Nested containers

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -626,7 +626,7 @@ class List(Field, ContainerMixin):
         return result
 
 
-class Tuple(Field):
+class Tuple(Field, ContainerMixin):
     """A tuple field, composed of a fixed number of other `Field` classes or
     instances
 
@@ -667,15 +667,18 @@ class Tuple(Field):
             )
 
         self.validate_length = Length(equal=len(self.tuple_fields))
+        for container in self.tuple_fields:
+            self.get_container_modifiers(container)
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         new_tuple_fields = []
         for container in self.tuple_fields:
-            new_container = copy.deepcopy(container)
-            new_container.parent = self
-            new_container.name = field_name
-            new_tuple_fields.append(new_container)
+            container = copy.deepcopy(container)
+            container.parent = self
+            container.name = field_name
+            new_tuple_fields.append(container)
+            self.set_container_modifiers(container)
         self.tuple_fields = new_tuple_fields
 
     def _serialize(self, value, attr, obj, **kwargs):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -576,12 +576,18 @@ class List(Field):
                 'The list elements must be a subclass or instance of '
                 'marshmallow.base.FieldABC.',
             )
+        if isinstance(self.container, Nested):
+            self.only = self.container.only
+            self.exclude = self.container.exclude
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         self.container = copy.deepcopy(self.container)
         self.container.parent = self
         self.container.name = field_name
+        if isinstance(self.container, Nested):
+            self.container.only = self.only
+            self.container.exclude = self.exclude
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
@@ -1288,6 +1294,9 @@ class Mapping(Field):
                     '"values" must be a subclass or instance of '
                     'marshmallow.base.FieldABC.',
                 )
+            if isinstance(self.value_container, Nested):
+                self.only = self.value_container.only
+                self.exclude = self.value_container.exclude
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
@@ -1295,6 +1304,9 @@ class Mapping(Field):
             self.value_container = copy.deepcopy(self.value_container)
             self.value_container.parent = self
             self.value_container.name = field_name
+        if isinstance(self.value_container, Nested):
+            self.value_container.only = self.only
+            self.value_container.exclude = self.exclude
         if self.key_container:
             self.key_container = copy.deepcopy(self.key_container)
             self.key_container.parent = self

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -122,32 +122,32 @@ class TestParentAndName:
         assert inner_field.root is None
 
     def test_list_field_inner_parent_and_name(self, schema):
-        assert schema.fields['bar'].container.parent == schema.fields['bar']
-        assert schema.fields['bar'].container.name == 'bar'
+        assert schema.fields['bar'].inner.parent == schema.fields['bar']
+        assert schema.fields['bar'].inner.name == 'bar'
 
     def test_tuple_field_inner_parent_and_name(self, schema):
-        for container in schema.fields['baz'].tuple_fields:
-            assert container.parent == schema.fields['baz']
-            assert container.name == 'baz'
+        for inner in schema.fields['baz'].tuple_fields:
+            assert inner.parent == schema.fields['baz']
+            assert inner.name == 'baz'
 
     def test_simple_field_root(self, schema):
         assert schema.fields['foo'].root == schema
         assert schema.fields['bar'].root == schema
 
     def test_list_field_inner_root(self, schema):
-        assert schema.fields['bar'].container.root == schema
+        assert schema.fields['bar'].inner.root == schema
 
     def test_tuple_field_inner_root(self, schema):
-        for container in schema.fields['baz'].tuple_fields:
-            assert container.root == schema
+        for inner in schema.fields['baz'].tuple_fields:
+            assert inner.root == schema
 
     def test_list_root_inheritance(self, schema):
         class OtherSchema(TestParentAndName.MySchema):
             pass
 
         schema2 = OtherSchema()
-        assert schema.fields['bar'].container.root == schema
-        assert schema2.fields['bar'].container.root == schema2
+        assert schema.fields['bar'].inner.root == schema
+        assert schema2.fields['bar'].inner.root == schema2
 
     def test_dict_root_inheritance(self):
         class MySchema(Schema):
@@ -158,10 +158,10 @@ class TestParentAndName:
 
         schema = MySchema()
         schema2 = OtherSchema()
-        assert schema.fields['foo'].key_container.root == schema
-        assert schema.fields['foo'].value_container.root == schema
-        assert schema2.fields['foo'].key_container.root == schema2
-        assert schema2.fields['foo'].value_container.root == schema2
+        assert schema.fields['foo'].key_inner.root == schema
+        assert schema.fields['foo'].value_inner.root == schema
+        assert schema2.fields['foo'].key_inner.root == schema2
+        assert schema2.fields['foo'].value_inner.root == schema2
 
 
 class TestMetadata:
@@ -257,7 +257,7 @@ class TestListNested:
             children = fields.List(fields.Nested(Child))
 
         schema = Family(**{param: ['children.name']})
-        assert getattr(schema.fields['children'].container, param) == {'name'}
+        assert getattr(schema.fields['children'].inner, param) == {'name'}
 
     @pytest.mark.parametrize('param', ('only', 'exclude'))
     def test_list_nested_only_and_exclude_merged_with_nested(self, param):
@@ -275,7 +275,7 @@ class TestListNested:
             'only': {'name'},
             'exclude': {'name', 'surname', 'age'},
         }[param]
-        assert getattr(schema.fields['children'].container, param) == expected
+        assert getattr(schema.fields['children'].inner, param) == expected
 
 class TestTupleNested:
 
@@ -306,7 +306,7 @@ class TestTupleNested:
                 (
                     fields.Nested(Child, **{param: ('name', 'surname')}),
                     fields.Nested(Child, **{param: ('name', 'surname')}),
-                )
+                ),
             )
 
         schema = Family(**{param: ['children.name', 'children.age']})
@@ -330,7 +330,7 @@ class TestDictNested:
             children = fields.Dict(values=fields.Nested(Child))
 
         schema = Family(**{param: ['children.name']})
-        assert getattr(schema.fields['children'].value_container, param) == {'name'}
+        assert getattr(schema.fields['children'].value_inner, param) == {'name'}
 
     @pytest.mark.parametrize('param', ('only', 'exclude'))
     def test_dict_nested_only_and_exclude_merged_with_nested(self, param):
@@ -348,4 +348,4 @@ class TestDictNested:
             'only': {'name'},
             'exclude': {'name', 'surname', 'age'},
         }[param]
-        assert getattr(schema.fields['children'].value_container, param) == expected
+        assert getattr(schema.fields['children'].value_inner, param) == expected


### PR DESCRIPTION
Fixes https://github.com/marshmallow-code/marshmallow/issues/946.

With `Dict`, I figured the nested options would apply to values schema, not keys schema.