### PR TITLE
bug: treat integers that overflow float as invalid

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -802,7 +802,7 @@ class Number(Field):
             return None
         try:
             return self._format_num(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             self.fail('invalid', input=value)
 
     def _to_string(self, value):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -93,6 +93,13 @@ class TestField:
             strict_field.serialize('value', {'value': True})
         assert excinfo.value.args[0] == 'Not a valid number.'
 
+    def test_number_field_overflow(self):
+        strict_field = fields.Float()
+        with pytest.raises(ValidationError) as excinfo:
+            strict_field.serialize('value', {'value': 2**1024})
+        assert excinfo.value.args[0] == 'Not a valid number.'
+
+
 class TestParentAndName:
     class MySchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Found this case where Marshmallow throws an exception instead of validating the input.