### PR TITLE
Validate missing field values when missing option is set

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -302,12 +302,16 @@ class Field(FieldABC):
         # Validate required fields, deserialize, then validate
         # deserialized value
         self._validate_missing(value)
+
         if value is missing_:
-            _miss = self.missing
-            return _miss() if callable(_miss) else _miss
-        if getattr(self, "allow_none", False) is True and value is None:
+            if self.missing is missing_:
+                return missing_
+            output = self.missing() if callable(self.missing) else self.missing
+        elif value is None and getattr(self, "allow_none", False):
             return None
-        output = self._deserialize(value, attr, data, **kwargs)
+        else:
+            output = self._deserialize(value, attr, data, **kwargs)
+
         self._validate(output)
         return output
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1321,6 +1321,23 @@ class TestSchemaDeserialization:
         assert result["name"] == "Mick"
         assert result["birthdate"] == bdate
 
+    def test_deserialize_with_static_missing_param_is_validated(self):
+        def validate_name(name):
+            if not name.startswith("A"):
+                raise ValidationError('Name should start with the letter "A"')
+
+        class WrongUserSerializer(Schema):
+            name = fields.String(missing="Unknown User", validate=validate_name)
+
+        with pytest.raises(ValidationError):
+            WrongUserSerializer().load({})
+
+        class GoodUserSerializer(Schema):
+            name = fields.String(missing="An Unknown User", validate=validate_name)
+
+        res = GoodUserSerializer().load({})
+        assert res["name"] == "An Unknown User"
+
     def test_deserialize_with_missing_param_none(self):
         class AliasingUserSerializer(Schema):
             name = fields.String()


### PR DESCRIPTION
When the `missing` `Field` option was set, it's value (or it's return value in
case it was a callable) was not validated. This made mistakes possible when the
implementation of the callable returned a wrong value or a wrong value for the
`missing` option was defined.

This is useful when using an external or third-party package function for the
missing option, and using a validator at the same time.  
For example, using a function for the missing value which returns an
environment variable makes it possible to validate environment variables.

As the readability of this function is already difficult, it has been optimized 
for speed with the nested `if` instead of more `elif`-s.
