### PR TITLE
add note regarding backwards compatibility change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -555,6 +555,9 @@ Bug fixes:
   multiple instantiations (:issue:`1212`). Thanks :user:`MHannila` for
   reporting.
 
+Other changes:
+- ``Schema.exclude`` is now a set (previously it was a list or tuple)
+
 2.19.2 (2019-03-30)
 +++++++++++++++++++
 


### PR DESCRIPTION
Not sure if I worded this right, but I ran into this when my build failed after attempting to modify a Schema's `exclude` attribute after `__init__` . I.e.:

```python
foo = MySchema()
foo.exclude = ['first_name']
foo._update_fields()
```

The above was failing on a subsequent call to (private) `_update_fields()`. Probably my own fault for making nasty use of private API in a rather... interesting implementation (basically I have some permissions overrides for different user types and rolled my own `exclude_only` pattern for different user types)

See stacktrace below:

```python
    def _update_fields(self, obj=None, many=False):
        """Update fields based on the passed in object."""
        if self.only is not None:
            # Return only fields specified in only option
            if self.opts.fields:
                field_names = self.set_class(self.opts.fields) & self.set_class(self.only)
            else:
                field_names = self.set_class(self.only)
        elif self.opts.fields:
            # Return fields specified in fields option
            field_names = self.set_class(self.opts.fields)
        elif self.opts.additional:
            # Return declared fields + additional fields
            field_names = (self.set_class(self.declared_fields.keys()) |
                            self.set_class(self.opts.additional))

       else:
            field_names = self.set_class(self.declared_fields.keys())
    
        # If "exclude" option or param is specified, remove those fields
>       field_names -= self.exclude
E       TypeError: unsupported operand type(s) for -=: 'set' and 'tuple'

/usr/local/lib/python3.6/site-packages/marshmallow/schema.py:770: TypeError
```