### PR TITLE
Fix load parameter *unknow* propagation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -140,3 +140,4 @@ Contributors (chronological)
 - `@phrfpeixoto <https://github.com/phrfpeixoto>`_
 - `@jceresini <https://github.com/jceresini>`_
 - Nikolay Shebanov `@killthekitten <https://github.com/killthekitten>`_
+- Laurent Mignon `@lmignon <https://github.com/lmignon>`_ 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -427,6 +427,55 @@ or when calling `load <Schema.load>`.
 
 The ``unknown`` option value set in :meth:`load <Schema.load>` will override the value applied at instantiation time, which itself will override the value defined in the *class Meta*.
 
+The ``unknown`` option value set in :meth:`load <Schema.load>` is propagated to nested Schema. It's not the case when the value is applied at instantiation time nor when the value is defined in the *class Meta*.
+
+.. code-block:: python
+
+    from marshmallow import fields, Schema, EXCLUDE, INCLUDE, RAISE
+
+
+    class UserSchema(Schema):
+        class Meta:
+            unknown = RAISE
+
+        name = fields.String()
+
+
+    class BlogSchema(Schema):
+        class Meta:
+            unknown = EXCLUDE
+
+        title = fields.String()
+        author = fields.Nested(UserSchema)
+
+
+    BlogSchema().load(
+        {
+            "title": "Some title",
+            "unknown_field": "value",
+            "author": {"name": "Author name", "unknown_field": "value"},
+        }
+    )  # => ValidationError: {'author': {'unknown_field': ['Unknown field.']}}
+
+    BlogSchema().load(
+        {
+            "title": "Some title",
+            "unknown_field": "value",
+            "author": {"name": "Author name", "unknown_field": "value"},
+        },
+        unknown=EXCLUDE,
+    )  # => {'author': {'name': 'Author name'}, 'title': 'Some title'}
+
+
+    BogSchema.load(
+        {
+            "title": "Some title",
+            "unknown_field": "value",
+            "author": {"name": "Author name", "unknown_field": "value"},
+        },
+        unknown=INCLUDE,
+    )  # => {'author': {'name': 'Author name', 'unknown_field': 'value'}, 'title': 'Some title', 'unknown_field': 'value'}
+
 This order of precedence allows you to change the behavior of a schema for different contexts.
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -567,11 +567,12 @@ class Nested(Field):
         if many and not utils.is_collection(value):
             raise self.make_error("type", input=value, type=value.__class__.__name__)
 
-    def _load(self, value, data, partial=None, many=False):
+    def _load(self, value, data, partial=None, many=False, unknown=None):
         many = self.schema.many or self.many or many
+        unknown = unknown or self.unknown
         try:
             valid_data = self.schema.load(
-                value, unknown=self.unknown, partial=partial, many=many
+                value, unknown=unknown, partial=partial, many=many
             )
         except ValidationError as error:
             raise ValidationError(
@@ -579,17 +580,23 @@ class Nested(Field):
             ) from error
         return valid_data
 
-    def _deserialize(self, value, attr, data, partial=None, many=False, **kwargs):
+    def _deserialize(
+        self, value, attr, data, partial=None, many=False, unknown=None, **kwargs
+    ):
         """Same as :meth:`Field._deserialize` with additional ``partial`` argument.
 
         :param bool|tuple partial: For nested schemas, the ``partial``
             parameter passed to `Schema.load`.
+        :param unknown: For nested schemas, the ``unknown``
+            parameter passed to `Schema.load`..
 
         .. versionchanged:: 3.0.0
             Add ``partial`` parameter.
+        .. versionchanged:: 3.2.2
+            Add ``unknown`` parameter.
         """
         self._test_collection(value, many=many)
-        return self._load(value, data, partial=partial, many=many)
+        return self._load(value, data, partial=partial, many=many, unknown=unknown)
 
 
 class Pluck(Nested):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -300,8 +300,14 @@ def test_load_unknown(val):
     class Inner(Schema):
         name = fields.String()
 
+        class Meta:
+            unknown = RAISE
+
     class Outer(Schema):
         inner = fields.Nested(Inner)
+
+        class Meta:
+            unknown = RAISE
 
     assert Outer().load(val, unknown=EXCLUDE) == {"inner": {"name": "name"}}
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -289,6 +289,23 @@ def test_load_many_in_nested_empty_collection(val):
     assert Outer().load({"list1": val, "list2": val}) == {"list1": [], "list2": []}
 
 
+@pytest.mark.parametrize(
+    "val",
+    (
+        {"inner": {"name": "name"}, "unknown": 1},
+        {"inner": {"name": "name", "unknown_nested": 1}, "unknown": 1},
+    ),
+)
+def test_load_unknown(val):
+    class Inner(Schema):
+        name = fields.String()
+
+    class Outer(Schema):
+        inner = fields.Nested(Inner)
+
+    assert Outer().load(val, unknown=EXCLUDE) == {"inner": {"name": "name"}}
+
+
 def test_loads_returns_a_user():
     s = UserSchema()
     result = s.loads(json.dumps({"name": "Monty"}))


### PR DESCRIPTION
When deserializing a data structure with the load method, the *unknown* was not propagated to the loading of nested data structures. As result, if a unknown field was present into a nested data structure a ValidationError was raised even if the load methd was called with *unknown=EXCLUDE*. This commit ensures that this parameter is now propagated also to the loading of nested data structures.
fixes #1428