### PR TITLE
ported fix made by lafrech to correctly handle type errors in 2.x

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -91,3 +91,4 @@ Contributors (chronological)
 - `@miniscruff <https://github.com/miniscruff>`_
 - Kim Gustyr `@khvn26 <https://github.com/khvn26>`_
 - Bryce Drennan `@brycedrennan <https://github.com/brycedrennan>`_
+- Cristi Scoarta `@cristi23 <https://github.com/cristi23>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -118,7 +118,7 @@ class Field(FieldABC):
     #: :exc:`marshmallow.ValidationError`.
     default_error_messages = {
         'required': 'Missing data for required field.',
-        'type': 'Invalid input type.',  # used by Unmarshaller
+        'type': 'Invalid type.',  # used by Unmarshaller
         'null': 'Field may not be null.',
         'validator_failed': 'Invalid value.'
     }
@@ -329,9 +329,11 @@ class Field(FieldABC):
             ret = ret.parent
         return ret if isinstance(ret, SchemaABC) else None
 
+
 class Raw(Field):
     """Field that applies no formatting or validation."""
     pass
+
 
 class Nested(Field):
     """Allows you to nest a :class:`Schema <marshmallow.Schema>`
@@ -373,11 +375,6 @@ class Nested(Field):
     :param bool many: Whether the field is a collection of objects.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
-
-    default_error_messages = {
-        'type': 'Invalid type.',
-    }
-
     def __init__(self, nested, default=missing_, exclude=tuple(), only=None, **kwargs):
         self.nested = nested
         self.only = only
@@ -811,6 +808,7 @@ class Boolean(Field):
             except TypeError:
                 pass
         self.fail('invalid')
+
 
 class FormattedString(Field):
     """Interpolate other values from the object into this field. The syntax for

--- a/src/marshmallow/marshalling.py
+++ b/src/marshmallow/marshalling.py
@@ -248,7 +248,6 @@ class Unmarshaller(ErrorStore):
                     )
             return ret
 
-        partial_is_collection = is_collection(partial)
         ret = dict_class()
 
         if not isinstance(data, collections.Mapping):
@@ -259,6 +258,7 @@ class Unmarshaller(ErrorStore):
             errors.setdefault(SCHEMA, []).append(msg)
             return None
         else:
+            partial_is_collection = is_collection(partial)
             for attr_name, field_obj in iteritems(fields_dict):
                 if field_obj.dump_only:
                     continue

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -263,8 +263,7 @@ class TestUnmarshaller:
 
     def test_deserialize_wrong_type_root_data(self, unmarshal):
         data = ''
-        fields_dict = {
-        }
+        fields_dict = {}
         result = unmarshal.deserialize(data, fields_dict)
         assert result is None
         assert '_schema' in unmarshal.errors

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from marshmallow import fields
+from marshmallow import fields, Schema
 from marshmallow.marshalling import Marshaller, Unmarshaller, missing
 from marshmallow.exceptions import ValidationError
 
@@ -260,3 +260,27 @@ class TestUnmarshaller:
         assert 'years' not in result
 
         assert 'always_invalid' not in unmarshal.errors
+
+    def test_deserialize_wrong_type_root_data(self, unmarshal):
+        data = ''
+        fields_dict = {
+        }
+        result = unmarshal.deserialize(data, fields_dict)
+        assert result is None
+        assert '_schema' in unmarshal.errors
+
+    def test_deserialize_wrong_type_nested_data(self, unmarshal):
+        class TestSchema(Schema):
+            pass
+
+        data = {
+            'foo': 'not what we need'
+        }
+        fields_dict = {
+            'foo': fields.Nested(TestSchema, required=True)
+        }
+        with pytest.raises(ValidationError) as excinfo:
+            result = unmarshal.deserialize(data, fields_dict)
+
+            assert result is None
+            assert excinfo.value.messages == {'foo': {'_schema': ['Invalid input type.']}}


### PR DESCRIPTION
This should fix https://github.com/marshmallow-code/marshmallow/issues/1303

The solution was initially designed for addressing a different (but similar) issue on version 3.x

The code is therefore very similar to https://github.com/marshmallow-code/marshmallow/pull/857

The tests are all passing.