### PR TITLE
Fix wrong get_declared_fields() param types

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -103,7 +103,7 @@ class SchemaMeta(type):
         # Set klass.opts in __new__ rather than __init__ so that it is accessible in
         # get_declared_fields
         klass.opts = klass.OPTIONS_CLASS(meta, ordered=ordered)
-        # Add fields specifid in the `include` class Meta option
+        # Add fields specified in the `include` class Meta option
         cls_fields += list(klass.opts.include.items())
 
         dict_cls = OrderedDict if ordered else dict

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -123,9 +123,9 @@ class SchemaMeta(type):
         computed from class Meta options.
 
         :param type klass: The class object.
-        :param dict cls_fields: The fields declared on the class, including those added
+        :param list cls_fields: The fields declared on the class, including those added
             by the ``include`` class Meta option.
-        :param dict inherited_fileds: Inherited fields.
+        :param list inherited_fileds: Inherited fields.
         :param type dict_class: Either `dict` or `OrderedDict`, depending on the whether
             the user specified `ordered=True`.
         """

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -125,7 +125,7 @@ class SchemaMeta(type):
         :param type klass: The class object.
         :param list cls_fields: The fields declared on the class, including those added
             by the ``include`` class Meta option.
-        :param list inherited_fileds: Inherited fields.
+        :param list inherited_fields: Inherited fields.
         :param type dict_class: Either `dict` or `OrderedDict`, depending on the whether
             the user specified `ordered=True`.
         """


### PR DESCRIPTION
It seems that `SchemaMeta.get_declared_fields()` takes arguments `cls_fields` and `inherited_fields` as `list` type. Yet the docstring params indicate their expected type as `dict`.

This PR adjusts the docstring declared types and corrects a couple of typos.
