### PR TITLE
Deprecate Field.fail in favor of Field.make_error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 - Optimize ``List(Nested(...))`` (:issue:`779`).
 - Minor performance improvements and cleanup (:pr:`1328`).
 
+Deprecations/Removals:
+
+- ``Field.fail`` is deprecated. Use ``Field.make_error`` instead.
+
 Support:
 
 - Various docs improvements (:pr:`1329`).

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -997,6 +997,40 @@ In marshmallow 2, it was possible to have multiple fields with the same ``attrib
     # No error
 
 
+``Field.fail`` is deprecated in favor of ``Field.make_error``
+*************************************************************
+
+`Field.fail <marshmallow.fields.Field.fail>` is deprecated. 
+Use `Field.make_error <marshmallow.fields.Field.fail>`. This allows you to
+re-raise exceptions using ``raise ... from ...``.
+
+.. code-block:: python
+
+    from marshmallow import fields, ValidationError
+    from packaging import version
+
+    # 2.x
+    class Version(fields.Field):
+        default_error_messages = {"invalid": "Not a valid version."}
+
+        def _deserialize(self, value, *args, **kwargs):
+            try:
+                return version.Version(value)
+            except version.InvalidVersion:
+                self.fail("invalid")
+
+
+    # 3.x
+    class Version(fields.Field):
+        default_error_messages = {"invalid": "Not a valid version."}
+
+        def _deserialize(self, value, *args, **kwargs):
+            try:
+                return version.Version(value)
+            except version.InvalidVersion as error:
+                raise self.make_error("invalid") from error
+
+
 ``python-dateutil`` recommended dependency is removed
 *****************************************************
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -7,6 +7,7 @@ import numbers
 import uuid
 import decimal
 import math
+import warnings
 from collections.abc import Mapping as _Mapping
 
 from marshmallow import validate, utils, class_registry
@@ -236,7 +237,7 @@ class Field(FieldABC):
             try:
                 r = validator(value)
                 if not isinstance(validator, Validator) and r is False:
-                    self.fail("validator_failed")
+                    raise self.make_error("validator_failed")
             except ValidationError as err:
                 kwargs.update(err.kwargs)
                 if isinstance(err.messages, dict):
@@ -247,6 +248,9 @@ class Field(FieldABC):
             raise ValidationError(errors, **kwargs)
 
     def make_error(self, key: str, **kwargs) -> ValidationError:
+        """Helper method to make a `ValidationError` with an error message
+        from ``self.error_messages``.
+        """
         try:
             msg = self.error_messages[key]
         except KeyError as error:
@@ -257,10 +261,19 @@ class Field(FieldABC):
             msg = msg.format(**kwargs)
         return ValidationError(msg)
 
-    # Hat tip to django-rest-framework.
     def fail(self, key: str, **kwargs):
-        """A helper method that simply raises a `ValidationError`.
+        """Helper method that raises a `ValidationError` with an error message
+        from ``self.error_messages``.
+
+        .. deprecated:: 3.0.0
+            Use `make_error <marshmallow.fields.Field.make_error>` instead.
         """
+        warnings.warn(
+            '`Field.fail` is deprecated. Use `raise self.make_error("{}", ...)` instead.'.format(
+                key
+            ),
+            DeprecationWarning,
+        )
         raise self.make_error(key=key, **kwargs)
 
     def _validate_missing(self, value):
@@ -269,10 +282,10 @@ class Field(FieldABC):
         """
         if value is missing_:
             if hasattr(self, "required") and self.required:
-                self.fail("required")
+                raise self.make_error("required")
         if value is None:
             if hasattr(self, "allow_none") and self.allow_none is not True:
