### PR TITLE
Add strict parameter to docstring

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -138,3 +138,4 @@ Contributors (chronological)
 - Anthony Sottile `@asottile <https://github.com/asottile>`_
 - Charles-Axel Dein `@charlax <https://github.com/charlax>`_
 - `@phrfpeixoto <https://github.com/phrfpeixoto>`_
+- `@jceresini <https://github.com/jceresini>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -850,6 +850,7 @@ class Number(Field):
 class Integer(Number):
     """An integer field.
 
+    :param bool strict: If True, only integer types are valid, otherwise any value castable to `int` is valid.
     :param kwargs: The same keyword arguments that :class:`Number` receives.
     """
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -801,7 +801,7 @@ class UUID(String):
 class Number(Field):
     """Base class for number fields.
 
-    :param bool as_string: If True, format the serialized value as a string.
+    :param bool as_string: If `True`, format the serialized value as a string.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
@@ -850,7 +850,8 @@ class Number(Field):
 class Integer(Number):
     """An integer field.
 
-    :param bool strict: If True, only integer types are valid, otherwise any value castable to `int` is valid.
+    :param bool strict: If `True`, only integer types are valid.
+        Otherwise, any value castable to `int` is valid.
     :param kwargs: The same keyword arguments that :class:`Number` receives.
     """
 
@@ -877,7 +878,7 @@ class Float(Number):
 
     :param bool allow_nan: If `True`, `NaN`, `Infinity` and `-Infinity` are allowed,
         even though they are illegal according to the JSON specification.
-    :param bool as_string: If True, format the value as a string.
+    :param bool as_string: If `True`, format the value as a string.
     :param kwargs: The same keyword arguments that :class:`Number` receives.
     """
 
@@ -924,11 +925,11 @@ class Decimal(Number):
     :param int places: How many decimal places to quantize the value. If `None`, does
         not quantize the value.
     :param rounding: How to round the value during quantize, for example
-        `decimal.ROUND_UP`. If None, uses the rounding value from
+        `decimal.ROUND_UP`. If `None`, uses the rounding value from
         the current thread's context.
     :param bool allow_nan: If `True`, `NaN`, `Infinity` and `-Infinity` are allowed,
         even though they are illegal according to the JSON specification.
-    :param bool as_string: If True, serialize to a string instead of a Python
+    :param bool as_string: If `True`, serialize to a string instead of a Python
         `decimal.Decimal` type.
     :param kwargs: The same keyword arguments that :class:`Number` receives.
 


### PR DESCRIPTION
Adding `strict` parameter to docstring, reported in #1389.