### PR TITLE
Improving pre- and post-processors documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -136,3 +136,4 @@ Contributors (chronological)
 - Stanislav Rogovskiy `@atmo <https://github.com/atmo>`_
 - Cristi Scoarta `@cristi23 <https://github.com/cristi23>`_
 - Anthony Sottile `@asottile <https://github.com/asottile>`_
+- `@phrfpeixoto <https://github.com/phrfpeixoto>`_

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -28,18 +28,14 @@ Data pre-processing and post-processing methods can be registered using the `pre
     result = schema.load({"name": "Steve", "slug": "Steve Loria "})
     result["slug"]  # => 'steve-loria'
 
-
 Passing "many"
 ++++++++++++++
 
-By default, despite of the ``many`` parameter value, pre- and post-processing methods receive one object/datum at a time, transparently handling the ``many`` parameter passed to the ``Schema``'s :func:`~marshmallow.Schema.dump`/:func:`~marshmallow.Schema.load` method at runtime.
+By default, pre- and post-processing methods receive one object/datum at a time, transparently handling the ``many`` parameter passed to the ``Schema``'s :func:`~marshmallow.Schema.dump`/:func:`~marshmallow.Schema.load` method at runtime.
 
 In cases where your pre- and post-processing methods needs to handle the input collection when processing multiple objects, add ``pass_many=True`` to the method decorators.
 
-Your method will then receive the input data (which may be a single datum or a collection, depending ont the dump/load call) along with a relevant ``many`` value
-
-.. versionchanged:: 3.0.0
-    ``many`` is always passed as a keyword arguments to the pre- and post-processing methods.
+Your method will then receive the input data (which may be a single datum or a collection, depending on the dump/load call).
 
 Example: Enveloping
 +++++++++++++++++++

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -32,10 +32,14 @@ Data pre-processing and post-processing methods can be registered using the `pre
 Passing "many"
 ++++++++++++++
 
-By default, pre- and post-processing methods receive one object/datum at a time, transparently handling the ``many`` parameter passed to the schema at runtime.
+By default, despite of the ``many`` parameter value, pre- and post-processing methods receive one object/datum at a time, transparently handling the ``many`` parameter passed to the ``Schema``'s :func:`~marshmallow.Schema.dump`/:func:`~marshmallow.Schema.load` method at runtime.
 
-In cases where your pre- and post-processing methods need to receive the input collection  when ``many=True``, add ``pass_many=True`` to the method decorators. The method will receive the input data (which may be a single datum or a collection) and the boolean value of ``many``.
+In cases where your pre- and post-processing methods needs to handle the input collection when processing multiple objects, add ``pass_many=True`` to the method decorators.
 
+Your method will then receive the input data (which may be a single datum or a collection, depending ont the dump/load call) along with a relevant ``many`` value
+
+.. versionchanged:: 3.0.0
+    ``many`` is always passed as a keyword arguments to the pre- and post-processing methods.
 
 Example: Enveloping
 +++++++++++++++++++

--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -1,6 +1,8 @@
 """Decorators for registering schema pre-processing and post-processing methods.
 These should be imported from the top-level `marshmallow` module.
 
+.. _decorator_example:
+
 Example: ::
 
     from marshmallow import (
@@ -14,12 +16,12 @@ Example: ::
         age = fields.Integer(required=True)
 
         @post_load
-        def lowerstrip_email(self, item, **kwargs):
+        def lowerstrip_email(self, item, partial, many, **kwargs):
             item['email'] = item['email'].lower().strip()
             return item
 
         @pre_load(pass_many=True)
-        def remove_envelope(self, data, many, **kwargs):
+        def remove_envelope(self, data, partial, many, **kwargs):
             namespace = 'results' if many else 'result'
             return data[namespace]
 
@@ -29,7 +31,7 @@ Example: ::
             return {namespace: data}
 
         @validates_schema
-        def validate_email(self, data, **kwargs):
+        def validate_email(self, data, partial, many, **kwargs):
             if len(data['email']) < 3:
                 raise ValidationError('Email must be more than 3 characters', 'email')
 

--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -1,7 +1,16 @@
 """Decorators for registering schema pre-processing and post-processing methods.
 These should be imported from the top-level `marshmallow` module.
 
