### PR TITLE
Fix contained parent in container fields

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -585,8 +585,7 @@ class List(Field):
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         self.inner = copy.deepcopy(self.inner)
-        self.inner.parent = self
-        self.inner.name = field_name
+        self.inner._bind_to_schema(field_name, self.parent)
         if isinstance(self.inner, Nested):
             self.inner.only = self.only
             self.inner.exclude = self.exclude
@@ -663,8 +662,7 @@ class Tuple(Field):
         new_tuple_fields = []
         for field in self.tuple_fields:
             field = copy.deepcopy(field)
-            field.parent = self
-            field.name = field_name
+            field._bind_to_schema(field_name, self.parent)
             new_tuple_fields.append(field)
 
         self.tuple_fields = new_tuple_fields
@@ -1303,15 +1301,13 @@ class Mapping(Field):
         super()._bind_to_schema(field_name, schema)
         if self.value_field:
             self.value_field = copy.deepcopy(self.value_field)
-            self.value_field.parent = self
-            self.value_field.name = field_name
+            self.value_field._bind_to_schema(field_name, self.parent)
         if isinstance(self.value_field, Nested):
             self.value_field.only = self.only
             self.value_field.exclude = self.exclude
         if self.key_field:
             self.key_field = copy.deepcopy(self.key_field)
-            self.key_field.parent = self
-            self.key_field.name = field_name
+            self.key_field._bind_to_schema(field_name, self.parent)
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -107,6 +107,7 @@ class TestParentAndName:
         foo = fields.Field()
         bar = fields.List(fields.Str())
         baz = fields.Tuple([fields.Str(), fields.Int()])
+        bax = fields.Mapping(fields.Str(), fields.Int())
 
     @pytest.fixture()
     def schema(self):
@@ -130,13 +131,19 @@ class TestParentAndName:
         assert inner_field.root is None
 
     def test_list_field_inner_parent_and_name(self, schema):
-        assert schema.fields["bar"].inner.parent == schema.fields["bar"]
+        assert schema.fields["bar"].inner.parent == schema
         assert schema.fields["bar"].inner.name == "bar"
 
     def test_tuple_field_inner_parent_and_name(self, schema):
         for field in schema.fields["baz"].tuple_fields:
-            assert field.parent == schema.fields["baz"]
+            assert field.parent == schema
             assert field.name == "baz"
+
+    def test_mapping_field_inner_parent_and_name(self, schema):
+        assert schema.fields["bax"].value_field.parent == schema
+        assert schema.fields["bax"].value_field.name == "bax"
+        assert schema.fields["bax"].key_field.parent == schema
+        assert schema.fields["bax"].key_field.name == "bax"
 
     def test_simple_field_root(self, schema):
         assert schema.fields["foo"].root == schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2359,7 +2359,7 @@ class TestSelfReference:
         relative = data["rels"][0]
         assert relative == user.relatives[0].name
 
-    def test_nested_many(self):
+    def test_nested_self_many(self):
         class SelfManySchema(Schema):
             relatives = fields.Nested("self", many=True)
 
@@ -2369,6 +2369,21 @@ class TestSelfReference:
         person = User(name="Foo")
         person.relatives = [User(name="Bar", age=12), User(name="Baz", age=34)]
         data = SelfManySchema().dump(person)
+        assert data["name"] == person.name
+        assert len(data["relatives"]) == len(person.relatives)
+        assert data["relatives"][0]["name"] == person.relatives[0].name
+        assert data["relatives"][0]["age"] == person.relatives[0].age
+
+    def test_nested_self_list(self):
+        class SelfListSchema(Schema):
+            relatives = fields.List(fields.Nested("self"))
+
+            class Meta:
+                additional = ("name", "age")
+
+        person = User(name="Foo")
+        person.relatives = [User(name="Bar", age=12), User(name="Baz", age=34)]
+        data = SelfListSchema().dump(person)
         assert data["name"] == person.name
         assert len(data["relatives"]) == len(person.relatives)
         assert data["relatives"][0]["name"] == person.relatives[0].name


### PR DESCRIPTION
I think this is the right fix for https://github.com/marshmallow-code/marshmallow/issues/779#issuecomment-396354987.

I had to modify some tests. Apparently, the former behaviour was intended but I don't see why so I assume it was a mistake.