### PR TITLE
utils.from_rfc: use email.utils.parsedate_to_datetime

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -5,10 +5,9 @@ import datetime
 import inspect
 import json
 import re
-import time
 from calendar import timegm
 from collections.abc import Mapping, Iterable
-from email.utils import formatdate, parsedate
+from email.utils import formatdate, parsedate_to_datetime
 from pprint import pprint as py_pprint
 
 from marshmallow.base import FieldABC
@@ -203,20 +202,12 @@ def isoformat(dt, *args, localtime=False, **kwargs):
     return localized.isoformat(*args, **kwargs)
 
 
-def from_rfc(datestring, *, use_dateutil=True):
+def from_rfc(datestring):
     """Parse a RFC822-formatted datetime string and return a datetime object.
-
-    Use dateutil's parser if possible.
 
     https://stackoverflow.com/questions/885015/how-to-parse-a-rfc-2822-date-time-into-a-python-datetime
     """
-    # Use dateutil's parser if possible
-    if dateutil_available and use_dateutil:
-        return parser.parse(datestring)
-    else:
-        parsed = parsedate(datestring)  # as a tuple
-        timestamp = time.mktime(parsed)
-        return datetime.datetime.fromtimestamp(timestamp)
+    return parsedate_to_datetime(datestring)
 
 
 def from_iso_datetime(datetimestring, *, use_dateutil=True):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,11 +141,10 @@ def test_isoformat_localtime():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
     assert utils.isoformat(d, localtime=True) == '2013-11-10T01:23:45-06:00'
 
-@pytest.mark.parametrize('use_dateutil', [True, False])
-def test_from_rfc(use_dateutil):
+def test_from_rfc():
     d = dt.datetime.now()
     rfc = utils.rfcformat(d)
-    result = utils.from_rfc(rfc, use_dateutil=use_dateutil)
+    result = utils.from_rfc(rfc)
     assert type(result) == dt.datetime
     assert_datetime_equal(result, d)
 


### PR DESCRIPTION
No need to use dateutil to parse RFC dates.

Python 3.3 introduces [email.utils.parsedate_to_datetime](https://docs.python.org/3/library/email.utils.html#email.utils.parsedate_to_datetime).

See https://github.com/marshmallow-code/marshmallow/issues/1234#issue-453390160.