### PR TITLE
Add __version_info__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+2.17.0 (unreleased)
++++++++++++++++++++
+
+Features:
+
+- Add ``marshmallow.__version_info__``.
+
 2.16.3 (2018-11-01)
 +++++++++++++++++++
 

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -13,8 +13,10 @@ from marshmallow.decorators import (
 )
 from marshmallow.utils import pprint, missing
 from marshmallow.exceptions import ValidationError
+from distutils.version import LooseVersion
 
 __version__ = '2.16.3'
+__version_info__ = tuple(LooseVersion(__version__).version)
 __author__ = 'Steven Loria'
 __all__ = [
     'Schema',


### PR DESCRIPTION
This makes it slightly more convenient for consuming libs to
support both marshmallow 2 and 3 (once this is forward-ported to 3.x).