### PR TITLE
Pre-compute dump-only and load-only fields; clean up signatures

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -534,15 +534,7 @@ class BaseSchema(base.SchemaABC):
         return self.opts.render_module.dumps(serialized, *args, **kwargs)
 
     def _deserialize(
-        self,
-        data,
-        *,
-        error_store,
-        many=False,
-        partial=False,
-        unknown=RAISE,
-        index_errors=True,
-        index=None
+        self, data, *, error_store, many=False, partial=False, unknown=RAISE, index=None
     ):
         """Deserialize ``data``.
 
@@ -555,12 +547,11 @@ class BaseSchema(base.SchemaABC):
             will be ignored. Use dot delimiters to specify nested fields.
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
-        :param bool index_errors: Whether to store the index of invalid items in
-            ``self.errors`` when ``many=True``.
         :param int index: Index of the item being serialized (for storing errors) if
             serializing a collection, otherwise `None`.
         :return: A dictionary of the deserialized data.
         """
+        index_errors = self.opts.index_errors
         index = index if index_errors else None
         if many:
             if not is_collection(data):
@@ -575,7 +566,6 @@ class BaseSchema(base.SchemaABC):
                         partial=partial,
                         unknown=unknown,
                         index=idx,
-                        index_errors=index_errors,
                     )
                     for idx, d in enumerate(data)
                 ]
@@ -775,7 +765,6 @@ class BaseSchema(base.SchemaABC):
                 many=many,
                 partial=partial,
                 unknown=unknown,
