### PR TITLE
Add python_requires to help pip

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -127,3 +127,4 @@ Contributors (chronological)
 - Kim Gustyr `@khvn26 <https://github.com/khvn26>`_
 - Bryce Drennan `@brycedrennan <https://github.com/brycedrennan>`_
 - Tim Shaffer `@timster <https://github.com/timster>`_
+- Hugo van Kemenade `@hugovk <https://github.com/hugovk>`_

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'serialization', 'rest', 'json', 'api', 'marshal',
         'marshalling', 'deserialization', 'validation', 'schema',
     ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This helps pip install the appropriate version of this library for the user's running Python.

Important when dropping Python 2 (#1120), and also useful now.
