### PR TITLE
Fix data_key with dotted path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,3 +132,4 @@ Contributors (chronological)
 - Kostas Konstantopoulos `@kdop <https://github.com/kdop>`_
 - Stephen J. Fuhry `@fuhrysteve <https://github.com/fuhrysteve>`_
 - `@dursk <https://github.com/dursk>`_
+- David Louis `@davidlouis https://github.com/davidlouis`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,4 +132,4 @@ Contributors (chronological)
 - Kostas Konstantopoulos `@kdop <https://github.com/kdop>`_
 - Stephen J. Fuhry `@fuhrysteve <https://github.com/fuhrysteve>`_
 - `@dursk <https://github.com/dursk>`_
-- David Louis `@davidlouis https://github.com/davidlouis`_
+- David Louis `@davidlouis <https://github.com/davidlouis>`_

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -492,7 +492,7 @@ class BaseSchema(base.SchemaABC):
             ]
             self._pending = False
             return ret
-        items = []
+        ret = dict_class()  # empty dict or OrderedDict
         for attr_name, field_obj in fields_dict.items():
             if getattr(field_obj, "load_only", False):
                 continue
@@ -507,8 +507,9 @@ class BaseSchema(base.SchemaABC):
             )
             if value is missing:
                 continue
-            items.append((key, value))
-        ret = dict_class(items)
+
+            set_value(ret, key, value)
+
         return ret
 
     def dump(self, obj, *, many=None):

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -657,7 +657,7 @@ class BaseSchema(base.SchemaABC):
                 field_name = attr_name
                 if field_obj.data_key:
                     field_name = field_obj.data_key
-                raw_value = data.get(field_name, missing)
+                raw_value = get_value(data, field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
                     if partial is True or (

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1178,6 +1178,18 @@ class TestSchemaDeserialization:
         assert result["email"] == "foo@bar.com"
         assert "years" not in result
 
+    def test_deserialize_dotted_path_with_data_key_param(self):
+        class MySchema(Schema):
+            foo = fields.Str(data_key="foo")
+            bar = fields.Str(data_key="data.bar")
+
+        sch = MySchema(unknown=EXCLUDE)
+        data = {"foo": "dotted", "data": {"bar": "paths!"}}
+
+        ret = sch.load(data)
+        assert ret["foo"] == "dotted"
+        assert ret["bar"] == "paths!"
+
     def test_deserialize_with_dump_only_param(self):
         class AliasingUserSerializer(Schema):
             name = fields.String()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -841,6 +841,26 @@ class TestFieldSerialization:
         res = field.serialize("foo", {"foo": None})
         assert res is None
 
+    def test_dotted_schema_serializes_to_nested_json(self):
+        """
+        Serialization of dotted path data keys should yield a nested json
+        structure, rather than {"foo.bar": 1}.
+        """
+
+        class MySchema(Schema):
+            foo = fields.Integer(data_key="data.foo")
+            bar = fields.Integer(data_key="data.bar")
+            baz = fields.Str(data_key="three.deep.baz")
+
+            class Meta:
+                ordered = True
+
+        sch = MySchema()
+        data = {"foo": 1, "bar": 2, "baz": "foo"}
+
+        ret = sch.dump(data)
+        assert ret == {"data": {"foo": 1, "bar": 2}, "three": {"deep": {"baz": "foo"}}}
+
 
 class TestSchemaSerialization:
     def test_serialize_with_missing_param_value(self):


### PR DESCRIPTION
I was expecting that I would be able to use `data_key` like so:
`bar = fields.Str(data_key="data.bar")`

which would in turn deserialize the following data such that bar == "paths!"
`data = {"foo": "dotted", "data": {"bar": "paths!"}}`
