### PR TITLE
Fix a warning under Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,10 @@ setup(
     extras_require=EXTRAS_REQUIRE,
     license='MIT',
     zip_safe=False,
-    keywords=(
+    keywords=[
         'serialization', 'rest', 'json', 'api', 'marshal',
         'marshalling', 'deserialization', 'validation', 'schema',
-    ),
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
```
Warning: 'keywords' should be a list, got type 'tuple'
```
Related issue: https://bugs.python.org/issue19610