### PR TITLE
Don't swallow TypeErrors raised by _bind_to_schema or on_bind_field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Changelog
 Bug fixes:
 
 - Fix incorrect ``super()`` call in ``SchemaMeta.__init__``.
+- Don't swallow ``TypeError`` exceptions raised by ``Field._bind_to_schema``
+  or ``Schema.on_bind_field``.
 
 3.0.1 (2019-08-21)
 ++++++++++++++++++

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -961,13 +961,12 @@ class BaseSchema(base.SchemaABC):
         Also set field load_only and dump_only values if field_name was
         specified in ``class Meta``.
         """
+        if field_name in self.load_only:
+            field_obj.load_only = True
+        if field_name in self.dump_only:
+            field_obj.dump_only = True
         try:
-            if field_name in self.load_only:
-                field_obj.load_only = True
-            if field_name in self.dump_only:
-                field_obj.dump_only = True
             field_obj._bind_to_schema(field_name, self)
-            self.on_bind_field(field_name, field_obj)
         except TypeError as error:
             # field declared as a class, not an instance
             if isinstance(field_obj, type) and issubclass(field_obj, base.FieldABC):
@@ -977,6 +976,9 @@ class BaseSchema(base.SchemaABC):
                     'Did you mean "fields.{}()"?'.format(field_name, field_obj.__name__)
                 )
                 raise TypeError(msg) from error
+            raise error
+        else:
+            self.on_bind_field(field_name, field_obj)
 
     @lru_cache(maxsize=8)
     def _has_processors(self, tag):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -551,6 +551,18 @@ def test_fields_must_be_declared_as_instances(user):
         BadUserSchema().dump(user)
 
 
+# regression test
+def test_bind_field_does_not_swallow_typeerror():
+    class MySchema(Schema):
+        name = fields.Str()
+
+        def on_bind_field(self, field_name, field_obj):
+            raise TypeError("boom")
+
+    with pytest.raises(TypeError, match="boom"):
+        MySchema()
+
+
 @pytest.mark.parametrize("SchemaClass", [UserSchema, UserMetaSchema])
 def test_serializing_generator(SchemaClass):
     users = [User("Foo"), User("Bar")]


### PR DESCRIPTION
Considering this a bug fix because it was not intentional to swallow TypeErrors here. I can't imagine anyone depending on this behavior.

I discovered this while writing a custom field that intentionally raised a `TypeError`, only to find that it would never get raised.