### PR TITLE
Adjusted documentation for Regexp validator method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -132,3 +132,4 @@ Contributors (chronological)
 - Kostas Konstantopoulos `@kdop <https://github.com/kdop>`_
 - Stephen J. Fuhry `@fuhrysteve <https://github.com/fuhrysteve>`_
 - `@dursk <https://github.com/dursk>`_
+- Ezra MacDonald `@kdop <https://github.com/macdonaldezra>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Bug fixes:
 
 - Fix behavior of `List(Nested("self"))` (`#779 (comment) <https://github.com/marshmallow-code/marshmallow/issues/779#issuecomment-396354987>`_).
 
+Support:
+
+- Document usage of  `validate.Regexp`'s usage `re.search` (:issue:`1285`). Thanks :user:`macdonaldezra`.
+
 3.0.0rc8 (2019-07-04)
 +++++++++++++++++++++
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -334,9 +334,11 @@ class Equal(Validator):
 
 
 class Regexp(Validator):
-    """Validator which succeeds if the ``value`` matches ``regex``. Note that
-    this validator uses the re library’s match() function which searches for
-    a match at the beginning of a string.
+    """Validator which succeeds if the ``value`` matches ``regex``.
+
+    .. note::
+
+        Uses `re.match`, which searches for a match at the beginning of a string.
 
     :param regex: The regular expression string to use. Can also be a compiled
         regular expression pattern.

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -334,7 +334,9 @@ class Equal(Validator):
 
 
 class Regexp(Validator):
-    """Validate ``value`` against the provided regex.
+    """Validator which succeeds if the ``value`` matches ``regex``. Note that
+    this validator uses the re library’s match() function which searches for
+    a match at the beginning of a string.
 
     :param regex: The regular expression string to use. Can also be a compiled
         regular expression pattern.


### PR DESCRIPTION
I added a brief comment indicating that the Regexp method uses re's match() function. Knowing that match() is used for the validator could help newcomers write better regular expression validators.
