### PR TITLE
Documentation updates

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -44,10 +44,10 @@ Utility Functions
 .. automodule:: marshmallow.utils
     :members:
 
-Marshalling
+Error Store
 ===========
 
-.. automodule:: marshmallow.marshalling
+.. automodule:: marshmallow.error_store
     :members:
     :private-members:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,7 @@ html_theme_options = {
         ('marshmallow @ PyPI', 'https://pypi.python.org/pypi/marshmallow'),
         ('marshmallow @ GitHub', 'https://github.com/marshmallow-code/marshmallow'),
         ('Issue Tracker', 'https://github.com/marshmallow-code/marshmallow/issues'),
+        ('Ecosystem', 'https://github.com/marshmallow-code/marshmallow/wiki/Ecosystem'),
     ]),
 }
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,78 @@
 Examples
 ********
 
-The examples below will use `httpie <https://github.com/jkbr/httpie>`_ (a curl-like tool) for testing the APIs.
+Validating ``package.json``
+===========================
+
+marshmallow can be used to validate configuration according to a schema.
+Below is a schema that could be used to validate
+``package.json`` files. This example demonstrates the following features:
+
+
+- Validation and deserialization using :meth:`Schema.load`
+- :doc:`Custom fields <custom_fields>`
+- Specifying deserialization keys using ``data_key``
+- Including unknown keys using ``unknown = INCLUDE``
+
+.. literalinclude:: ../examples/package_json_example.py
+    :language: python
+
+
+Given the following ``package.json`` file...
+
+.. code-block:: json
+
+    {
+      "name": "dunderscore",
+      "version": "1.2.3",
+      "description": "The Pythonic JavaScript toolkit",
+      "devDependencies": {
+        "pest": "^23.4.1"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "pest"
+      },
+      "license": "MIT"
+    }
+
+
+We can validate it using the above script.
+
+.. code-block:: bash
+
+    $ python examples/package_json_example.py < package.json
+    {'description': 'The Pythonic JavaScript toolkit',
+    'dev_dependencies': {'pest': '^23.4.1'},
+    'license': 'MIT',
+    'main': 'index.js',
+    'name': 'dunderscore',
+    'scripts': {'test': 'pest'},
+    'version': <Version('1.2.3')>}
+
+Notice that our custom field deserialized the version string to a ``Version`` object.
+
+But if we pass an invalid package.json file...
+
+.. code-block:: json
+
+    {
+      "name": "dunderscore",
+      "version": "INVALID",
+      "homepage": "INVALID",
+      "description": "The Pythonic JavaScript toolkit",
+      "license": "MIT"
+    }
+
+We see the corresponding error messages.
+
+.. code-block:: bash
+
+    $ python examples/package_json_example.py < invalid_package.json
+    ERROR: package.json is invalid
+    {'homepage': ['Not a valid URL.'], 'version': ['Not a valid version.']}
+
+
 
 Text Analysis API (Bottle + TextBlob)
 =====================================
@@ -22,12 +93,14 @@ First, run the app.
 
 .. code-block:: bash
 
-    $ python textblob_example.py
+    $ python examples/textblob_example.py
 
-Then send a POST request with some text.
+Then send a POST request with some text with `httpie <https://github.com/jkbr/httpie>`_ (a curl-like tool) for testing the APIs.
+
 
 .. code-block:: bash
 
+    $ pip install httpie
     $ http POST :5000/api/v1/analyze text="Simple is better"
     HTTP/1.0 200 OK
     Content-Length: 189
@@ -65,12 +138,11 @@ Quotes API (Flask + SQLAlchemy)
 
 Below is a full example of a REST API for a quotes app using `Flask <http://flask.pocoo.org/>`_  and `SQLAlchemy <https://www.sqlalchemy.org/>`_  with marshmallow. It demonstrates a number of features, including:
 
