### PR TITLE
Drop support for Python 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Full documentation is available at https://marshmallow.readthedocs.io/ .
 Requirements
 ============
 
-- Python >= 2.7 or >= 3.5
+- Python >= 3.5
 
 marshmallow has no external dependencies outside of the Python standard library, although `python-dateutil <https://pypi.python.org/pypi/python-dateutil>`_ is recommended for robust datetime deserialization.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-**marshmallow** requires Python >= 2.7 or >= 3.5. It has no external dependencies other than the Python standard library.
+**marshmallow** requires Python >= 3.5. It has no external dependencies other than the Python standard library.
 
 .. note::
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1013,14 +1013,6 @@ class TestFieldDeserialization:
             field.deserialize('invalid')
         assert 'Bad value.' in str(excinfo)
 
-    def test_field_deserialization_with_non_utf8_value(self):
-        non_utf8_char = '\xc8'
-        field = fields.String()
-        # This exception only happens in Python version <= 2.7
-        if isinstance(non_utf8_char, bytes):
-            with pytest.raises(ValidationError) as excinfo:
-                field.deserialize(non_utf8_char)
-            assert excinfo.value.args[0] == 'Not a valid utf-8 string.'
 
 # No custom deserialization behavior, so a dict is returned
 class SimpleUserSchema(Schema):

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,6 @@ deps = pre-commit~=1.14
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:py27]
-commands = pytest --ignore=tests/test_py3/ {posargs}
-
 [testenv:docs]
 deps = -rdocs/requirements.txt
 extras =


### PR DESCRIPTION
A few little bits to follow on from https://github.com/marshmallow-code/marshmallow/pull/1204, for https://github.com/marshmallow-code/marshmallow/issues/1120.