### PR TITLE
Fix behavior when passing nested instance and `only`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+3.0.5 (unreleased)
+++++++++++++++++++
+
+Bug fixes:
+
+- Fix bug that raised an uncaught error when passing a an schema instance to ``Pluck`` and ``only``.
+- Fix behavior of ``Nested(SchemaInstance(), only=('field_a',))``.
+
+
 3.0.4 (2019-09-11)
 ++++++++++++++++++
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ Changelog
 
 Bug fixes:
 
-- Fix bug that raised an uncaught error when passing a an schema instance to ``Pluck`` and ``only``.
-- Fix behavior of ``Nested(SchemaInstance(), only=('field_a',))``.
+- Fix bug that raised an uncaught error when passing a an schema instance to ``Pluck`` and ``only`` (:pr:`1395`).
+- Fix behavior of ``Nested(SchemaInstance(), only=('field_a',))`` (:pr:`1395`).
 
 
 3.0.4 (2019-09-11)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -473,7 +473,10 @@ class Nested(Field):
                 # Respect only and exclude passed from parent and re-initialize fields
                 set_class = self._schema.set_class
                 if self.only is not None:
-                    original = self._schema.only
+                    if self._schema.only is not None:
+                        original = self._schema.only
+                    else:  # only=None -> all fields
+                        original = self._schema.fields.keys()
                     self._schema.only = set_class(self.only).intersection(original)
                 if self.exclude:
                     original = self._schema.exclude


### PR DESCRIPTION
#1385 introduced a regression with passing an instance to `Nested` along with `only` e.g.

```python
artist = fields.Nested(ArtistSchema(), only=('name', ))
```

```python
artist_name = fields.Pluck(ArtistSchema(), "name")
```
