### PR TITLE
Remove unused _pending attribute

### DIFF
--- a/src/marshmallow/error_store.py
+++ b/src/marshmallow/error_store.py
@@ -13,8 +13,6 @@ class ErrorStore:
     def __init__(self):
         #: Dictionary of errors stored during serialization
         self.errors = {}
-        #: True while (de)serializing a collection
-        self._pending = False
 
     def store_error(self, messages, field_name=SCHEMA, index=None):
         # field error  -> store/merge error messages under field name key


### PR DESCRIPTION
ErrorStore will likely be useless after #1304, but might as well clean this up.