### PR TITLE
Upgrade Python syntax with pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
   rev: 3.7.7
   hooks:
   - id: flake8
+- repo: https://github.com/asottile/pyupgrade
+  rev: v1.15.0
+  hooks:
+  - id: pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+- repo: https://github.com/asottile/pyupgrade
+  rev: v1.15.0
+  hooks:
+  - id: pyupgrade
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v0.8.0
   hooks:
@@ -13,7 +17,3 @@ repos:
   rev: 3.7.7
   hooks:
   - id: flake8
-- repo: https://github.com/asottile/pyupgrade
-  rev: v1.15.0
-  hooks:
-  - id: pyupgrade

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'marshmallow'
-copyright = ' {0:%Y} <a href="https://stevenloria.com">Steven Loria</a>'.format(
+copyright = ' {:%Y} <a href="https://stevenloria.com">Steven Loria</a>'.format(
     dt.datetime.utcfromtimestamp(os.path.getmtime('../CHANGELOG.rst')),
 )
 

--- a/examples/peewee_example.py
+++ b/examples/peewee_example.py
@@ -146,7 +146,7 @@ def register():
             email=data['email'], joined_on=dt.datetime.now(),
             password=data['password'],
         )
-        message = 'Successfully created user: {0}'.format(user.email)
+        message = 'Successfully created user: {}'.format(user.email)
     else:
         return jsonify({'errors': 'That email address is already in the database'}), 400
 

--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -33,7 +33,7 @@ class AuthorSchema(Schema):
         return obj.first + ' ' + obj.last
 
     def format_name(self, author):
-        return '{0}, {1}'.format(author.last, author.first)
+        return '{}, {}'.format(author.last, author.first)
 
 
 class QuoteSchema(Schema):
@@ -137,7 +137,7 @@ def main():
             ),
         )
 
