### PR TITLE
Don't swallow TypeErrors raised by _bind_to_schema or on_bind_field

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+2.20.3 (unreleased)
+*******************
+
+Bug fixes:
+
+- Don't swallow ``TypeError`` exceptions raised by ``Field._bind_to_schema`` or ``Schema.on_bind_field``.
+
 2.20.2 (2019-08-20)
 *******************
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -552,6 +552,17 @@ def test_fields_must_be_declared_as_instances(user):
     with pytest.raises(TypeError, match='must be declared as a Field instance'):
         BadUserSchema().dump(user)
 
+# regression test
+def test_bind_field_does_not_swallow_typeerror():
+    class MySchema(Schema):
+        name = fields.Str()
+
+        def on_bind_field(self, field_name, field_obj):
+            raise TypeError("boom")
+
+    with pytest.raises(TypeError, match="boom"):
+        MySchema()
+
 @pytest.mark.parametrize('SchemaClass',
     [UserSchema, UserMetaSchema])
 def test_serializing_generator(SchemaClass):


### PR DESCRIPTION
Same as #1375 except against 2.x-line