### PR TITLE
Fix propagation of options to Nested containers

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -576,12 +576,18 @@ class List(Field):
                 'The list elements must be a subclass or instance of '
                 'marshmallow.base.FieldABC.',
             )
+        if isinstance(self.container, Nested):
+            self.only = self.container.only
+            self.exclude = self.container.exclude
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         self.container = copy.deepcopy(self.container)
         self.container.parent = self
         self.container.name = field_name
+        if isinstance(self.container, Nested):
+            self.container.only = self.only
+            self.container.exclude = self.exclude
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
@@ -651,15 +657,24 @@ class Tuple(Field):
             )
 
         self.validate_length = Length(equal=len(self.tuple_fields))
+        for container in self.tuple_fields:
+            if isinstance(container, Nested):
+                self.only = container.only
+                self.exclude = container.exclude
+                break
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         new_tuple_fields = []
         for container in self.tuple_fields:
-            new_container = copy.deepcopy(container)
-            new_container.parent = self
-            new_container.name = field_name
-            new_tuple_fields.append(new_container)
+            container = copy.deepcopy(container)
+            container.parent = self
+            container.name = field_name
+            new_tuple_fields.append(container)
+            if isinstance(container, Nested):
+                container.only = self.only
+                container.exclude = self.exclude
+
         self.tuple_fields = new_tuple_fields
 
     def _serialize(self, value, attr, obj, **kwargs):
@@ -1288,6 +1303,9 @@ class Mapping(Field):
                     '"values" must be a subclass or instance of '
                     'marshmallow.base.FieldABC.',
                 )
+            if isinstance(self.value_container, Nested):
+                self.only = self.value_container.only
+                self.exclude = self.value_container.exclude
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
@@ -1295,6 +1313,9 @@ class Mapping(Field):
             self.value_container = copy.deepcopy(self.value_container)
             self.value_container.parent = self
             self.value_container.name = field_name
+        if isinstance(self.value_container, Nested):
+            self.value_container.only = self.only
+            self.value_container.exclude = self.exclude
         if self.key_container:
             self.key_container = copy.deepcopy(self.key_container)
             self.key_container.parent = self

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -657,11 +657,6 @@ class Tuple(Field):
             )
 
         self.validate_length = Length(equal=len(self.tuple_fields))
-        for container in self.tuple_fields:
-            if isinstance(container, Nested):
-                self.only = container.only
-                self.exclude = container.exclude
-                break
 
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
@@ -671,9 +666,6 @@ class Tuple(Field):
             container.parent = self
             container.name = field_name
             new_tuple_fields.append(container)
-            if isinstance(container, Nested):
-                container.only = self.only
-                container.exclude = self.exclude
 
         self.tuple_fields = new_tuple_fields
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -260,8 +260,11 @@ class TestListNested:
         schema = Family(**{param: ['children.name']})
         assert getattr(schema.fields['children'].container.schema, param) == {'name'}
 
-    @pytest.mark.parametrize('param', ('only', 'exclude'))
-    def test_list_nested_only_and_exclude_merged_with_nested(self, param):
+    @pytest.mark.parametrize(
+        ('param', 'expected'),
+        (('only', {'name'}), ('exclude', {'name', 'surname', 'age'})),
+    )
+    def test_list_nested_only_and_exclude_merged_with_nested(self, param, expected):
 
         class Child(Schema):
             name = fields.String()
@@ -272,10 +275,6 @@ class TestListNested:
             children = fields.List(fields.Nested(Child, **{param: ('name', 'surname')}))
 
         schema = Family(**{param: ['children.name', 'children.age']})
-        expected = {
-            'only': {'name'},
-            'exclude': {'name', 'surname', 'age'},
-        }[param]
         assert getattr(schema.fields['children'].container, param) == expected
 
     def test_list_nested_partial_propagated_to_nested(self):
