### PR TITLE
Add tuple field

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -118,3 +118,4 @@ Contributors (chronological)
 - Hampus Dunström `@Dunstrom <https://github.com/Dunstrom>`_
 - Robert Jensen `@r1b <https://github.com/r1b>`_
 - Arijit Basu `@sayanarijit <https://github.com/sayanarijit>`_
+- Víctor Zabalza `@zblz <https://github.com/zblz>`_

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -686,13 +686,9 @@ class Tuple(Field):
         if not utils.is_collection(value):
             self.fail('invalid')
 
-        self.validate_length(value)
-
         return tuple(
-            (
-                container._serialize(each, attr, obj, **kwargs)
-                for container, each in zip(self.tuple_fields, value)
-            )
+            container._serialize(each, attr, obj, **kwargs)
+            for container, each in zip(self.tuple_fields, value)
         )
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -622,8 +622,8 @@ class Tuple(Field):
 
     .. note::
         Because of the structured nature of `collections.namedtuple` and
-        `typing.NamedTuple`, using a nested schema for them is more appropriate
-        than using a `Tuple` field.
+        `typing.NamedTuple`, using a Schema within a Nested field for them is
+        more appropriate than using a `Tuple` field.
 
     :param Iterable[Field] tuple_fields: An iterable of field classes or
         instances.

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -699,8 +699,6 @@ class Tuple(Field):
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return None
-        if not utils.is_collection(value):
-            self.fail('invalid')
 
         return tuple(
             container._serialize(each, attr, obj, **kwargs)

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -703,12 +703,12 @@ class Tuple(Field):
         for idx, (container, each) in enumerate(zip(self.tuple_fields, value)):
             try:
                 result.append(container.deserialize(each))
-            except ValidationError as e:
-                result.append(e.data)
-                errors.update({idx: e.messages})
-
+            except ValidationError as error:
+                if error.valid_data is not None:
+                    result.append(error.valid_data)
+                errors.update({idx: error.messages})
         if errors:
-            raise ValidationError(errors, data=result)
+            raise ValidationError(errors, valid_data=result)
 
         return tuple(result)
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -637,9 +637,8 @@ class Tuple(Field):
         super(Tuple, self).__init__(*args, **kwargs)
         if not utils.is_collection(tuple_fields):
             raise ValueError(
-                'The tuple elements argument must be an iterable of '
-                'subclasses or instances of subclasses of '
-                'marshmallow.base.FieldABC',
+                'tuple_fields must be an iterable of Field classes or '
+                'instances.',
             )
         self.tuple_fields = [
             self._get_instance_from_field_class_or_instance(cls_or_instance)
@@ -652,17 +651,15 @@ class Tuple(Field):
         if isinstance(cls_or_instance, type):
             if not issubclass(cls_or_instance, FieldABC):
                 raise ValueError(
-                    'The type of the tuple elements '
-                    'must be a subclass of '
-                    'marshmallow.base.FieldABC',
+                    'Elements of "tuple_fields" must be subclasses or '
+                    'instances of marshmallow.base.FieldABC.',
                 )
             return cls_or_instance()
         else:
             if not isinstance(cls_or_instance, FieldABC):
                 raise ValueError(
-                    'The instances of the tuple '
-                    'elements must be of type '
-                    'marshmallow.base.FieldABC',
+                    'Elements of "tuple_fields" must be subclasses or '
+                    'instances of marshmallow.base.FieldABC.',
                 )
             return cls_or_instance
 

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -618,7 +618,7 @@ class List(Field):
 
 
 class Tuple(Field):
-    """A tuple field, composed with a fixed number of other `Field` classes or
+    """A tuple field, composed of a fixed number of other `Field` classes or
     instances
 
     Example: ::
@@ -626,8 +626,8 @@ class Tuple(Field):
         row = Tuple((fields.String(), fields.Integer(), fields.Float()))
 
     .. note::
-        Because of the structured nature of collections.namedtuple and
-        typing.NamedTuple, using a nested schema for them is more appropriate
+        Because of the structured nature of `collections.namedtuple` and
+        `typing.NamedTuple`, using a nested schema for them is more appropriate
         than using a `Tuple` field.
 
     :param Iterable[Field] tuple_fields: An iterable of field classes or

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -561,22 +561,13 @@ class List(Field):
 
     def __init__(self, cls_or_instance, **kwargs):
         super(List, self).__init__(**kwargs)
-        if isinstance(cls_or_instance, type):
-            if not issubclass(cls_or_instance, FieldABC):
-                raise ValueError(
-                    'The type of the list elements '
-                    'must be a subclass of '
-                    'marshmallow.base.FieldABC',
-                )
-            self.container = cls_or_instance()
-        else:
-            if not isinstance(cls_or_instance, FieldABC):
-                raise ValueError(
-                    'The instances of the list '
-                    'elements must be of type '
-                    'marshmallow.base.FieldABC',
-                )
-            self.container = cls_or_instance
+        try:
+            self.container = resolve_field_instance(cls_or_instance)
+        except FieldInstanceResolutionError:
+            raise ValueError(
+                'The list elements must be a subclass or instance of '
+                'marshmallow.base.FieldABC',
+            )
 
     def get_value(self, obj, attr, accessor=None):
         """Return the value for a given key from an object."""
@@ -1302,36 +1293,25 @@ class Mapping(Field):
         super(Mapping, self).__init__(**kwargs)
         if keys is None:
             self.key_container = None
-        elif isinstance(keys, type):
-            if not issubclass(keys, FieldABC):
-                raise ValueError(
-                    '"keys" must be a subclass of '
-                    'marshmallow.base.FieldABC',
-                )
-            self.key_container = keys()
         else:
-            if not isinstance(keys, FieldABC):
+            try:
+                self.key_container = resolve_field_instance(keys)
+            except FieldInstanceResolutionError:
                 raise ValueError(
-                    '"keys" must be of type '
+                    '"keys" must be a subclass or instance of '
                     'marshmallow.base.FieldABC',
                 )
-            self.key_container = keys
+
         if values is None:
             self.value_container = None
-        elif isinstance(values, type):
-            if not issubclass(values, FieldABC):
-                raise ValueError(
-                    '"values" must be a subclass of '
-                    'marshmallow.base.FieldABC',
-                )
-            self.value_container = values()
         else:
-            if not isinstance(values, FieldABC):
+            try:
+                self.value_container = resolve_field_instance(values)
+            except FieldInstanceResolutionError:
                 raise ValueError(
-                    '"values" must be of type '
+                    '"values" must be a subclass or instance of '
                     'marshmallow.base.FieldABC',
                 )
-            self.value_container = values
 
     def _bind_to_schema(self, field_name, schema):
         super(Mapping, self)._bind_to_schema(field_name, schema)

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -647,6 +647,16 @@ class Tuple(Field):
         ]
         self.validate_length = Length(equal=len(self.tuple_fields))
 
+    def _bind_to_schema(self, field_name, schema):
+        super(Tuple, self)._bind_to_schema(field_name, schema)
+        new_tuple_fields = []
+        for container in self.tuple_fields:
+            new_container = copy.deepcopy(container)
+            new_container.parent = self
+            new_container.name = field_name
+            new_tuple_fields.append(new_container)
+        self.tuple_fields = new_tuple_fields
+
     @staticmethod
     def _get_instance_from_field_class_or_instance(cls_or_instance):
         if isinstance(cls_or_instance, type):

--- a/marshmallow/fields.py
+++ b/marshmallow/fields.py
@@ -625,6 +625,11 @@ class Tuple(Field):
 
         row = Tuple((fields.String(), fields.Integer(), fields.Float()))
 
+    .. note::
+        Because of the structured nature of collections.namedtuple and
+        typing.NamedTuple, using a nested schema for them is more appropriate
+        than using a `Tuple` field.
+
     :param Iterable[Field] tuple_fields: An iterable of field classes or
         instances.
     :param kwargs: The same keyword arguments that :class:`Field` receives.

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -14,6 +14,7 @@ from calendar import timegm
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
 
+from marshmallow.base import FieldABC
 from marshmallow.compat import binary_type, text_type
 from marshmallow.compat import Mapping, Iterable
 
@@ -398,3 +399,18 @@ def get_func_args(func):
         return _signature(func)
     # Callable class
     return _signature(func.__call__)
+
+
+class FieldInstanceResolutionError(Exception):
+    pass
+
+
+def resolve_field_instance(cls_or_instance):
+    if isinstance(cls_or_instance, type):
+        if not issubclass(cls_or_instance, FieldABC):
+            raise FieldInstanceResolutionError
+        return cls_or_instance()
+    else:
+        if not isinstance(cls_or_instance, FieldABC):
+            raise FieldInstanceResolutionError
+        return cls_or_instance

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -51,7 +51,7 @@ class TestDeserializingNone:
         field = fields.List(fields.String(allow_none=True), allow_none=True)
         assert field.deserialize(None) is None
 
-    def test_tuple_field_deserialize_none_to_nont(self):
+    def test_tuple_field_deserialize_none_to_none(self):
         field = fields.Tuple([fields.String()], allow_none=True)
         assert field.deserialize(None) is None
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -51,6 +51,10 @@ class TestDeserializingNone:
         field = fields.List(fields.String(allow_none=True), allow_none=True)
         assert field.deserialize(None) is None
 
+    def test_tuple_field_deserialize_none_to_nont(self):
+        field = fields.Tuple([fields.String()], allow_none=True)
+        assert field.deserialize(None) is None
+
 
 class TestFieldDeserialization:
 
@@ -838,6 +842,64 @@ class TestFieldDeserialization:
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize(value)
         assert excinfo.value.args[0] == 'Not a valid list.'
+
+    def test_datetime_int_tuple_field_deserialization(self):
+        dtime = dt.datetime.now()
+        data = dtime.isoformat(), 42
+        field = fields.Tuple([fields.DateTime(), fields.Integer()])
+        result = field.deserialize(data)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        for val, type_, true_val in zip(result, (dt.datetime, int), (dtime, 42)):
+            assert isinstance(val, type_)
+            assert val == true_val
+
+    def test_tuple_field_deserialize_invalid_item(self):
+        field = fields.Tuple([fields.DateTime])
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(['badvalue'])
+        assert excinfo.value.args[0] == {0: ['Not a valid datetime.']}
+
+        field = fields.Tuple([fields.Str(), fields.Integer()])
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(['good', 'bad'])
+        assert excinfo.value.args[0] == {1: ['Not a valid integer.']}
+
+    def test_tuple_field_deserialize_multiple_invalid_items(self):
+        validator = validate.Range(10, 20, error='Value {input} not in range')
+        field = fields.Tuple([
+            fields.Int(validate=validator),
+            fields.Int(validate=validator),
+            fields.Int(validate=validator),
+        ])
+
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize([10, 5, 25])
+        assert len(excinfo.value.args[0]) == 2
+        assert excinfo.value.args[0][1] == ['Value 5 not in range']
+        assert excinfo.value.args[0][2] == ['Value 25 not in range']
+
+    @pytest.mark.parametrize(
+        'value',
+        [
+            'notalist',
+            42,
+            {},
+        ],
+    )
+    def test_tuple_field_deserialize_value_that_is_not_a_collection(self, value):
+        field = fields.Tuple([fields.Str()])
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(value)
+        assert excinfo.value.args[0] == 'Not a valid tuple.'
+
+    def test_tuple_field_deserialize_invalid_length(self):
+        field = fields.Tuple([fields.Str(), fields.Str()])
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize([42])
+        assert excinfo.value.args[0] == 'Length must be 2.'
+
 
     def test_constant_field_deserialization(self):
         field = fields.Constant('something')

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -900,7 +900,6 @@ class TestFieldDeserialization:
             field.deserialize([42])
         assert excinfo.value.args[0] == 'Length must be 2.'
 
-
     def test_constant_field_deserialization(self):
         field = fields.Constant('something')
         assert field.deserialize('whatever') == 'something'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -97,6 +97,7 @@ class TestParentAndName:
     class MySchema(Schema):
         foo = fields.Field()
         bar = fields.List(fields.Str())
+        baz = fields.Tuple([fields.Str(), fields.Int()])
 
     @pytest.fixture()
     def schema(self):
@@ -123,12 +124,21 @@ class TestParentAndName:
         assert schema.fields['bar'].container.parent == schema.fields['bar']
         assert schema.fields['bar'].container.name == 'bar'
 
+    def test_tuple_field_inner_parent_and_name(self, schema):
+        for container in schema.fields['baz'].tuple_fields:
+            assert container.parent == schema.fields['baz']
+            assert container.name == 'baz'
+
     def test_simple_field_root(self, schema):
         assert schema.fields['foo'].root == schema
         assert schema.fields['bar'].root == schema
 
     def test_list_field_inner_root(self, schema):
         assert schema.fields['bar'].container.root == schema
+
+    def test_tuple_field_inner_root(self, schema):
+        for container in schema.fields['baz'].tuple_fields:
+            assert container.root == schema
 
     def test_list_root_inheritance(self, schema):
         class OtherSchema(TestParentAndName.MySchema):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -808,8 +808,8 @@ class TestFieldSerialization:
         with pytest.raises(ValueError) as excinfo:
             fields.List(ASchema)
         expected_msg = (
-            'The type of the list elements must be a subclass '
-            'of marshmallow.base.FieldABC'
+            'The list elements must be a subclass or instance of '
+            'marshmallow.base.FieldABC'
         )
         assert expected_msg in str(excinfo)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -854,8 +854,8 @@ class TestFieldSerialization:
         with pytest.raises(ValueError) as excinfo:
             fields.Tuple([ASchema])
         expected_msg = (
-            'The type of the tuple elements must be a subclass '
-            'of marshmallow.base.FieldABC'
+            'Elements of "tuple_fields" must be subclasses or '
+            'instances of marshmallow.base.FieldABC.'
         )
         assert expected_msg in str(excinfo)
 


### PR DESCRIPTION
This is a proposal to add a tuple field, defined as a fixed-length, heterogeneous list. This `Tuple` field allows to define a list that, e.g., is of length 3 and always has a string and two floats.

AFAIK, It is not possible to build such a field or schema out of existing marshmallow fields. Some of the need for this type of field has been discussed in #644, and my particular need for it stems from trying to build a schema for a [Pandas Dataframe in the `orient=split` format](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html), which has a `data` field with a list of such tuples:

```json
{
  "columns": ["col 1", "col 2"], 
  "index": ["row 1", "row 2"], 
  "data": [["a", 10], ["b", 20]]
}
```

In the example above column 1 if of type `string` and column 2 of type `int`, so the data field could be written in a mm schema as:

```
data = fields.Tuple([fields.String(), fields.Integer()], many=True)
```

The implementation below tries to mimic most behaviour of the `List` field to avoid doing things in different was for similar container fields.

There are still a couple of things to be done, but I thought it would be good to have a discussion on whether such a field is seen as a necessary addition and the implementation.

TODO:

- [x] Deserialization tests
- [x] Mention in documentation