### PR TITLE
Officially support Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py26,py27,py34,py35,docs
+envlist = lint,py26,py27,py34,py35,py36,py37,docs
 
 [testenv]
 extras = tests,reco


### PR DESCRIPTION
We're already testing against py36 and py37 in AP, so might as well document official support.