### PR TITLE
Use Xenial for all builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 cache: pip
 install: travis_retry pip install -U tox
 script: tox
@@ -10,7 +11,7 @@ jobs:
   - { python: '2.7', env: TOXENV=py27 }
   - { python: '3.5', env: TOXENV=py35 }
   - { python: '3.6', env: TOXENV=py36 }
-  - { python: '3.7', env: TOXENV=py37, dist: xenial }
+  - { python: '3.7', env: TOXENV=py37 }
   - { python: '3.6', env: TOXENV=docs }
 
   - stage: PyPI Release


### PR DESCRIPTION
This was special cased for Python 3.7, but it supports all of the versions of Python we test on so it makes sense to just use it for all builds.