-.. _decorator_example:
+Methods decorated with
+`pre_load <marshmallow.decorators.pre_load>`, `post_load <marshmallow.decorators.post_load>`,
+`pre_dump <marshmallow.decorators.pre_dump>`, `post_dump <marshmallow.decorators.post_dump>`,
+and `validates_schema <marshmallow.decorators.validates_schema>` receive
+``many`` as a keyword argument. In addition, `pre_load <marshmallow.decorators.pre_load>`,
+ `post_load <marshmallow.decorators.post_load>`,
+and `validates_schema <marshmallow.decorators.validates_schema>` receive
+``partial``. If you don't need these arguments, add ``**kwargs`` to your method
+signature.
+
 
 Example: ::
 
@@ -16,12 +25,12 @@ Example: ::
         age = fields.Integer(required=True)
 
         @post_load
-        def lowerstrip_email(self, item, partial, many, **kwargs):
+        def lowerstrip_email(self, item, many, **kwargs):
             item['email'] = item['email'].lower().strip()
             return item
 
         @pre_load(pass_many=True)
-        def remove_envelope(self, data, partial, many, **kwargs):
+        def remove_envelope(self, data, many, **kwargs):
             namespace = 'results' if many else 'result'
             return data[namespace]
 
@@ -31,7 +40,7 @@ Example: ::
             return {namespace: data}
 
         @validates_schema
-        def validate_email(self, data, partial, many, **kwargs):
+        def validate_email(self, data, **kwargs):
             if len(data['email']) < 3:
                 raise ValidationError('Email must be more than 3 characters', 'email')
 
