### PR TITLE
Remove unnecessary inheritance complexity

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+3.2.0 (unreleased)
+++++++++++++++++++
+
+Refactoring:
+
+- Remove unnecessary ``BaseSchema`` superclass (:pr:`1406`).
+
 3.1.1 (2019-09-16)
 ++++++++++++++++++
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -222,7 +222,7 @@ class SchemaOpts:
         self.register = getattr(meta, "register", True)
 
 
-class BaseSchema(base.SchemaABC):
+class Schema(base.SchemaABC, metaclass=SchemaMeta):
     """Base schema class with which to define custom schemas.
 
     Example usage:
@@ -1148,5 +1148,4 @@ class BaseSchema(base.SchemaABC):
         return data
 
 
-class Schema(BaseSchema, metaclass=SchemaMeta):
-    __doc__ = BaseSchema.__doc__
+BaseSchema = Schema  # for backwards compatibility


### PR DESCRIPTION
Whatever peculiarity this was working around no longer exists
(with_metaclass weirdness, perhaps). At this point, BaseSchema
is completely unnecessary.