### PR TITLE
Respect `many` when set on a Nested instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+2.20.4 (unreleased)
++++++++++++++++++++
+
+Bug fixes:
+
+- Respect the ``many`` value on ``Schema`` instances passed to ``Nested`` (:issue:`1160`).
+  Thanks :user:`Kamforka` for reporting.
+
 2.20.3 (2019-09-04)
 +++++++++++++++++++
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -440,17 +440,18 @@ class Nested(Field):
         schema = self.schema
         if nested_obj is None:
             return None
-        if self.many and utils.is_iterable_but_not_string(nested_obj):
+        many = schema.many or self.many
+        if many and utils.is_iterable_but_not_string(nested_obj):
             nested_obj = list(nested_obj)
         if not self.__updated_fields:
-            schema._update_fields(obj=nested_obj, many=self.many)
+            schema._update_fields(obj=nested_obj, many=many)
             self.__updated_fields = True
-        ret, errors = schema.dump(nested_obj, many=self.many,
+        ret, errors = schema.dump(nested_obj, many=many,
                 update_fields=not self.__updated_fields)
         if isinstance(self.only, basestring):  # self.only is a field name
             only_field = self.schema.fields[self.only]
             key = ''.join([self.schema.prefix or '', only_field.dump_to or self.only])
-            if self.many:
+            if many:
                 return utils.pluck(ret, key=key)
             else:
                 return ret[key]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -937,6 +937,34 @@ def test_nested_exclude_and_only_inheritance():
     assert 'fuu' not in child
 
 
+# https://github.com/marshmallow-code/marshmallow/issues/1160
+def test_nested_instance_many():
+    class BookSchema(Schema):
+        id = fields.Int()
+        title = fields.String()
+
+        class Meta:
+            strict = True
+
+
+    class UserSchema(Schema):
+        id = fields.Int()
+        name = fields.String()
+        books = fields.Nested(BookSchema(many=True))
+
+        class Meta:
+            strict = True
+
+    books = [{'id': 1, 'title': 'First book'}, {'id': 2, 'title': 'Second book'}]
+    user = {'id': 1, 'name': 'Peter', 'books': books}
+
+    user_dump = UserSchema().dump(user).data
+    assert user_dump['books'] == books
+
+    user_load = UserSchema().load(user_dump).data
+    assert user_load == user
+
+
 def test_meta_nested_exclude():
     class ChildSchema(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Addresses #1160 

Per the documented behavior, nested instances' `many` argument is respected.

>  When passing a `Schema <marshmallow.Schema>` instance as the first argument,
>  the instance's ``exclude``, ``only``, and ``many`` attributes will be respected.