### PR TITLE
Fix doc block for schema.dump

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -118,3 +118,4 @@ Contributors (chronological)
 - Hampus Dunström `@Dunstrom <https://github.com/Dunstrom>`_
 - Robert Jensen `@r1b <https://github.com/r1b>`_
 - Arijit Basu `@sayanarijit <https://github.com/sayanarijit>`_
+- Sanjay P `@snjypl <https://github.com/snjypl>`_

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -245,7 +245,7 @@ class BaseSchema(base.SchemaABC):
 
         album = Album("Beggars Banquet", dt.date(1968, 12, 6))
         schema = AlbumSchema()
-        data, errors = schema.dump(album)
+        data = schema.dump(album)
         data  # {'release_date': '1968-12-06', 'title': 'Beggars Banquet'}
 
     :param tuple|list only: Whitelist of the declared fields to select when


### PR DESCRIPTION
schema.dump now returns only the data. not a tuple. fixed doc block 