### PR TITLE
Remove duplicated default_error_messages

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -783,7 +783,6 @@ class Number(Field):
     """
 
     num_type = float
-    default_error_messages = {'invalid': 'Not a valid number.'}
     default_error_messages = {
         'invalid': 'Not a valid number.',
         'too_large': 'Number too large.',


### PR DESCRIPTION
The Number field has duplicated default_error_messages.

This fixes it.