### PR TITLE
Make error handling more consistent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Features:
   (:issue:`1234`, :pr:`1287`).
 - *Backwards-incompatible*: ``List`` does not wrap single values in a list on
   serialization (:pr:`1307`).
+- Use `raise from` more uniformly to improve stack traces (:pr:`1313`).
 
 Deprecations/Removals:
 

--- a/src/marshmallow/class_registry.py
+++ b/src/marshmallow/class_registry.py
@@ -66,11 +66,11 @@ def get_class(classname, all=False):
     """
     try:
         classes = _registry[classname]
-    except KeyError as exc:
+    except KeyError as error:
         raise RegistryError(
             "Class with name {!r} was not found. You may need "
             "to import the class.".format(classname)
-        ) from exc
+        ) from error
     if len(classes) > 1:
         if all:
             return _registry[classname]

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -436,11 +436,11 @@ class BaseSchema(base.SchemaABC):
         """
         try:
             value = getter_func(data)
-        except ValidationError as err:
-            error_store.store_error(err.messages, field_name, index=index)
+        except ValidationError as error:
+            error_store.store_error(error.messages, field_name, index=index)
             # When a Nested field fails validation, the marshalled data is stored
             # on the ValidationError's valid_data attribute
-            return err.valid_data or missing
+            return error.valid_data or missing
         return value
 
     def _serialize(


### PR DESCRIPTION
* Use `error` to name handled exceptions
* Use `raise from` more uniformly