### PR TITLE
Add `require_tld` parameter to `Url` field doc

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -133,3 +133,4 @@ Contributors (chronological)
 - Stephen J. Fuhry `@fuhrysteve <https://github.com/fuhrysteve>`_
 - `@dursk <https://github.com/dursk>`_
 - Ezra MacDonald `@kdop <https://github.com/macdonaldezra>`_
+- Stanislav Rogovskiy `@atmo <https://github.com/atmo>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1477,7 +1477,8 @@ class Url(String):
     :param default: Default value for the field if the attribute is not set.
     :param str attribute: The name of the attribute to get the value from. If
         `None`, assumes the attribute has the same name as the field.
-    :param bool relative: Allow relative URLs.
+    :param bool relative: Whether to allow relative URLs.
+    :param bool require_tld: Whether to reject non-FQDN hostnames.
     :param kwargs: The same keyword arguments that :class:`String` receives.
     """
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -37,7 +37,7 @@ class URL(Validator):
         Can be interpolated with `{input}`.
     :param set schemes: Valid schemes. By default, ``http``, ``https``,
         ``ftp``, and ``ftps`` are allowed.
-    :param bool require_tld: Whether to reject non-FQDN hostnames
+    :param bool require_tld: Whether to reject non-FQDN hostnames.
     """
 
     class RegexMemoizer:


### PR DESCRIPTION
Docstring for `Url` field is missing description for its `require_tld` parameter.