### PR TITLE
utils.rfcformat: use email.utils.format_datetime

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,6 +125,10 @@ def test_rfcformat_central():
     d = central.localize(dt.datetime(2013, 11, 10, 1, 23, 45), is_dst=False)
     assert utils.rfcformat(d) == 'Sun, 10 Nov 2013 07:23:45 -0000'
 
+def test_rfcformat_naive_localized():
+    d = dt.datetime(2013, 11, 10, 1, 23, 45)
+    assert utils.rfcformat(d, localtime=True) == 'Sun, 10 Nov 2013 01:23:45 +0000'
+
 def test_rfcformat_central_localized():
     d = central.localize(dt.datetime(2013, 11, 10, 8, 23, 45), is_dst=False)
     assert utils.rfcformat(d, localtime=True) == 'Sun, 10 Nov 2013 08:23:45 -0600'


### PR DESCRIPTION
Python 3.3 introduces [email.utils.format_datetime](https://docs.python.org/3/library/email.utils.html#email.utils.format_datetime).