### PR TITLE
Better default error messages for OneOf and ContainsOnly

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -410,16 +410,13 @@ class OneOf(Validator):
         interpolated with `{input}`, `{choices}` and `{labels}`.
     """
 
-    default_message_prefix = 'Not one of'
+    default_message = 'Must be one of: {choices}.'
 
     def __init__(self, choices, labels=None, error=None):
         self.choices = choices
         self.choices_text = ', '.join(text_type(choice) for choice in self.choices)
         self.labels = labels if labels is not None else []
         self.labels_text = ', '.join(text_type(label) for label in self.labels)
-        self.default_message = '{msg_prefix} [{choices}].'.format(
-            msg_prefix=self.default_message_prefix, choices=self.choices_text,
-        )
         self.error = error or self.default_message
 
     def _repr_args(self):
@@ -474,7 +471,7 @@ class ContainsOnly(OneOf):
         to validate against empty inputs.
     """
 
-    default_message_prefix = 'One or more of the choices you made was not in'
+    default_message = 'One or more of the choices you made was not in: {choices}.'
 
     def _format_error(self, value):
         value_text = ', '.join(text_type(val) for val in value)

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -410,13 +410,16 @@ class OneOf(Validator):
         interpolated with `{input}`, `{choices}` and `{labels}`.
     """
 
-    default_message = 'Not a valid choice.'
+    default_message_prefix = 'Not one of'
 
     def __init__(self, choices, labels=None, error=None):
         self.choices = choices
         self.choices_text = ', '.join(text_type(choice) for choice in self.choices)
         self.labels = labels if labels is not None else []
         self.labels_text = ', '.join(text_type(label) for label in self.labels)
+        self.default_message = '{msg_prefix} [{choices}].'.format(
+            msg_prefix=self.default_message_prefix, choices=self.choices_text,
+        )
         self.error = error or self.default_message
 
     def _repr_args(self):
@@ -471,7 +474,7 @@ class ContainsOnly(OneOf):
         to validate against empty inputs.
     """
 
-    default_message = 'One or more of the choices you made was not acceptable.'
+    default_message_prefix = 'One or more of the choices you made was not in'
 
     def _format_error(self, value):
         value_text = ', '.join(text_type(val) for val in value)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -568,7 +568,7 @@ def test_oneof():
 
     with pytest.raises(ValidationError) as excinfo:
         validate.OneOf([1, 2, 3])(4)
-    assert 'Not a valid choice.' in str(excinfo)
+    assert 'Not one of [1, 2, 3].' in str(excinfo)
     with pytest.raises(ValidationError):
         validate.OneOf('abc')('d')
     with pytest.raises(ValidationError):
@@ -633,7 +633,7 @@ def test_oneof_repr():
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=None, error=None)) ==
         '<OneOf(choices=[1, 2, 3], labels=[], error={0!r})>'
-        .format('Not a valid choice.')
+        .format('Not one of [1, 2, 3].')
     )
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==
@@ -731,7 +731,7 @@ def test_containsonly_repr():
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=None, error=None)) ==
         '<ContainsOnly(choices=[1, 2, 3], labels=[], error={0!r})>'
-        .format('One or more of the choices you made was not acceptable.')
+        .format('One or more of the choices you made was not in [1, 2, 3].')
     )
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -568,7 +568,7 @@ def test_oneof():
 
     with pytest.raises(ValidationError) as excinfo:
         validate.OneOf([1, 2, 3])(4)
-    assert 'Not one of [1, 2, 3].' in str(excinfo)
+    assert 'Must be one of: 1, 2, 3.' in str(excinfo)
     with pytest.raises(ValidationError):
         validate.OneOf('abc')('d')
     with pytest.raises(ValidationError):
@@ -633,7 +633,7 @@ def test_oneof_repr():
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=None, error=None)) ==
         '<OneOf(choices=[1, 2, 3], labels=[], error={0!r})>'
-        .format('Not one of [1, 2, 3].')
+        .format('Must be one of: {choices}.')
     )
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==
@@ -654,8 +654,9 @@ def test_containsonly_in_list():
     assert validate.ContainsOnly([1, 2, 3])([1, 2, 3, 1]) == [1, 2, 3, 1]
     assert validate.ContainsOnly([1, 2, 3])([]) == []
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as excinfo:
         validate.ContainsOnly([1, 2, 3])([4])
+    assert 'One or more of the choices you made was not in: 1, 2, 3.' in str(excinfo)
     with pytest.raises(ValidationError):
         validate.ContainsOnly([])([1])
 
@@ -731,7 +732,7 @@ def test_containsonly_repr():
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=None, error=None)) ==
         '<ContainsOnly(choices=[1, 2, 3], labels=[], error={0!r})>'
-        .format('One or more of the choices you made was not in [1, 2, 3].')
+        .format('One or more of the choices you made was not in: {choices}.')
     )
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==


### PR DESCRIPTION
This PR is related to #885. (Not sure if it fully closes it?).

It changes the default messages for `OneOf` and `ContainsOnly` to the ones suggested by @sloria:
- `OneOf`: `'Not one of {choices}.'`
- `ContainsOnly`: `'One or more of the choices you made was not in {choices}'`

Please let me know if I should add a CHANGELOG entry for this change.

P.S.: Many thanks for everyone's work on this project!