### PR TITLE
Remove the deprecated fields param from ValidationError docs

### DIFF
--- a/src/marshmallow/exceptions.py
+++ b/src/marshmallow/exceptions.py
@@ -21,7 +21,6 @@ class ValidationError(MarshmallowError):
         error messages. If a dict, the keys are subitems and the values are error messages.
     :param str field_name: Field name to store the error on.
         If `None`, the error is stored as schema-level error.
-    :param list fields: `Field` objects to which the error applies.
     :param dict data: Raw input data.
     :param dict valid_data: Valid (de)serialized data.
     """


### PR DESCRIPTION
The `fields` keyword param is no longer used on the `ValidationError`. Remove that from the docstring for `ValidationError`.