@@ -324,8 +323,11 @@ class TestTupleNested:
         assert getattr(schema.fields['children'].tuple_fields[0].schema, param) == {'name'}
         assert getattr(schema.fields['children'].tuple_fields[1].schema, param) == {'name'}
 
-    @pytest.mark.parametrize('param', ('only', 'exclude'))
-    def test_tuple_nested_only_and_exclude_merged_with_nested(self, param):
+    @pytest.mark.parametrize(
+        ('param', 'expected'),
+        (('only', {'name'}), ('exclude', {'name', 'surname', 'age'})),
+    )
+    def test_tuple_nested_only_and_exclude_merged_with_nested(self, param, expected):
 
         class Child(Schema):
             name = fields.String()
@@ -341,10 +343,6 @@ class TestTupleNested:
             )
 
         schema = Family(**{param: ['children.name', 'children.age']})
-        expected = {
-            'only': {'name'},
-            'exclude': {'name', 'surname', 'age'},
-        }[param]
         assert getattr(schema.fields['children'].tuple_fields[0], param) == expected
         assert getattr(schema.fields['children'].tuple_fields[1], param) == expected
 
@@ -393,8 +391,11 @@ class TestDictNested:
         schema = Family(**{param: ['children.name']})
         assert getattr(schema.fields['children'].value_container.schema, param) == {'name'}
 
-    @pytest.mark.parametrize('param', ('only', 'exclude'))
-    def test_dict_nested_only_and_exclude_merged_with_nested(self, param):
+    @pytest.mark.parametrize(
+        ('param', 'expected'),
+        (('only', {'name'}), ('exclude', {'name', 'surname', 'age'})),
+    )
+    def test_dict_nested_only_and_exclude_merged_with_nested(self, param, expected):
 
         class Child(Schema):
             name = fields.String()
@@ -405,10 +406,6 @@ class TestDictNested:
             children = fields.Dict(values=fields.Nested(Child, **{param: ('name', 'surname')}))
 
         schema = Family(**{param: ['children.name', 'children.age']})
