### PR TITLE
Copy ISO8601 deserialization functions from Django

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Features:
   within ``List`` and ``Dict`` (:issue:`779`, :issue:`946`).
 - Use ``email.utils.parsedate_to_datetime`` instead of conditionally
   using dateutil for parsing RFC dates (:pr:`1246`).
+- Use internal util functions instead of conditionally using dateutil
+  for parsing  ISO 8601 datetimes, dates and times. Timezone info is now
+  correctly deserialized whether or not dateutil is installed. (:pr:`1265`)
 - Improve error messages for ``validate.Range``.
 - Use ``raise from exc`` for better stack traces (:pr:`1254`). Thanks
   :user:`fuhrysteve`.
@@ -23,6 +26,8 @@ Other changes:
 - *Backwards-incompatible*: Rename ``fields.List.container`` to ``fields.List.inner``,
   ``fields.Dict.key_container`` to ``fields.Dict.key_field``, and
   ``fields.Dict.value_container`` to ``fields.Dict.value_field``.
+- python-dateutil is not used anymore and dropped from the recommended
+  dependencies.
 
 3.0.0rc7 (2019-06-15)
 +++++++++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,6 @@ Requirements
 
 - Python >= 3.5
 
-marshmallow has no external dependencies outside of the Python standard library, although `python-dateutil <https://pypi.python.org/pypi/python-dateutil>`_ is recommended for robust datetime deserialization.
-
-
 Ecosystem
 =========
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,14 +5,6 @@ Installation
 
 **marshmallow** requires Python >= 3.5. It has no external dependencies other than the Python standard library.
 
-.. note::
-
-    The `python-dateutil <https://pypi.python.org/pypi/python-dateutil>`_ package is not a hard dependency, but it is recommended for robust datetime deserialization.
-
-    ::
-
-        $ pip install 'python-dateutil>=2.7.0'
-
 Installing/Upgrading from the PyPI
 ----------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -883,6 +883,17 @@ In marshmallow 2, it was possible to have multiple fields with the same ``attrib
     MySchema()
     # No error
 
+
+``python-dateutil`` recommended dependency is removed
+*****************************************************
+
+In marshmallow 2, ``python-dateutil`` was used to deserialize RFC or ISO 8601
+datetimes if it was installed. In marshmallow 3, datetime deserialization is
+done with no additional dependency.
+
+``python-dateutil`` is no longer used by marshmallow.
+
+
 Upgrading to 2.3
 ++++++++++++++++
 

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,10 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    "reco": ["simplejson"],
-    "tests": ["pytest", "pytz"],
+    "tests": ["pytest", "pytz", "simplejson"],
     "lint": ["flake8==3.7.7", "flake8-bugbear==19.3.0", "pre-commit==1.17.0"],
 }
-EXTRAS_REQUIRE["dev"] = (
-    EXTRAS_REQUIRE["reco"] + EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
-)
+EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 
 
 def find_version(fname):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    "reco": ["python-dateutil>=2.7.0", "simplejson"],
+    "reco": ["simplejson"],
     "tests": ["pytest", "pytz"],
     "lint": ["flake8==3.7.7", "flake8-bugbear==19.3.0", "pre-commit==1.17.0"],
 }

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -199,7 +199,7 @@ def get_fixed_timezone(offset):
     return datetime.timezone(datetime.timedelta(minutes=offset), name)
 
 
-def from_iso_datetime(value, **kwargs):
+def from_iso_datetime(value):
     """Parse a string and return a datetime.datetime.
 
     This function supports time zone offsets. When the input contains one,
@@ -227,7 +227,7 @@ def from_iso_datetime(value, **kwargs):
     return datetime.datetime(**kw)
 
 
-def from_iso_time(value, **kwargs):
+def from_iso_time(value):
     """Parse a string and return a datetime.time.
 
     This function doesn't support time zone offsets.
@@ -245,7 +245,7 @@ def from_iso_time(value, **kwargs):
     return datetime.time(**kw)
 
 
