### PR TITLE
Remove usages of typing.Type to fix compatibility with Python<3.5.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Features:
 
 - Add type annotations to ``marshmallow.schema`` and ``marshmallow.validate`` (:pr:`1407`, :issue:`663`).
 
+Bug fixes:
+
+- Fix compatibility with Python < 3.5.3 (:issue:`1409`). Thanks :user:`lukaszdudek-silvair` for reporting.
+
 Refactoring:
 
 - Remove unnecessary ``BaseSchema`` superclass (:pr:`1406`).

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -471,7 +471,7 @@ class Nested(Field):
 
     def __init__(
         self,
-        nested: typing.Union[SchemaABC, typing.Type[SchemaABC], str],
+        nested: typing.Union[SchemaABC, type, str],
         *,
         default: typing.Any = missing_,
         only: types.StrSequenceOrSet = None,
@@ -664,9 +664,7 @@ class List(Field):
 
     default_error_messages = {"invalid": "Not a valid list."}
 
-    def __init__(
-        self, cls_or_instance: typing.Union[Field, typing.Type[Field]], **kwargs
-    ):
+    def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)
         try:
             self.inner = resolve_field_instance(cls_or_instance)
@@ -1427,8 +1425,8 @@ class Mapping(Field):
 
     def __init__(
         self,
-        keys: typing.Union[Field, typing.Type[Field]] = None,
-        values: typing.Union[Field, typing.Type[Field]] = None,
+        keys: typing.Union[Field, type] = None,
+        values: typing.Union[Field, type] = None,
         **kwargs
     ):
         super().__init__(**kwargs)

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -415,10 +415,10 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
     @classmethod
     def from_dict(
         cls,
-        fields: typing.Dict[str, typing.Union[ma_fields.Field, typing.Type]],
+        fields: typing.Dict[str, typing.Union[ma_fields.Field, type]],
         *,
         name: str = "GeneratedSchema"
-    ) -> typing.Type["Schema"]:
+    ) -> type:
         """Generate a `Schema` class given a dictionary of fields.
 
         .. code-block:: python


### PR DESCRIPTION
fix #1409
see https://github.com/python/typing/issues/266