### PR TITLE
Nested schemas should only inherit 'ordered' if available

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -447,7 +447,8 @@ class Nested(Field):
                     load_only=self._nested_normalized_option('load_only'),
                     dump_only=self._nested_normalized_option('dump_only'),
                 )
-            self.__schema.ordered = getattr(self.parent, 'ordered', False)
+            if hasattr(self.parent, 'ordered'):
+                self.__schema.ordered = self.parent.ordered
         return self.__schema
 
     def _nested_normalized_option(self, option_name):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -447,8 +447,7 @@ class Nested(Field):
                     load_only=self._nested_normalized_option('load_only'),
                     dump_only=self._nested_normalized_option('dump_only'),
                 )
-            if hasattr(self.parent, 'ordered'):
-                self.__schema.ordered = self.parent.ordered
+            self.__schema.ordered = self.root.ordered
         return self.__schema
 
     def _nested_normalized_option(self, option_name):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -171,24 +171,24 @@ class TestFieldOrdering:
             user = fields.Nested(Unordered)
 
         parent_schema = OrderedParentWithUnorderedNested()
-        assert parent_schema.ordered == True
-        assert parent_schema.fields['user'].schema.ordered == True
+        assert parent_schema.ordered
+        assert parent_schema.fields['user'].schema.ordered
 
     def test_ordered_nested_field_is_overridden_by_parent(self):
         class UnorderedParentWithOrderedNested(Schema):
             user = fields.Nested(KeepOrder)
 
         parent_schema = UnorderedParentWithOrderedNested()
-        assert parent_schema.ordered == False
-        assert parent_schema.fields['user'].schema.ordered == False
+        assert not parent_schema.ordered
+        assert not parent_schema.fields['user'].schema.ordered
 
     def test_ordered_nested_field_in_dict_is_not_overriden(self):
         class DictWithNestedOrdered(Schema):
             users = fields.Dict(keys=fields.Str(), values=fields.Nested(KeepOrder))
 
         parent_schema = DictWithNestedOrdered()
-        assert parent_schema.ordered == False
-        assert parent_schema.fields['users'].value_container.schema.ordered == False
+        assert not parent_schema.ordered
+        assert not parent_schema.fields['users'].value_container.schema.ordered
 
 
 class TestIncludeOption:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -159,6 +159,38 @@ class TestFieldOrdering:
         keys = list(data)
         assert keys == ['name', 'email', 'age', 'created', 'id', 'homepage', 'birthdate']
 
+    def test_unordered_nested_field_is_overridden_by_parent(self):
+        class Unordered(KeepOrder):
+            class Meta:
+                ordered = False
+
+        class OrderedParentWithUnorderedNested(Schema):
+            class Meta:
+                ordered = True
+
+            user = fields.Nested(Unordered)
+
+        parent_schema = OrderedParentWithUnorderedNested()
+        assert parent_schema.ordered == True
+        assert parent_schema.fields['user'].schema.ordered == True
+
+    def test_ordered_nested_field_is_overridden_by_parent(self):
+        class UnorderedParentWithOrderedNested(Schema):
+            user = fields.Nested(KeepOrder)
+
+        parent_schema = UnorderedParentWithOrderedNested()
+        assert parent_schema.ordered == False
+        assert parent_schema.fields['user'].schema.ordered == False
+
+    def test_ordered_nested_field_in_dict_is_not_overriden(self):
+        class DictWithNestedOrdered(Schema):
+            users = fields.Dict(keys=fields.Str(), values=fields.Nested(KeepOrder))
+
+        parent_schema = DictWithNestedOrdered()
+        assert parent_schema.ordered == False
+        assert parent_schema.fields['users'].value_container.schema.ordered == False
+
+
 class TestIncludeOption:
 
     class AddFieldsSchema(Schema):


### PR DESCRIPTION
Currently, using `fields.Dict(values=Nested(Foo))`, Foo will never be ordered, even if it has `ordered = True` in its Meta. 
I'm not sure what the right precedence is here (could instead be `getattr(self.__schema, 'ordered', False) or getattr(self.parent, 'ordered', False)`, or `getattr(self.__schema, 'ordered', getattr(self.parent, 'ordered', False))`, or vice-versa?), but as is, it's impossible to order a Dict(Nested(Foo)).