-    - Validation and deserialization using :meth:`Schema.load`.
-    - Custom validation
-    - Nesting fields
-    - Using ``dump_only=True`` to specify read-only fields
-    - Output filtering using the ``only`` parameter
-    - Using `@pre_load <marshmallow.decorators.pre_load>` to preprocess input data.
+- Custom validation
+- Nesting fields
+- Using ``dump_only=True`` to specify read-only fields
+- Output filtering using the ``only`` parameter
+- Using `@pre_load <marshmallow.decorators.pre_load>` to preprocess input data.
 
 .. literalinclude:: ../examples/flask_example.py
     :language: python
@@ -82,12 +154,13 @@ Run the app.
 
 .. code-block:: bash
 
-    $ python flask_example.py
+    $ python examples/flask_example.py
 
 First we'll POST some quotes.
 
 .. code-block:: bash
 
+    $ pip install httpie
     $ http POST :5000/quotes/ author="Tim Peters" content="Beautiful is better than ugly."
     $ http POST :5000/quotes/ author="Tim Peters" content="Now is better than never."
     $ http POST :5000/quotes/ author="Peter Hintjens" content="Simplicity is always better than functionality."
@@ -97,6 +170,7 @@ If we provide invalid input data, we get 400 error response. Let's omit "author"
 
 .. code-block:: bash
 
+    $ pip install httpie
     $ http POST :5000/quotes/ content="I have no author"
     {
         "author": [
@@ -166,6 +240,7 @@ After registering a user and creating some todo items in the database, here is a
 
 .. code-block:: bash
 
+    $ pip install httpie
     $ http GET :5000/todos/
     {
         "todos": [

--- a/examples/package_json_example.py
+++ b/examples/package_json_example.py
@@ -1,0 +1,51 @@
+import sys
+import json
+from packaging import version
+from marshmallow import Schema, fields, INCLUDE, pprint, ValidationError
+
+
+class Version(fields.Field):
+    """Version field that deserializes to a Version object.
+    Raises a ValidationError if version is invalid.
+    """
+
+    def _deserialize(self, value, *args, **kwargs):
+        try:
+            return version.Version(value)
+        except version.InvalidVersion:
+            raise ValidationError('Not a valid version.')
+
+    def _serialize(self, value, *args, **kwargs):
+        return str(value)
+
+
+class PackageSchema(Schema):
+    name = fields.Str(required=True)
+    version = Version(required=True)
+    description = fields.Str(required=True)
+    main = fields.Str(required=False)
+    homepage = fields.URL(required=False)
+    scripts = fields.Dict(keys=fields.Str(), values=fields.Str())
+    license = fields.Str(required=True)
+    dependencies = fields.Dict(keys=fields.Str(), values=fields.Str(), required=False)
+    dev_dependencies = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Str(),
+        required=False,
+        data_key='devDependencies',
+    )
+
+    class Meta:
+        # Include unknown fields in the
+        # deserialized output
+        unknown = INCLUDE
+
+
+if __name__ == '__main__':
+    pkg = json.load(sys.stdin)
+    try:
+        pprint(PackageSchema().load(pkg))
+    except ValidationError as error:
+        print('ERROR: package.json is invalid')
+        pprint(error.messages)
+        sys.exit(1)

--- a/marshmallow/error_store.py
+++ b/marshmallow/error_store.py
@@ -35,11 +35,10 @@ class ErrorStore(object):
 
 
 def merge_errors(errors1, errors2):
-    """Deeply merge two error messages
+    """Deeply merge two error messages.
 
-    Error messages can be string, list of strings or dict of error messages
-    (recursively). Format is the same as accepted by :exc:`ValidationError`.
-    Returns new error messages.
+    The format of ``errors1`` and ``errors2`` matches the ``message``
+    parameter of :exc:`marshmallow.exceptions.ValidationError`.
     """
     if not errors1:
         return errors2

--- a/marshmallow/exceptions.py
+++ b/marshmallow/exceptions.py
@@ -46,4 +46,4 @@ class RegistryError(NameError):
 
 
 class StringNotCollectionError(MarshmallowError, TypeError):
-    """Raised when a string is passed while a list of strings is expected."""
+    """Raised when a string is passed when a list of strings is expected."""


### PR DESCRIPTION
* Replace `marshalling` with `error_store` in API docs
* Add "Validating package.json" example
* Add "Ecosystem" to sidebar links