@@ -75,8 +84,7 @@ def validates_schema(
 
     By default it receives a single object at a time, transparently handling the ``many``
     argument passed to the `Schema`'s :func:`~marshmallow.Schema.validate` call.
-    If ``pass_many=True``, the raw data (which may be a collection) is passed
-    to the decorated method, along with a relevant ``many`` value.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed.
 
     If ``pass_original=True``, the original data (before unmarshalling) will be passed as
     an additional argument to the method.
@@ -103,12 +111,9 @@ def pre_dump(fn=None, pass_many=False):
     """Register a method to invoke before serializing an object. The method
     receives the object to be serialized and returns the processed object.
 
-    See :ref:`examples <decorator_example>` for the method signature.
-
     By default it receives a single object at a time, transparently handling the ``many``
     argument passed to the `Schema`'s :func:`~marshmallow.Schema.dump` call.
-    If ``pass_many=True``, the raw data (which may be a collection) is passed
-    to the decorated method, along with a relevant ``many`` value.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed.
 
     .. versionchanged:: 3.0.0
         ``many`` is always passed as a keyword arguments to the decorated method.
@@ -120,12 +125,9 @@ def post_dump(fn=None, pass_many=False, pass_original=False):
     """Register a method to invoke after serializing an object. The method
     receives the serialized object and returns the processed object.
 
-    See :ref:`examples <decorator_example>` for the method signature.
-
     By default it receives a single object at a time, transparently handling the ``many``
     argument passed to the `Schema`'s :func:`~marshmallow.Schema.dump` call.
-    If ``pass_many=True``, the raw data (which may be a collection) is passed
-    to the decorated method, along with a relevant ``many`` value.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed.
 
     If ``pass_original=True``, the original data (before serializing) will be passed as
     an additional argument to the method.
@@ -140,12 +142,9 @@ def pre_load(fn=None, pass_many=False):
     """Register a method to invoke before deserializing an object. The method
     receives the data to be deserialized and returns the processed data.
 
-    See :ref:`examples <decorator_example>` for the method signature.
-
     By default it receives a single object at a time, transparently handling the ``many``
     argument passed to the `Schema`'s :func:`~marshmallow.Schema.load` call.
-    If ``pass_many=True``, the raw data (which may be a collection) is passed
-    to the decorated method, along with a relevant ``many`` value.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed.
 
     .. versionchanged:: 3.0.0
         ``partial`` and ``many`` are always passed as keyword arguments to
@@ -162,8 +161,7 @@ def post_load(fn=None, pass_many=False, pass_original=False):
 
     By default it receives a single object at a time, transparently handling the ``many``
     argument passed to the `Schema`'s :func:`~marshmallow.Schema.load` call.
-    If ``pass_many=True``, the raw data (which may be a collection) is passed
-    to the decorated method, along with a relevant ``many`` value.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed.
 
     If ``pass_original=True``, the original data (before deserializing) will be passed as
     an additional argument to the method.
@@ -177,6 +175,7 @@ def post_load(fn=None, pass_many=False, pass_original=False):
 
 def set_hook(fn, key, **kwargs):
     """Mark decorated function as a hook to be picked up later.
+    You should not need to use this method directly.
 
     .. note::
         Currently only works with functions and instance methods. Class and

--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -73,9 +73,10 @@ def validates_schema(
 ):
     """Register a schema-level validator.
 
-    By default, receives a single object at a time, regardless of whether ``many=True``
-    is passed to the `Schema`. If ``pass_many=True``, the raw data (which may be a collection)
-    and the value for ``many`` is passed.
+    By default it receives a single object at a time, transparently handling the ``many``
+    argument passed to the `Schema`'s :func:`~marshmallow.Schema.validate` call.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed
+    to the decorated method, along with a relevant ``many`` value.
 
     If ``pass_original=True``, the original data (before unmarshalling) will be passed as
     an additional argument to the method.
@@ -102,9 +103,12 @@ def pre_dump(fn=None, pass_many=False):
     """Register a method to invoke before serializing an object. The method
     receives the object to be serialized and returns the processed object.
 
-    By default, receives a single object at a time, regardless of whether ``many=True``
-    is passed to the `Schema`. If ``pass_many=True``, the raw data (which may be a collection)
-    and the value for ``many`` is passed.
+    See :ref:`examples <decorator_example>` for the method signature.
+
+    By default it receives a single object at a time, transparently handling the ``many``
+    argument passed to the `Schema`'s :func:`~marshmallow.Schema.dump` call.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed
+    to the decorated method, along with a relevant ``many`` value.
 
     .. versionchanged:: 3.0.0
         ``many`` is always passed as a keyword arguments to the decorated method.
@@ -116,9 +120,12 @@ def post_dump(fn=None, pass_many=False, pass_original=False):
     """Register a method to invoke after serializing an object. The method
     receives the serialized object and returns the processed object.
 
-    By default, receives a single object at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``pass_many=True``, the raw data
-    (which may be a collection) and the value for ``many`` is passed.
+    See :ref:`examples <decorator_example>` for the method signature.
+
+    By default it receives a single object at a time, transparently handling the ``many``
+    argument passed to the `Schema`'s :func:`~marshmallow.Schema.dump` call.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed
+    to the decorated method, along with a relevant ``many`` value.
 
     If ``pass_original=True``, the original data (before serializing) will be passed as
     an additional argument to the method.
@@ -133,9 +140,12 @@ def pre_load(fn=None, pass_many=False):
     """Register a method to invoke before deserializing an object. The method
     receives the data to be deserialized and returns the processed data.
 
-    By default, receives a single datum at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``pass_many=True``, the raw data
-    (which may be a collection) and the value for ``many`` is passed.
+    See :ref:`examples <decorator_example>` for the method signature.
+
+    By default it receives a single object at a time, transparently handling the ``many``
+    argument passed to the `Schema`'s :func:`~marshmallow.Schema.load` call.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed
+    to the decorated method, along with a relevant ``many`` value.
 
     .. versionchanged:: 3.0.0
         ``partial`` and ``many`` are always passed as keyword arguments to
@@ -148,9 +158,12 @@ def post_load(fn=None, pass_many=False, pass_original=False):
     """Register a method to invoke after deserializing an object. The method
     receives the deserialized data and returns the processed data.
 
-    By default, receives a single datum at a time, transparently handling the ``many``
-    argument passed to the Schema. If ``pass_many=True``, the raw data
-    (which may be a collection) and the value for ``many`` is passed.
+    See :ref:`examples <decorator_example>` for the method signature.
+
+    By default it receives a single object at a time, transparently handling the ``many``
+    argument passed to the `Schema`'s :func:`~marshmallow.Schema.load` call.
+    If ``pass_many=True``, the raw data (which may be a collection) is passed
+    to the decorated method, along with a relevant ``many`` value.
 
     If ``pass_original=True``, the original data (before deserializing) will be passed as
     an additional argument to the method.


### PR DESCRIPTION
As discussed on #1368, the documentation for `pass_many` and `many` parameters on the pre- and post-processors is not clear about the behaviour of these parameters.

This PR aims to improve the documentation.

Could not find a 3.0-line branch, so I've branched from the 3.0.1 tag.