-                self.fail("null")
+                raise self.make_error("null")
 
     def serialize(self, attr, obj, accessor=None, **kwargs):
         """Pulls the value for the given key from the object, applies the
@@ -502,7 +515,7 @@ class Nested(Field):
     def _test_collection(self, value, many=False):
         many = self.many or many
         if many and not utils.is_collection(value):
-            self.fail("type", input=value, type=value.__class__.__name__)
+            raise self.make_error("type", input=value, type=value.__class__.__name__)
 
     def _load(self, value, data, partial=None, many=False):
         try:
@@ -632,7 +645,7 @@ class List(Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         if not utils.is_collection(value):
-            self.fail("invalid")
+            raise self.make_error("invalid")
         # Optimize loading a list of Nested objects by calling load(many=True)
         if isinstance(self.inner, Nested) and not self.inner.many:
             return self.inner.deserialize(value, many=True, **kwargs)
@@ -714,7 +727,7 @@ class Tuple(Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         if not utils.is_collection(value):
-            self.fail("invalid")
+            raise self.make_error("invalid")
 
         self.validate_length(value)
 
@@ -752,7 +765,7 @@ class String(Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         if not isinstance(value, (str, bytes)):
-            self.fail("invalid")
+            raise self.make_error("invalid")
         try:
             return utils.ensure_text_type(value)
         except UnicodeDecodeError as error:
@@ -813,7 +826,7 @@ class Number(Field):
             return None
         # (value is True or value is False) is ~5x faster than isinstance(value, bool)
         if value is True or value is False:
-            self.fail("invalid", input=value)
+            raise self.make_error("invalid", input=value)
         try:
             return self._format_num(value)
         except (TypeError, ValueError) as error:
@@ -855,7 +868,7 @@ class Integer(Number):
                 value, numbers.Integral
             ):
                 return super()._validated(value)
-            self.fail("invalid", input=value)
+            raise self.make_error("invalid", input=value)
         return super()._validated(value)
 
 
@@ -881,7 +894,7 @@ class Float(Number):
         num = super()._validated(value)
         if self.allow_nan is False:
             if math.isnan(num) or num == float("inf") or num == float("-inf"):
-                self.fail("special")
+                raise self.make_error("special")
         return num
 
 
@@ -1045,7 +1058,7 @@ class Boolean(Field):
                     return False
             except TypeError as error:
                 raise self.make_error("invalid", input=value) from error
-        self.fail("invalid", input=value)
+        raise self.make_error("invalid", input=value)
 
 
 class DateTime(Field):
@@ -1114,7 +1127,7 @@ class DateTime(Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         if not value:  # Falsy values, e.g. '', None, [] are not valid
-            self.fail("invalid", input=value, obj_type=self.OBJ_TYPE)
+            raise self.make_error("invalid", input=value, obj_type=self.OBJ_TYPE)
         data_format = self.format or self.DEFAULT_FORMAT
         func = self.DESERIALIZATION_FUNCS.get(data_format)
         if func:
@@ -1160,7 +1173,7 @@ class NaiveDateTime(DateTime):
         ret = super()._deserialize(value, attr, data, **kwargs)
         if is_aware(ret):
             if self.timezone is None:
-                self.fail(
+                raise self.make_error(
                     "invalid_awareness",
                     awareness=self.AWARENESS,
                     obj_type=self.OBJ_TYPE,
@@ -1191,7 +1204,7 @@ class AwareDateTime(DateTime):
         ret = super()._deserialize(value, attr, data, **kwargs)
         if not is_aware(ret):
             if self.default_timezone is None:
-                self.fail(
+                raise self.make_error(
                     "invalid_awareness",
                     awareness=self.AWARENESS,
                     obj_type=self.OBJ_TYPE,
@@ -1222,7 +1235,7 @@ class Time(Field):
     def _deserialize(self, value, attr, data, **kwargs):
         """Deserialize an ISO8601-formatted time to a :class:`datetime.time` object."""
         if not value:  # falsy values are invalid
-            self.fail("invalid")
+            raise self.make_error("invalid")
         try:
             return utils.from_iso_time(value)
         except (AttributeError, TypeError, ValueError) as error:
@@ -1411,7 +1424,7 @@ class Mapping(Field):
 
     def _deserialize(self, value, attr, data, **kwargs):
         if not isinstance(value, _Mapping):
-            self.fail("invalid")
+            raise self.make_error("invalid")
         if not self.value_field and not self.key_field:
             return value
 


### PR DESCRIPTION
As pointed in https://github.com/marshmallow-code/marshmallow/pull/1301#issuecomment-511235599 , `fail` is less flexible than `make_error` and is no longer necessary.