### PR TITLE
Do not attempt to inherit `ordered` from parent field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -464,7 +464,6 @@ class Nested(Field):
                     load_only=self._nested_normalized_option('load_only'),
                     dump_only=self._nested_normalized_option('dump_only'),
                 )
-            self.__schema.ordered = getattr(self.parent, 'ordered', False)
         return self.__schema
 
     def _nested_normalized_option(self, option_name):


### PR DESCRIPTION
class Meta options should not be passed down to nested fields.

close #1172