### PR TITLE
Rework container fields _bind_to_schema

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -585,8 +585,7 @@ class List(Field):
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         self.inner = copy.deepcopy(self.inner)
-        self.inner.parent = self
-        self.inner.name = field_name
+        self.inner._bind_to_schema(field_name, self)
         if isinstance(self.inner, Nested):
             self.inner.only = self.only
             self.inner.exclude = self.exclude
@@ -663,8 +662,7 @@ class Tuple(Field):
         new_tuple_fields = []
         for field in self.tuple_fields:
             field = copy.deepcopy(field)
-            field.parent = self
-            field.name = field_name
+            field._bind_to_schema(field_name, self)
             new_tuple_fields.append(field)
 
         self.tuple_fields = new_tuple_fields
@@ -1303,15 +1301,13 @@ class Mapping(Field):
         super()._bind_to_schema(field_name, schema)
         if self.value_field:
             self.value_field = copy.deepcopy(self.value_field)
-            self.value_field.parent = self
-            self.value_field.name = field_name
+            self.value_field._bind_to_schema(field_name, self)
         if isinstance(self.value_field, Nested):
             self.value_field.only = self.only
             self.value_field.exclude = self.exclude
         if self.key_field:
             self.key_field = copy.deepcopy(self.key_field)
-            self.key_field.parent = self
-            self.key_field.name = field_name
+            self.key_field._bind_to_schema(field_name, self)
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -107,6 +107,7 @@ class TestParentAndName:
         foo = fields.Field()
         bar = fields.List(fields.Str())
         baz = fields.Tuple([fields.Str(), fields.Int()])
+        bax = fields.Mapping(fields.Str(), fields.Int())
 
     @pytest.fixture()
     def schema(self):
@@ -137,6 +138,12 @@ class TestParentAndName:
         for field in schema.fields["baz"].tuple_fields:
             assert field.parent == schema.fields["baz"]
             assert field.name == "baz"
+
+    def test_mapping_field_inner_parent_and_name(self, schema):
+        assert schema.fields["bax"].value_field.parent == schema.fields["bax"]
+        assert schema.fields["bax"].value_field.name == "bax"
+        assert schema.fields["bax"].key_field.parent == schema.fields["bax"]
+        assert schema.fields["bax"].key_field.name == "bax"
 
     def test_simple_field_root(self, schema):
         assert schema.fields["foo"].root == schema


### PR DESCRIPTION
- Minor rework to avoid duplicating `_bind_to_schema` logic (copied from `Inferred`).
- Add `test_mapping_field_inner_parent_and_name`