-    print('Benchmark Result: {0:.2f} usec/dump'.format(
+    print('Benchmark Result: {:.2f} usec/dump'.format(
         run_timeit(quotes, args.iterations, args.repeat, profile=args.profile),
     ))
 

--- a/src/marshmallow/class_registry.py
+++ b/src/marshmallow/class_registry.py
@@ -68,12 +68,12 @@ def get_class(classname, all=False):
     try:
         classes = _registry[classname]
     except KeyError:
-        raise RegistryError('Class with name {0!r} was not found. You may need '
+        raise RegistryError('Class with name {!r} was not found. You may need '
             'to import the class.'.format(classname))
     if len(classes) > 1:
         if all:
             return _registry[classname]
-        raise RegistryError('Multiple classes with name {0!r} '
+        raise RegistryError('Multiple classes with name {!r} '
             'were found. Please use the full, '
             'module-qualified path.'.format(classname))
     else:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -450,7 +450,7 @@ class Nested(Field):
                 elif not isinstance(self.nested, basestring):
                     raise ValueError(
                         'Nested fields must be passed a '
-                        'Schema, not {0}.'.format(self.nested.__class__),
+                        'Schema, not {}.'.format(self.nested.__class__),
                     )
                 elif self.nested == 'self':
                     schema_class = self.parent.__class__
@@ -1220,7 +1220,7 @@ class TimeDelta(Field):
         )
 
         if precision not in units:
-            msg = 'The precision must be {0} or "{1}".'.format(
+            msg = 'The precision must be {} or "{}".'.format(
                 ', '.join(['"{}"'.format(each) for each in units[:-1]]), units[-1],
             )
             raise ValueError(msg)
@@ -1545,7 +1545,7 @@ class Function(Field):
     def _call_or_raise(self, func, value, attr):
         if len(utils.get_func_args(func)) > 1:
             if self.parent.context is None:
-                msg = 'No context available for Function field {0!r}'.format(attr)
+                msg = 'No context available for Function field {!r}'.format(attr)
                 raise ValidationError(msg)
             return func(value, self.parent.context)
         else:

--- a/src/marshmallow/orderedset.py
+++ b/src/marshmallow/orderedset.py
@@ -73,8 +73,8 @@ class OrderedSet(MutableSet):
 
     def __repr__(self):
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
+            return '{}()'.format(self.__class__.__name__)
+        return '{}({!r})'.format(self.__class__.__name__, list(self))
 
     def __eq__(self, other):
         if isinstance(other, OrderedSet):

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -941,7 +941,7 @@ class BaseSchema(base.SchemaABC):
             invalid_fields |= exclude_field_names - available_field_names
 
         if invalid_fields:
-            message = 'Invalid fields for {0}: {1}.'.format(self, invalid_fields)
+            message = 'Invalid fields for {}: {}.'.format(self, invalid_fields)
             raise ValueError(message)
 
         fields_dict = self.dict_class()
@@ -1001,9 +1001,9 @@ class BaseSchema(base.SchemaABC):
             # field declared as a class, not an instance
             if (isinstance(field_obj, type) and
                     issubclass(field_obj, base.FieldABC)):
-                msg = ('Field for "{0}" must be declared as a '
+                msg = ('Field for "{}" must be declared as a '
                        'Field instance, not a class. '
-                       'Did you mean "fields.{1}()"?'
+                       'Did you mean "fields.{}()"?'
                        .format(field_name, field_obj.__name__))
                 raise TypeError(msg)
 
@@ -1048,7 +1048,7 @@ class BaseSchema(base.SchemaABC):
             except KeyError:
                 if field_name in self.declared_fields:
                     continue
-                raise ValueError('"{0}" field does not exist.'.format(field_name))
+                raise ValueError('"{}" field does not exist.'.format(field_name))
 
             if many:
                 for idx, item in enumerate(data):

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -348,7 +348,7 @@ def callable_or_raise(obj):
     """Check that an object is callable, else raise a :exc:`ValueError`.
     """
     if not callable(obj):
-        raise ValueError('Object {0!r} is not callable.'.format(obj))
+        raise ValueError('Object {!r} is not callable.'.format(obj))
     return obj
 
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -20,7 +20,7 @@ class Validator(object):
 
     def __repr__(self):
         args = self._repr_args()
-        args = '{0}, '.format(args) if args else ''
+        args = '{}, '.format(args) if args else ''
 
         return (
             '<{self.__class__.__name__}({args}error={self.error!r})>'
@@ -82,7 +82,7 @@ class URL(Validator):
     _regex = RegexMemoizer()
 
     default_message = 'Not a valid URL.'
-    default_schemes = set(['http', 'https', 'ftp', 'ftps'])
+    default_schemes = {'http', 'https', 'ftp', 'ftps'}
 
     # TODO; Switch position of `error` and `schemes` in 3.0
     def __init__(self, relative=False, error=None, schemes=None, require_tld=True):
@@ -92,7 +92,7 @@ class URL(Validator):
         self.require_tld = require_tld
 
     def _repr_args(self):
-        return 'relative={0!r}'.format(self.relative)
+        return 'relative={!r}'.format(self.relative)
 
     def _format_error(self, value):
         return self.error.format(input=value)
@@ -199,7 +199,7 @@ class Range(Validator):
         self.error = error
 
     def _repr_args(self):
-        return 'min={0!r}, max={1!r}'.format(self.min, self.max)
+        return 'min={!r}, max={!r}'.format(self.min, self.max)
 
     def _format_error(self, value, message):
         return (self.error or message).format(input=value, min=self.min, max=self.max)
@@ -249,7 +249,7 @@ class Length(Validator):
         self.equal = equal
 
     def _repr_args(self):
-        return 'min={0!r}, max={1!r}, equal={2!r}'.format(self.min, self.max, self.equal)
+        return 'min={!r}, max={!r}, equal={!r}'.format(self.min, self.max, self.equal)
 
     def _format_error(self, value, message):
         return (self.error or message).format(
@@ -292,7 +292,7 @@ class Equal(Validator):
         self.error = error or self.default_message
 
     def _repr_args(self):
-        return 'comparable={0!r}'.format(self.comparable)
+        return 'comparable={!r}'.format(self.comparable)
 
     def _format_error(self, value):
         return self.error.format(input=value, other=self.comparable)
@@ -321,7 +321,7 @@ class Regexp(Validator):
         self.error = error or self.default_message
 
     def _repr_args(self):
-        return 'regex={0!r}'.format(self.regex)
+        return 'regex={!r}'.format(self.regex)
 
     def _format_error(self, value):
         return self.error.format(input=value, regex=self.regex.pattern)
@@ -353,7 +353,7 @@ class Predicate(Validator):
         self.kwargs = kwargs
 
     def _repr_args(self):
-        return 'method={0!r}, kwargs={1!r}'.format(self.method, self.kwargs)
+        return 'method={!r}, kwargs={!r}'.format(self.method, self.kwargs)
 
     def _format_error(self, value):
         return self.error.format(input=value, method=self.method)
@@ -383,7 +383,7 @@ class NoneOf(Validator):
         self.error = error or self.default_message
 
     def _repr_args(self):
-        return 'iterable={0!r}'.format(self.iterable)
+        return 'iterable={!r}'.format(self.iterable)
 
     def _format_error(self, value):
         return self.error.format(
@@ -420,7 +420,7 @@ class OneOf(Validator):
         self.error = error or self.default_message
 
     def _repr_args(self):
-        return 'choices={0!r}, labels={1!r}'.format(self.choices, self.labels)
+        return 'choices={!r}, labels={!r}'.format(self.choices, self.labels)
 
     def _format_error(self, value):
         return self.error.format(

--- a/tests/base.py
+++ b/tests/base.py
@@ -103,7 +103,7 @@ class User(object):
         return dt.datetime(2013, 11, 24) - self.created
 
     def __repr__(self):
-        return '<User {0}>'.format(self.name)
+        return '<User {}>'.format(self.name)
 
 
 class Blog(object):
@@ -126,7 +126,7 @@ class DummyModel(object):
         return self.foo == other.foo
 
     def __str__(self):
-        return 'bar {0}'.format(self.foo)
+        return 'bar {}'.format(self.foo)
 
 ###### Schemas #####
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -333,7 +333,7 @@ class TestFieldDeserialization:
 
     def test_boolean_field_deserialization_with_custom_truthy_values(self):
         class MyBoolean(fields.Boolean):
-            truthy = set(['yep'])
+            truthy = {'yep'}
         field = MyBoolean()
         assert field.deserialize('yep') is True
 
@@ -352,7 +352,7 @@ class TestFieldDeserialization:
             self, in_val,
     ):
         class MyBoolean(fields.Boolean):
-            truthy = set(['yep'])
+            truthy = {'yep'}
         field = MyBoolean()
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize(in_val)
@@ -695,7 +695,7 @@ class TestFieldDeserialization:
         url = 'ws://test.test'
         with pytest.raises(ValidationError):
             field.deserialize(url)
-        field2 = fields.URL(schemes=set(['http', 'https', 'ws']))
+        field2 = fields.URL(schemes={'http', 'https', 'ws'})
         assert field2.deserialize(url) == url
 
     def test_email_field_deserialization(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -163,7 +163,7 @@ def test_invalid_class_name_in_nested_field_raises_error(user):
     sch = MySchema()
     with pytest.raises(RegistryError) as excinfo:
         sch.dump({'nf': None})
-    assert 'Class with name {0!r} was not found'.format('notfound') in str(excinfo)
+    assert 'Class with name {!r} was not found'.format('notfound') in str(excinfo)
 
 class FooSerializer(Schema):
     _id = fields.Integer()
@@ -181,7 +181,7 @@ def test_multiple_classes_with_same_name_raises_error():
     sch = MySchema()
     with pytest.raises(RegistryError) as excinfo:
         sch.dump({'foo': {'_id': 1}})
-    msg = 'Multiple classes with name {0!r} were found.'\
+    msg = 'Multiple classes with name {!r} were found.'\
             .format('FooSerializer')
     assert msg in str(excinfo)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1531,7 +1531,7 @@ def test_nested_with_sets():
     sch = Outer()
 
     DataClass = namedtuple('DataClass', ['foo'])
-    data = dict(inners=set([DataClass(42), DataClass(2)]))
+    data = dict(inners={DataClass(42), DataClass(2)})
     result = sch.dump(data)
     assert len(result['inners']) == 2
 
@@ -2350,7 +2350,7 @@ class TestContext:
         serializer.context = None
         with pytest.raises(ValidationError) as excinfo:
             serializer.dump(owner)
-        msg = 'No context available for Function field {0!r}'.format('is_collab')
+        msg = 'No context available for Function field {!r}'.format('is_collab')
         assert msg in str(excinfo)
 
     def test_function_field_handles_bound_serializer(self):
@@ -2646,7 +2646,7 @@ class TestDefaults:
         assert errors == {}
         result = schema.dump(data)
         for key in data.keys():
-            msg = 'result[{0!r}] should be None'.format(key)
+            msg = 'result[{!r}] should be None'.format(key)
             assert result[key] is None, msg
 
     def test_default_and_value_missing(self, schema, data):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -525,7 +525,7 @@ class TestFieldSerialization:
 
         with pytest.raises(ValidationError) as excinfo:
             field.serialize('created', user)
-        assert excinfo.value.args[0] == '"{0}" cannot be formatted as a datetime.'.format(value)
+        assert excinfo.value.args[0] == '"{}" cannot be formatted as a datetime.'.format(value)
 
     @pytest.mark.parametrize('fmt', ['rfc', 'rfc822'])
     def test_datetime_field_rfc822(self, fmt, user):
@@ -588,7 +588,7 @@ class TestFieldSerialization:
         user.time_registered = in_data
         with pytest.raises(ValidationError) as excinfo:
             field.serialize('time_registered', user)
-        msg = '"{0}" cannot be formatted as a time.'.format(in_data)
+        msg = '"{}" cannot be formatted as a time.'.format(in_data)
         assert excinfo.value.args[0] == msg
 
     def test_date_field(self, user):
@@ -612,7 +612,7 @@ class TestFieldSerialization:
         user.birthdate = in_data
         with pytest.raises(ValidationError) as excinfo:
             field.serialize('birthdate', user)
-        msg = '"{0}" cannot be formatted as a date.'.format(in_data)
+        msg = '"{}" cannot be formatted as a date.'.format(in_data)
         assert excinfo.value.args[0] == msg
 
     def test_timedelta_field(self, user):
@@ -750,7 +750,7 @@ class TestFieldSerialization:
         assert result[1] is None
 
     def test_list_field_work_with_set(self):
-        custom_set = set([1, 2, 3])
+        custom_set = {1, 2, 3}
         obj = IntegerList(custom_set)
         field = fields.List(fields.Int)
         result = field.serialize('ints', obj)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -133,7 +133,7 @@ def test_url_custom_scheme():
     with pytest.raises(ValidationError):
         validator(url)
 
-    validator = validate.URL(schemes=set(['http', 'https', 'ws']))
+    validator = validate.URL(schemes={'http', 'https', 'ws'})
     assert validator(url) == url
 
 def test_url_relative_and_custom_schemes():
@@ -143,7 +143,7 @@ def test_url_relative_and_custom_schemes():
     with pytest.raises(ValidationError):
         validator(url)
 
-    validator = validate.URL(relative=True, schemes=set(['http', 'https', 'ws']))
+    validator = validate.URL(relative=True, schemes={'http', 'https', 'ws'})
     assert validator(url) == url
 
 def test_url_custom_message():
@@ -155,12 +155,12 @@ def test_url_custom_message():
 def test_url_repr():
     assert (
         repr(validate.URL(relative=False, error=None)) ==
-        '<URL(relative=False, error={0!r})>'
+        '<URL(relative=False, error={!r})>'
         .format('Not a valid URL.')
     )
     assert (
         repr(validate.URL(relative=True, error='foo')) ==
-        '<URL(relative=True, error={0!r})>'
+        '<URL(relative=True, error={!r})>'
         .format('foo')
     )
 
@@ -176,8 +176,8 @@ def test_url_repr():
         "!#$%&'*+-/=?^_`{}|~@example.org",
         'niceandsimple@[64.233.160.0]',
         'niceandsimple@localhost',
-        u'josé@blah.com',
-        u'δοκ.ιμή@παράδειγμα.δοκιμή',
+        'josé@blah.com',
+        'δοκ.ιμή@παράδειγμα.δοκιμή',
     ],
 )
 def test_email_valid(valid_email):
@@ -215,12 +215,12 @@ def test_email_custom_message():
 def test_email_repr():
     assert (
         repr(validate.Email(error=None)) ==
-        '<Email(error={0!r})>'
+        '<Email(error={!r})>'
         .format('Not a valid email address.')
     )
     assert (
         repr(validate.Email(error='foo')) ==
-        '<Email(error={0!r})>'
+        '<Email(error={!r})>'
         .format('foo')
     )
 
@@ -270,7 +270,7 @@ def test_range_repr():
     )
     assert (
         repr(validate.Range(min=1, max=3, error='foo')) ==
-        '<Range(min=1, max=3, error={0!r})>'
+        '<Range(min=1, max=3, error={!r})>'
         .format('foo')
     )
 
@@ -359,12 +359,12 @@ def test_length_repr():
     )
     assert (
         repr(validate.Length(min=1, max=3, error='foo', equal=None)) ==
-        '<Length(min=1, max=3, equal=None, error={0!r})>'
+        '<Length(min=1, max=3, equal=None, error={!r})>'
         .format('foo')
     )
     assert (
         repr(validate.Length(min=None, max=None, error='foo', equal=5)) ==
-        '<Length(min=None, max=None, equal=5, error={0!r})>'
+        '<Length(min=None, max=None, equal=5, error={!r})>'
         .format('foo')
     )
 
@@ -390,12 +390,12 @@ def test_equal_custom_message():
 def test_equal_repr():
     assert (
         repr(validate.Equal(comparable=123, error=None)) ==
-        '<Equal(comparable=123, error={0!r})>'
+        '<Equal(comparable=123, error={!r})>'
         .format('Must be equal to {other}.')
     )
     assert (
         repr(validate.Equal(comparable=123, error='foo')) ==
-        '<Equal(comparable=123, error={0!r})>'
+        '<Equal(comparable=123, error={!r})>'
         .format('foo')
     )
 
@@ -443,12 +443,12 @@ def test_regexp_custom_message():
 def test_regexp_repr():
     assert (
         repr(validate.Regexp(regex='abc', flags=0, error=None)) ==
-        '<Regexp(regex={0!r}, error={1!r})>'
+        '<Regexp(regex={!r}, error={!r})>'
         .format(re.compile('abc'), 'String does not match expected pattern.')
     )
     assert (
         repr(validate.Regexp(regex='abc', flags=re.IGNORECASE, error='foo')) ==
-        '<Regexp(regex={0!r}, error={1!r})>'
+        '<Regexp(regex={!r}, error={!r})>'
         .format(re.compile('abc', re.IGNORECASE), 'foo')
     )
 
@@ -505,12 +505,12 @@ def test_predicate_custom_message():
 def test_predicate_repr():
     assert (
         repr(validate.Predicate(method='foo', error=None)) ==
-        '<Predicate(method={0!r}, kwargs={1!r}, error={2!r})>'
+        '<Predicate(method={!r}, kwargs={!r}, error={!r})>'
         .format('foo', {}, 'Invalid input.')
     )
     assert (
         repr(validate.Predicate(method='foo', error='bar', zoo=1)) ==
-        '<Predicate(method={0!r}, kwargs={1!r}, error={2!r})>'
+        '<Predicate(method={!r}, kwargs={!r}, error={!r})>'
         .format('foo', {str('zoo') if PY2 else 'zoo': 1}, 'bar')
     )
 
@@ -549,12 +549,12 @@ def test_noneof_custom_message():
 def test_noneof_repr():
     assert (
         repr(validate.NoneOf(iterable=[1, 2, 3], error=None)) ==
-        '<NoneOf(iterable=[1, 2, 3], error={0!r})>'
+        '<NoneOf(iterable=[1, 2, 3], error={!r})>'
         .format('Invalid input.')
     )
     assert (
         repr(validate.NoneOf(iterable=[1, 2, 3], error='foo')) ==
-        '<NoneOf(iterable=[1, 2, 3], error={0!r})>'
+        '<NoneOf(iterable=[1, 2, 3], error={!r})>'
         .format('foo')
     )
 
@@ -632,12 +632,12 @@ def test_oneof_custom_message():
 def test_oneof_repr():
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=None, error=None)) ==
-        '<OneOf(choices=[1, 2, 3], labels=[], error={0!r})>'
+        '<OneOf(choices=[1, 2, 3], labels=[], error={!r})>'
         .format('Must be one of: {choices}.')
     )
     assert (
         repr(validate.OneOf(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==
-        '<OneOf(choices=[1, 2, 3], labels={0!r}, error={1!r})>'
+        '<OneOf(choices=[1, 2, 3], labels={!r}, error={!r})>'
         .format(['a', 'b', 'c'], 'foo')
     )
 
@@ -731,11 +731,11 @@ def test_containsonly_custom_message():
 def test_containsonly_repr():
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=None, error=None)) ==
-        '<ContainsOnly(choices=[1, 2, 3], labels=[], error={0!r})>'
+        '<ContainsOnly(choices=[1, 2, 3], labels=[], error={!r})>'
         .format('One or more of the choices you made was not in: {choices}.')
     )
     assert (
         repr(validate.ContainsOnly(choices=[1, 2, 3], labels=['a', 'b', 'c'], error='foo')) ==
-        '<ContainsOnly(choices=[1, 2, 3], labels={0!r}, error={1!r})>'
+        '<ContainsOnly(choices=[1, 2, 3], labels={!r}, error={!r})>'
         .format(['a', 'b', 'c'], 'foo')
     )


### PR DESCRIPTION
pyupgrade is a tool "to automatically upgrade syntax for newer versions of the language".

```
pyupgrade `find . -name "*.py" -type f`
```

https://github.com/asottile/pyupgrade

Once Python 2 is dropped (#1120), it can be run with the `--py3-plus` flag.