-                index_errors=self.opts.index_errors,
             )
             # Run field-level validation
             self._invoke_field_validators(

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -458,23 +458,21 @@ class BaseSchema(base.SchemaABC):
             return error.valid_data or missing
         return value
 
-    def _serialize(self, obj, *, many=False, accessor=None):
+    def _serialize(self, obj, *, many=False):
         """Serialize ``obj``.
 
         :param obj: The object(s) to serialize.
         :param bool many: `True` if ``data`` should be serialized as a collection.
-        :param callable accessor: Function to use for getting values from ``obj``.
-        :param type dict_class: Dictionary class used to construct the output.
         :return: A dictionary of the serialized data
 
         .. versionchanged:: 1.0.0
             Renamed from ``marshal``.
         """
         if many and obj is not None:
-            return [self._serialize(d, many=False, accessor=accessor) for d in obj]
+            return [self._serialize(d, many=False) for d in obj]
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
-            value = field_obj.serialize(attr_name, obj, accessor=accessor)
+            value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
             if value is missing:
                 continue
             key = field_obj.data_key or attr_name
@@ -508,7 +506,7 @@ class BaseSchema(base.SchemaABC):
         else:
             processed_obj = obj
 
-        result = self._serialize(processed_obj, many=many, accessor=self.get_attribute)
+        result = self._serialize(processed_obj, many=many)
 
         if self._has_processors(POST_DUMP):
             result = self._invoke_dump_processors(

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -380,16 +380,15 @@ class BaseSchema(base.SchemaABC):
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
         self.fields = self._init_fields()
-        self.dump_fields = {
-            field_name: field_obj
-            for field_name, field_obj in self.fields.items()
-            if not field_obj.load_only
-        }
-        self.load_fields = {
-            field_name: field_obj
-            for field_name, field_obj in self.fields.items()
-            if not field_obj.dump_only
-        }
+        self.dump_fields, self.load_fields = self.dict_class(), self.dict_class()
+        for field_name, field_obj in self.fields.items():
+            if field_obj.load_only:
+                self.load_fields[field_name] = field_obj
+            elif field_obj.dump_only:
+                self.dump_fields[field_name] = field_obj
+            else:
+                self.load_fields[field_name] = field_obj
+                self.dump_fields[field_name] = field_obj
         messages = {}
         messages.update(self._default_error_messages)
         for cls in reversed(self.__class__.__mro__):

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -380,6 +380,16 @@ class BaseSchema(base.SchemaABC):
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
         self.fields = self._init_fields()
+        self.dump_fields = {
+            field_name: field_obj
+            for field_name, field_obj in self.fields.items()
+            if not field_obj.load_only
+        }
+        self.load_fields = {
+            field_name: field_obj
+            for field_name, field_obj in self.fields.items()
+            if not field_obj.dump_only
+        }
         messages = {}
         messages.update(self._default_error_messages)
         for cls in reversed(self.__class__.__mro__):
@@ -449,34 +459,22 @@ class BaseSchema(base.SchemaABC):
             return error.valid_data or missing
         return value
 
-    def _serialize(
-        self, obj, fields_dict, *, many=False, accessor=None, dict_class=dict
-    ):
-        """Takes raw data (a dict, list, or other object) and a dict of
-        fields to output and serializes the data based on those fields.
+    def _serialize(self, obj, *, many=False, accessor=None):
+        """Serialize ``obj``.
 
-        :param obj: The actual object(s) from which the fields are taken from
-        :param dict fields_dict: Mapping of field names to :class:`Field` objects.
-        :param bool many: Set to `True` if ``data`` should be serialized as
-            a collection.
+        :param obj: The object(s) to serialize.
+        :param bool many: `True` if ``data`` should be serialized as a collection.
         :param callable accessor: Function to use for getting values from ``obj``.
         :param type dict_class: Dictionary class used to construct the output.
-        :return: A dictionary of the marshalled data
+        :return: A dictionary of the serialized data
 
         .. versionchanged:: 1.0.0
             Renamed from ``marshal``.
         """
         if many and obj is not None:
-            return [
-                self._serialize(
-                    d, fields_dict, many=False, dict_class=dict_class, accessor=accessor
-                )
-                for d in obj
-            ]
+            return [self._serialize(d, many=False, accessor=accessor) for d in obj]
         ret = self.dict_class()
-        for attr_name, field_obj in fields_dict.items():
-            if getattr(field_obj, "load_only", False):
-                continue
+        for attr_name, field_obj in self.dump_fields.items():
             value = field_obj.serialize(attr_name, obj, accessor=accessor)
             if value is missing:
                 continue
@@ -511,13 +509,7 @@ class BaseSchema(base.SchemaABC):
         else:
             processed_obj = obj
 
-        result = self._serialize(
-            processed_obj,
-            fields_dict=self.fields,
-            many=many,
-            accessor=self.get_attribute,
-            dict_class=self.dict_class,
-        )
+        result = self._serialize(processed_obj, many=many, accessor=self.get_attribute)
 
         if self._has_processors(POST_DUMP):
             result = self._invoke_dump_processors(
@@ -547,30 +539,25 @@ class BaseSchema(base.SchemaABC):
     def _deserialize(
         self,
         data,
-        fields_dict,
         *,
         error_store,
         many=False,
         partial=False,
         unknown=RAISE,
-        dict_class=dict,
         index_errors=True,
         index=None
     ):
-        """Deserialize ``data`` based on the schema defined by ``fields_dict``.
+        """Deserialize ``data``.
 
         :param dict data: The data to deserialize.
-        :param dict fields_dict: Mapping of field names to :class:`Field` objects.
         :param ErrorStore error_store: Structure to store errors.
-        :param bool many: Set to `True` if ``data`` should be deserialized as
-            a collection.
+        :param bool many: `True` if ``data`` should be deserialized as a collection.
         :param bool|tuple partial: Whether to ignore missing fields and not require
             any fields declared. Propagates down to ``Nested`` fields as well. If
             its value is an iterable, only missing fields listed in that iterable
             will be ignored. Use dot delimiters to specify nested fields.
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
-        :param type dict_class: Dictionary class used to construct the output.
         :param bool index_errors: Whether to store the index of invalid items in
             ``self.errors`` when ``many=True``.
         :param int index: Index of the item being serialized (for storing errors) if
@@ -586,30 +573,24 @@ class BaseSchema(base.SchemaABC):
                 ret = [
                     self._deserialize(
                         d,
-                        fields_dict,
                         error_store=error_store,
                         many=False,
                         partial=partial,
                         unknown=unknown,
-                        dict_class=dict_class,
                         index=idx,
                         index_errors=index_errors,
                     )
                     for idx, d in enumerate(data)
                 ]
             return ret
-        ret = dict_class()
+        ret = self.dict_class()
         # Check data is a dict
         if not isinstance(data, Mapping):
             error_store.store_error([self.error_messages["type"]], index=index)
         else:
             partial_is_collection = is_collection(partial)
-            for attr_name, field_obj in fields_dict.items():
-                if field_obj.dump_only:
-                    continue
-                field_name = attr_name
-                if field_obj.data_key:
-                    field_name = field_obj.data_key
+            for attr_name, field_obj in self.load_fields.items():
+                field_name = field_obj.data_key or attr_name
                 raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
@@ -639,13 +620,12 @@ class BaseSchema(base.SchemaABC):
                     index=index,
                 )
                 if value is not missing:
-                    key = fields_dict[attr_name].attribute or attr_name
+                    key = field_obj.attribute or attr_name
                     set_value(ret, key, value)
             if unknown != EXCLUDE:
                 fields = {
                     field_obj.data_key or field_name
-                    for field_name, field_obj in fields_dict.items()
-                    if not field_obj.dump_only
+                    for field_name, field_obj in self.load_fields.items()
                 }
                 for key in set(data) - fields:
                     value = data[key]
@@ -716,7 +696,6 @@ class BaseSchema(base.SchemaABC):
         output,
         *,
         original_data,
-        fields_dict,
         error_store,
         many,
         partial,
@@ -795,12 +774,10 @@ class BaseSchema(base.SchemaABC):
             # Deserialize data
             result = self._deserialize(
                 processed_data,
-                fields_dict=self.fields,
                 error_store=error_store,
                 many=many,
                 partial=partial,
                 unknown=unknown,
-                dict_class=self.dict_class,
                 index_errors=self.opts.index_errors,
             )
             # Run field-level validation
@@ -1092,7 +1069,6 @@ class BaseSchema(base.SchemaABC):
                         validator,
                         item,
                         original_data=orig,
-                        fields_dict=self.fields,
                         error_store=error_store,
                         many=many,
                         partial=partial,
@@ -1104,7 +1080,6 @@ class BaseSchema(base.SchemaABC):
                     validator,
                     data,
                     original_data=original_data,
-                    fields_dict=self.fields,
                     error_store=error_store,
                     many=many,
                     pass_original=pass_original,


### PR DESCRIPTION
This results in a very small perf gain and removes
unnecessary parameters from _serialize, _deserialize, and _run_validator.