-        expected = {
-            'only': {'name'},
-            'exclude': {'name', 'surname', 'age'},
-        }[param]
         assert getattr(schema.fields['children'].value_container, param) == expected
 
     def test_dict_nested_partial_propagated_to_nested(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -309,7 +309,7 @@ class TestListNested:
 
 class TestTupleNested:
 
-    @pytest.mark.parametrize('param', ('only', 'exclude', 'dump_only', 'load_only'))
+    @pytest.mark.parametrize('param', ('dump_only', 'load_only'))
     def test_tuple_nested_only_exclude_dump_only_load_only_propagated_to_nested(self, param):
 
         class Child(Schema):
@@ -322,29 +322,6 @@ class TestTupleNested:
         schema = Family(**{param: ['children.name']})
         assert getattr(schema.fields['children'].tuple_fields[0].schema, param) == {'name'}
         assert getattr(schema.fields['children'].tuple_fields[1].schema, param) == {'name'}
-
-    @pytest.mark.parametrize(
-        ('param', 'expected'),
-        (('only', {'name'}), ('exclude', {'name', 'surname', 'age'})),
-    )
-    def test_tuple_nested_only_and_exclude_merged_with_nested(self, param, expected):
-
-        class Child(Schema):
-            name = fields.String()
-            surname = fields.String()
-            age = fields.Integer()
-
-        class Family(Schema):
-            children = fields.Tuple(
-                (
-                    fields.Nested(Child, **{param: ('name', 'surname')}),
-                    fields.Nested(Child, **{param: ('name', 'surname')}),
-                ),
-            )
-
-        schema = Family(**{param: ['children.name', 'children.age']})
-        assert getattr(schema.fields['children'].tuple_fields[0], param) == expected
-        assert getattr(schema.fields['children'].tuple_fields[1], param) == expected
 
     def test_tuple_nested_partial_propagated_to_nested(self):
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -247,6 +247,37 @@ class TestNestedField:
 
 class TestListNested:
 
+    @pytest.mark.parametrize('param', ('only', 'exclude', 'dump_only', 'load_only'))
+    def test_list_nested_only_exclude_dump_only_load_only_propagated_to_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.List(fields.Nested(Child))
+
+        schema = Family(**{param: ['children.name']})
+        assert getattr(schema.fields['children'].container.schema, param) == {'name'}
+
+    @pytest.mark.parametrize('param', ('only', 'exclude'))
+    def test_list_nested_only_and_exclude_merged_with_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            surname = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.List(fields.Nested(Child, **{param: ('name', 'surname')}))
+
+        schema = Family(**{param: ['children.name', 'children.age']})
+        expected = {
+            'only': {'name'},
+            'exclude': {'name', 'surname', 'age'},
+        }[param]
+        assert getattr(schema.fields['children'].container, param) == expected
+
     def test_list_nested_partial_propagated_to_nested(self):
 
         class Child(Schema):
@@ -279,6 +310,44 @@ class TestListNested:
 
 class TestTupleNested:
 
+    @pytest.mark.parametrize('param', ('only', 'exclude', 'dump_only', 'load_only'))
+    def test_tuple_nested_only_exclude_dump_only_load_only_propagated_to_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.Tuple((fields.Nested(Child), fields.Nested(Child)))
+
+        schema = Family(**{param: ['children.name']})
+        assert getattr(schema.fields['children'].tuple_fields[0].schema, param) == {'name'}
+        assert getattr(schema.fields['children'].tuple_fields[1].schema, param) == {'name'}
+
+    @pytest.mark.parametrize('param', ('only', 'exclude'))
+    def test_tuple_nested_only_and_exclude_merged_with_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            surname = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.Tuple(
+                (
+                    fields.Nested(Child, **{param: ('name', 'surname')}),
+                    fields.Nested(Child, **{param: ('name', 'surname')}),
+                ),
+            )
+
+        schema = Family(**{param: ['children.name', 'children.age']})
+        expected = {
+            'only': {'name'},
+            'exclude': {'name', 'surname', 'age'},
+        }[param]
+        assert getattr(schema.fields['children'].tuple_fields[0], param) == expected
+        assert getattr(schema.fields['children'].tuple_fields[1], param) == expected
+
     def test_tuple_nested_partial_propagated_to_nested(self):
 
         class Child(Schema):
@@ -310,6 +379,37 @@ class TestTupleNested:
 
 
 class TestDictNested:
+
+    @pytest.mark.parametrize('param', ('only', 'exclude', 'dump_only', 'load_only'))
+    def test_dict_nested_only_exclude_dump_only_load_only_propagated_to_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.Dict(values=fields.Nested(Child))
+
+        schema = Family(**{param: ['children.name']})
+        assert getattr(schema.fields['children'].value_container.schema, param) == {'name'}
+
+    @pytest.mark.parametrize('param', ('only', 'exclude'))
+    def test_dict_nested_only_and_exclude_merged_with_nested(self, param):
+
+        class Child(Schema):
+            name = fields.String()
+            surname = fields.String()
+            age = fields.Integer()
+
+        class Family(Schema):
+            children = fields.Dict(values=fields.Nested(Child, **{param: ('name', 'surname')}))
+
+        schema = Family(**{param: ['children.name', 'children.age']})
+        expected = {
+            'only': {'name'},
+            'exclude': {'name', 'surname', 'age'},
+        }[param]
+        assert getattr(schema.fields['children'].value_container, param) == expected
 
     def test_dict_nested_partial_propagated_to_nested(self):
 


### PR DESCRIPTION
Fixes #946.

Replaces https://github.com/marshmallow-code/marshmallow/pull/1066.

Note that the tests only test that the parameter is passed, they don't test the behaviour. This made parametrization easier. I could rework in a more verbose way if needed.