-def from_iso_date(value, **kwargs):
+def from_iso_date(value):
     """Parse a string and return a datetime.date.
 
     Raise ValueError if the input is well formatted but not a valid date.

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -460,9 +460,7 @@ class TestFieldDeserialization:
         field = fields.DateTime(format="iso")
         result = field.deserialize(localized_dtime.isoformat())
         assert_datetime_equal(result, dtime)
-        # If dateutil is used, the datetime will not be naive
-        if utils.dateutil_available:
-            assert result.tzinfo is not None
+        assert result.tzinfo is not None
 
     def test_time_field_deserialization(self):
         field = fields.Time()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -163,12 +163,11 @@ def test_from_rfc():
     assert_datetime_equal(result, d)
 
 
-@pytest.mark.parametrize("use_dateutil", [True, False])
 @pytest.mark.parametrize("timezone", [None, central])
-def test_from_iso_datetime(use_dateutil, timezone):
+def test_from_iso_datetime(timezone):
     d = dt.datetime.now(tz=timezone)
     formatted = d.isoformat()
-    result = utils.from_iso_datetime(formatted, use_dateutil=use_dateutil)
+    result = utils.from_iso_datetime(formatted)
     assert type(result) == dt.datetime
     assert_datetime_equal(result, d)
 
@@ -177,7 +176,7 @@ def test_from_iso_datetime(use_dateutil, timezone):
     d = dt.datetime.now(tz=timezone).replace(microsecond=123000)
     formatted = d.isoformat()
     formatted = formatted[:23] + formatted[26:]
-    result = utils.from_iso_datetime(formatted, use_dateutil=use_dateutil)
+    result = utils.from_iso_datetime(formatted)
     assert type(result) == dt.datetime
     assert_datetime_equal(result, d)
 
@@ -187,35 +186,29 @@ def test_from_iso_with_tz():
     formatted = d.isoformat()
     result = utils.from_iso_datetime(formatted)
     assert_datetime_equal(result, d)
-    if utils.dateutil_available:
-        # Note a naive datetime
-        assert result.tzinfo is not None
+    assert result.tzinfo is not None
 
 
-# Test with and without dateutil
-@pytest.mark.parametrize("use_dateutil", [True, False])
-def test_from_iso_time_with_microseconds(use_dateutil):
+def test_from_iso_time_with_microseconds():
     t = dt.time(1, 23, 45, 6789)
     formatted = t.isoformat()
-    result = utils.from_iso_time(formatted, use_dateutil=use_dateutil)
+    result = utils.from_iso_time(formatted)
     assert type(result) == dt.time
     assert_time_equal(result, t)
 
 
-@pytest.mark.parametrize("use_dateutil", [True, False])
-def test_from_iso_time_without_microseconds(use_dateutil):
+def test_from_iso_time_without_microseconds():
     t = dt.time(1, 23, 45)
     formatted = t.isoformat()
-    result = utils.from_iso_time(formatted, use_dateutil=use_dateutil)
+    result = utils.from_iso_time(formatted)
     assert type(result) == dt.time
     assert_time_equal(result, t)
 
 
-@pytest.mark.parametrize("use_dateutil", [True, False])
-def test_from_iso_date(use_dateutil):
+def test_from_iso_date():
     d = dt.date(2014, 8, 21)
     iso_date = d.isoformat()
-    result = utils.from_iso_date(iso_date, use_dateutil=use_dateutil)
+    result = utils.from_iso_date(iso_date)
     assert type(result) == dt.date
     assert_date_equal(result, d)
 


### PR DESCRIPTION
Related to https://github.com/marshmallow-code/marshmallow/issues/1234 and https://github.com/marshmallow-code/marshmallow/pull/1252#issuecomment-503103373.

Using ISO8601 deserialization functions from Django makes python-dateutil dependency useless.

This PR copies the deserialization functions from Django and removes python-dateutil.

I can finish this later on (run black, cleanup, review docstrings) but feedback welcome already.