### PR TITLE
Implementation required_fields

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -665,7 +665,12 @@ class BaseSchema(base.SchemaABC):
                 raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     if field_name in self.load_necessary:
-                        field_obj.fail("required")
+                        try:
+                            field_obj.fail("required")
+                        except ValidationError as err:
+                            error_store.store_error(err.messages, field_name=field_name, index=index)
+                            continue
+
                     # Ignore missing field if we're allowed to.
                     if partial is True or (
                         partial_is_collection and attr_name in partial

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -362,7 +362,7 @@ class BaseSchema(base.SchemaABC):
         dump_only=(),
         partial=False,
         unknown=None,
-        load_necessary=(),
+        load_necessary=()
     ):
         # Raise error if only or exclude is passed as string, not list of strings
         if only is not None and not is_collection(only):

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -668,7 +668,9 @@ class BaseSchema(base.SchemaABC):
                         try:
                             field_obj.fail("required")
                         except ValidationError as err:
-                            error_store.store_error(err.messages, field_name=field_name, index=index)
+                            error_store.store_error(
+                                err.messages, field_name=field_name, index=index
+                            )
                             continue
 
                     # Ignore missing field if we're allowed to.

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -218,7 +218,7 @@ class SchemaOpts:
         self.dump_only = getattr(meta, "dump_only", ())
         self.unknown = getattr(meta, "unknown", RAISE)
         self.register = getattr(meta, "register", True)
-        self.load_necessary = getattr(meta, "load_necessary", ())
+        self.required_fields = getattr(meta, "required_fields", ())
 
 
 class BaseSchema(base.SchemaABC):
@@ -345,7 +345,7 @@ class BaseSchema(base.SchemaABC):
             class registry. Must be `True` if you intend to refer to this `Schema`
             by class name in `Nested` fields. Only set this to `False` when memory
             usage is critical. Defaults to `True`.
-        - ``load_necessary``:  Tuple or list of fields of necessarily include in the
+        - ``required_fields``:  Tuple or list of fields of necessarily include in the
             deserialization result
         """
 
@@ -362,7 +362,7 @@ class BaseSchema(base.SchemaABC):
         dump_only=(),
         partial=False,
         unknown=None,
-        load_necessary=()
+        required_fields=()
     ):
         # Raise error if only or exclude is passed as string, not list of strings
         if only is not None and not is_collection(only):
@@ -379,7 +379,7 @@ class BaseSchema(base.SchemaABC):
         self.dump_only = set(dump_only) or set(self.opts.dump_only)
         self.partial = partial
         self.unknown = unknown or self.opts.unknown
-        self.load_necessary = set(self.opts.load_necessary) | set(load_necessary)
+        self.required_fields = set(self.opts.required_fields) | set(required_fields)
         self.context = context or {}
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
@@ -664,7 +664,7 @@ class BaseSchema(base.SchemaABC):
                     field_name = field_obj.data_key
                 raw_value = data.get(field_name, missing)
                 if raw_value is missing:
-                    if field_name in self.load_necessary:
+                    if field_name in self.required_fields:
                         try:
                             field_obj.fail("required")
                         except ValidationError as err:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1794,8 +1794,11 @@ def test_required_fields_in_constructor():
     sch = MySchema(load_necessary=("foo",))
     data = dict(baz=242)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as excinfo:
         sch.load(data)
+
+    errors = excinfo.value.messages
+    assert len(errors["foo"]) == 1
 
 
 def test_required_fields_in_meta():
@@ -1808,8 +1811,11 @@ def test_required_fields_in_meta():
     sch = MySchema()
     data = dict(baz=242)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as excinfo:
         sch.load(data)
+
+    errors = excinfo.value.messages
+    assert len(errors["foo"]) == 1
 
 
 class CustomError(Exception):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1787,6 +1787,31 @@ def test_serializing_none_meta():
     assert s == {}
 
 
+def test_required_fields_in_constructor():
+    class MySchema(Schema):
+        foo = fields.Field()
+
+    sch = MySchema(load_necessary=("foo",))
+    data = dict(baz=242)
+
+    with pytest.raises(ValidationError):
+        sch.load(data)
+
+
+def test_required_fields_in_meta():
+    class MySchema(Schema):
+        foo = fields.Field()
+
+        class Meta:
+            load_necessary = ("foo",)
+
+    sch = MySchema()
+    data = dict(baz=242)
+
+    with pytest.raises(ValidationError):
+        sch.load(data)
+
+
 class CustomError(Exception):
     pass
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1791,7 +1791,7 @@ def test_required_fields_in_constructor():
     class MySchema(Schema):
         foo = fields.Field()
 
-    sch = MySchema(load_necessary=("foo",))
+    sch = MySchema(required_fields=("foo",))
     data = dict(baz=242)
 
     with pytest.raises(ValidationError) as excinfo:
@@ -1806,7 +1806,7 @@ def test_required_fields_in_meta():
         foo = fields.Field()
 
         class Meta:
-            load_necessary = ("foo",)
+            required_fields = ("foo",)
 
     sch = MySchema()
     data = dict(baz=242)


### PR DESCRIPTION
[Propouse](https://github.com/marshmallow-code/marshmallow/issues/1280#issuecomment-509678660)

Motivation:
Sometimes need to specify which field must be load without modifying the field description. For example, schema generated by marshmallow-sqlalchemy or django-rest-marshmallow. This pull request adds this feature. 

For example, you have a session model with fields: id(integer), table_id(integer), user_id(integer), comment(Text), mark(integer). You want that for post requests model create only if a request contains table_id, user_id and excluded id field and for put request data should contain id field. Now for that use case need create to schemas.

```
class CreateSessionSchema(ma.ModelSchema):
    class Meta(BaseMeta):
        model = Session
        exlude = ["id"]
        required_fields= ["table_id", "user_id"]

class UpdateSessionSchema(ma.ModelSchema):
    class Meta(BaseMeta):
        model = Session
        required_fields = ["id"]
```
 
Now if data in a request not contained fields from required_fields will raise the exception: ValidationError.

P.S: Where to need to add documentation and tests for it?