### PR TITLE
Fix from_iso for less than 6 digits microseconds.

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -285,6 +285,9 @@ def from_iso(datestring, use_dateutil=True):
         # Strip off timezone info.
         if '.' in datestring:
             # datestring contains microseconds
+            (dt_nomstz, mstz) = datestring.split('.')
+            ms_notz = mstz[:len(mstz) - len(mstz.lstrip('0123456789'))]
+            datestring = '.'.join((dt_nomstz, ms_notz))
             return datetime.datetime.strptime(datestring[:26], '%Y-%m-%dT%H:%M:%S.%f')
         return datetime.datetime.strptime(datestring[:19], '%Y-%m-%dT%H:%M:%S')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,6 +200,15 @@ def test_from_iso_datetime(use_dateutil, timezone):
     assert type(result) == dt.datetime
     assert_datetime_equal(result, d)
 
+    # Test with 3-digit only microseconds
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/1251
+    d = dt.datetime.now(tz=timezone).replace(microsecond=123000)
+    formatted = d.isoformat()
+    formatted = formatted[:23] + formatted[26:]
+    result = utils.from_iso(formatted, use_dateutil=use_dateutil)
+    assert type(result) == dt.datetime
+    assert_datetime_equal(result, d)
+
 def test_from_iso_with_tz():
     d = central.localize(dt.datetime.now())
     formatted = d.isoformat()


### PR DESCRIPTION
Fixes #1251.