### PR TITLE
Small perf improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features:
 - *Backwards-incompatible*: ``DateTime`` does not affect timezone information
   on serialization and deserialization.
 - Add ``NaiveDateTime`` and ``AwareDateTime`` to enforce timezone awareness.
+- Performance improvements (:pr:`1309`).
 
 Deprecations/Removals:
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -1,6 +1,7 @@
 """The :class:`Schema` class, including its metaclass and options (class Meta)."""
 from collections import defaultdict, OrderedDict
 from collections.abc import Mapping
+from functools import lru_cache
 import datetime as dt
 import uuid
 import decimal
@@ -492,7 +493,7 @@ class BaseSchema(base.SchemaABC):
             ]
             self._pending = False
             return ret
-        items = []
+        ret = self.dict_class()
         for attr_name, field_obj in fields_dict.items():
             if getattr(field_obj, "load_only", False):
                 continue
@@ -507,8 +508,7 @@ class BaseSchema(base.SchemaABC):
             )
             if value is missing:
                 continue
-            items.append((key, value))
-        ret = dict_class(items)
+            ret[key] = value
         return ret
 
     def dump(self, obj, *, many=None):
@@ -1030,6 +1030,7 @@ class BaseSchema(base.SchemaABC):
                 )
                 raise TypeError(msg) from exc
 
+    @lru_cache(maxsize=8)
     def _has_processors(self, tag):
         return self._hooks[(tag, True)] or self._hooks[(tag, False)]
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import re
 import typing
-from collections.abc import Mapping, Iterable
+from collections.abc import Mapping
 from email.utils import format_datetime, parsedate_to_datetime
 from pprint import pprint as py_pprint
 
@@ -46,9 +46,7 @@ def is_generator(obj):
 
 def is_iterable_but_not_string(obj):
     """Return True if ``obj`` is an iterable object that isn't a string."""
-    return (isinstance(obj, Iterable) and not hasattr(obj, "strip")) or is_generator(
-        obj
-    )
+    return (hasattr(obj, "__iter__") and not hasattr(obj, "strip")) or is_generator(obj)
 
 
 def is_collection(obj):

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -346,10 +346,10 @@ def get_func_args(func: typing.Callable) -> typing.List[str]:
     .. versionchanged:: 3.0.0a1
         Do not return bound arguments, eg. ``self``.
     """
-    if isinstance(func, functools.partial):
-        return _signature(func.func)
     if inspect.isfunction(func) or inspect.ismethod(func):
         return _signature(func)
+    if isinstance(func, functools.partial):
+        return _signature(func.func)
     # Callable class
     return _signature(func.__call__)
 


### PR DESCRIPTION
Just a few free micro-optimizations. Results in ~3% improvement in dump speed, using `tox -e benchmark`.

* Memoize _has_processors
* Don't make intermediate list
* Duck-type iterables