### PR TITLE
Fix "missing" singleton copy/deepcopy

### DIFF
--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -33,6 +33,12 @@ class _Missing(object):
 
     __nonzero__ = __bool__  # PY2 compat
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, _):
+        return self
+
     def __repr__(self):
         return '<marshmallow.missing>'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import datetime as dt
 from collections import namedtuple
 from functools import partial
+from copy import copy, deepcopy
 
 import pytest
 
@@ -13,6 +14,10 @@ from tests.base import (
     assert_date_equal,
 )
 
+
+def test_missing_singleton_copy():
+    assert copy(utils.missing) is utils.missing
+    assert deepcopy(utils.missing) is utils.missing
 
 def test_to_marshallable_type():
     class Foo(object):


### PR DESCRIPTION
Same as https://github.com/marshmallow-code/marshmallow/pull/1099 but on 2.x.