### PR TITLE
Fix "missing" singleton copy/deepcopy

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -35,6 +35,12 @@ class _Missing(object):
 
     __nonzero__ = __bool__  # PY2 compat
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, _):
+        return self
+
     def __repr__(self):
         return '<marshmallow.missing>'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import datetime as dt
 from collections import namedtuple
 from functools import partial
+from copy import copy, deepcopy
 
 import pytest
 
@@ -13,6 +14,10 @@ from tests.base import (
     assert_date_equal,
 )
 
+
+def test_missing_singleton_copy():
+    assert copy(utils.missing) is utils.missing
+    assert deepcopy(utils.missing) is utils.missing
 
 def test_to_marshallable_type():
     class Foo(object):


### PR DESCRIPTION
I had troubles while deep-copying objects and came to realize that `missing` was duplicated.

It was not obvious from the `print`s because the `repr` is the same but when printing the variable's address (`hex(id(variable))`) I could see that it was duplicated.

This PR implements [this answer from SO](https://stackoverflow.com/a/9887720/4653485).

We want a singleton because there are tests in the code like

```py
    if value is missing:
```