### PR TITLE
Fix invalid type handling when nested schema uses `@validates`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+2.20.1 (unreleased)
+*******************
+
+Bug fixes:
+
+- Fix bug that raised ``TypeError`` when invalid data type is
+  passed to a nested schema with ``@validates`` (:issue:`1342`).
+
 2.20.0 (2019-08-10)
 *******************
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -877,7 +877,7 @@ class BaseSchema(base.SchemaABC):
                 for idx, item in enumerate(data):
                     try:
                         value = item[field_obj.attribute or field_name]
-                    except KeyError:
+                    except (KeyError, TypeError):
                         pass
                     else:
                         validated_value = unmarshal.call_and_store(
@@ -892,7 +892,7 @@ class BaseSchema(base.SchemaABC):
             else:
                 try:
                     value = data[field_obj.attribute or field_name]
-                except KeyError:
+                except (KeyError, TypeError):
                     pass
                 else:
                     validated_value = unmarshal.call_and_store(

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, validates
 from marshmallow.marshalling import Marshaller, Unmarshaller, missing
 from marshmallow.exceptions import ValidationError
 
@@ -271,6 +271,27 @@ class TestUnmarshaller:
     def test_deserialize_wrong_type_nested_data(self, unmarshal):
         class TestSchema(Schema):
             pass
+
+        data = {
+            'foo': 'not what we need'
+        }
+        fields_dict = {
+            'foo': fields.Nested(TestSchema, required=True)
+        }
+        with pytest.raises(ValidationError) as excinfo:
+            result = unmarshal.deserialize(data, fields_dict)
+
+            assert result is None
+            assert excinfo.value.messages == {'foo': {'_schema': ['Invalid input type.']}}
+
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/1342
+    def test_deserialize_wrong_nested_type_with_validates_method(self, unmarshal):
+        class TestSchema(Schema):
+            value = fields.String()
+
+            @validates('value')
+            def validate_value(self, value):
+                pass
 
         data = {
             'foo': 'not what we need'


### PR DESCRIPTION
Close #1342

NOTE: This error handling is unnecessary in 3.x because `data` will always be a `dict` when an invalid type is passed as the input.