### PR TITLE
Inherit options

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -89,6 +89,7 @@ class SchemaMeta(type):
     names to field objects. Also sets the ``opts`` class attribute, which is
     the Schema class's ``class Meta`` options.
     """
+
     def __new__(mcs, name, bases, attrs, combine_opts=False):
         """
         :param combine_opts: If true, create a new SchemaOpts and Meta subclass from both parents
@@ -116,7 +117,9 @@ class SchemaMeta(type):
         meta = klass.Meta
         if combine_opts and len(bases) > 1:
             # Create a new options class that combines all the base classes
-            combined_opts = type(name + 'Opts', tuple(set([base.OPTIONS_CLASS for base in bases])), {})
+            combined_opts = type(
+                name + "Opts", tuple({base.OPTIONS_CLASS for base in bases}), {}
+            )
             # Instantiate the options class as we normally do
             klass.opts = combined_opts(meta, ordered=ordered)
         else:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -115,8 +115,6 @@ class SchemaMeta(type):
         # Instantiate the options class using class Meta
         meta = klass.Meta
         if combine_opts and len(bases) > 1:
-            # Create a new class Meta that combines all the base classes
-            # meta = type(name + 'Meta', tuple(set([base.Meta for base in bases])), {})
             # Create a new options class that combines all the base classes
             combined_opts = type(name + 'Opts', tuple(set([base.OPTIONS_CLASS for base in bases])), {})
             # Instantiate the options class as we normally do

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,7 +18,7 @@ from marshmallow import (
     INCLUDE,
     RAISE,
     class_registry,
-    SchemaOpts
+    SchemaOpts,
 )
 from marshmallow.exceptions import (
     ValidationError,
@@ -2772,8 +2772,10 @@ class TestFromDict:
 class TestCombineOpts:
     def test_basic(self):
         """
-        Create two options classes, each belonging to a schema, then combine the two schemas using inheritance
-        When combine_opts == True, we should have both options being stored in self.opts. Otherwise, we won't get any
+        Create two options classes, each belonging to a schema, then combine the two
+        schemas using inheritance. When combine_opts == True, we should have both options
+        being stored in self.opts. Otherwise, we should only get options defined in the
+        first options class stored in self.opts.
         """
 
         class Opts1(SchemaOpts):
@@ -2804,10 +2806,12 @@ class TestCombineOpts:
                 opt_1 = True
                 opt_2 = True
 
-        # Without using combine_opts, we should only get options defined by the first options class
+        # Without using combine_opts, we should only get options defined by the first
+        # options class
         assert NotCombined().opts.opt_1
-        assert not hasattr(NotCombined().opts, 'opt_2')
+        assert not hasattr(NotCombined().opts, "opt_2")
 
-        # However when we use combine_opts=True, we should get options defined by both options classes
+        # However when we use combine_opts=True, we should get options defined by both
+        # options classes
         assert Combined().opts.opt_1
         assert Combined().opts.opt_2

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2770,7 +2770,7 @@ class TestFromDict:
 
 
 class TestCombineOpts:
-    def test_basic(self):
+    def test_different_opts(self):
         """
         Create two options classes, each belonging to a schema, then combine the two
         schemas using inheritance. When combine_opts == True, we should have both options
@@ -2815,3 +2815,31 @@ class TestCombineOpts:
         # options classes
         assert Combined().opts.opt_1
         assert Combined().opts.opt_2
+
+    def test_same_opts(self):
+        """
+        Ensure this behaviour still works if the two parent schemas have the same opts
+        class
+        """
+
+        class Opts1(SchemaOpts):
+            def __init__(self, meta, **kwargs):
+                super().__init__(meta, **kwargs)
+                self.opt_1 = getattr(meta, "opt_1", None)
+
+        class Schema1(Schema):
+            OPTIONS_CLASS = Opts1
+            Field1 = fields.String()
+
+        class Schema2(Schema):
+            OPTIONS_CLASS = Opts1
+            Field2 = fields.String()
+
+        class Combined(Schema1, Schema2, combine_opts=True):
+            class Meta:
+                opt_1 = True
+                opt_2 = True
+
+        # However when we use combine_opts=True, we should get options defined by both
+        # options classes
+        assert Combined().opts.opt_1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -45,8 +45,8 @@ from tests.base import (
     Blog,
 )
 
-random.seed(1)
 
+random.seed(1)
 
 # Run tests with both verbose serializer and 'meta' option serializer
 @pytest.mark.parametrize("SchemaClass", [UserSchema, UserMetaSchema])
@@ -638,6 +638,7 @@ def test_invalid_dict_but_okay():
 
 def test_json_module_is_deprecated():
     with pytest.deprecated_call():
+
         class UserJSONSchema(Schema):
             name = fields.String()
 
@@ -780,6 +781,7 @@ def test_load_errors_with_many():
 
 def test_error_raised_if_fields_option_is_not_list():
     with pytest.raises(ValueError):
+
         class BadSchema(Schema):
             name = fields.String()
 
@@ -789,6 +791,7 @@ def test_error_raised_if_fields_option_is_not_list():
 
 def test_error_raised_if_additional_option_is_not_list():
     with pytest.raises(ValueError):
+
         class BadSchema(Schema):
             name = fields.String()
 
@@ -1581,8 +1584,8 @@ def test_meta_fields_mapping(user):
     assert type(s.fields["time_registered"]._field_cache[fields.Time]) == fields.Time
     assert type(s.fields["birthdate"]._field_cache[fields.Date]) == fields.Date
     assert (
-            type(s.fields["since_created"]._field_cache[fields.TimeDelta])
-            == fields.TimeDelta
+        type(s.fields["since_created"]._field_cache[fields.TimeDelta])
+        == fields.TimeDelta
     )
 
 
@@ -1605,6 +1608,7 @@ def test_exclude_fields(user):
 
 def test_fields_option_must_be_list_or_tuple():
     with pytest.raises(ValueError):
+
         class BadFields(Schema):
             class Meta:
                 fields = "name"
@@ -1612,6 +1616,7 @@ def test_fields_option_must_be_list_or_tuple():
 
 def test_exclude_option_must_be_list_or_tuple():
     with pytest.raises(ValueError):
+
         class BadExclude(Schema):
             class Meta:
                 exclude = "name"
@@ -1693,6 +1698,7 @@ def test_additional(user):
 
 def test_cant_set_both_additional_and_fields(user):
     with pytest.raises(ValueError):
+
         class BadSchema(Schema):
             name = fields.String()
 
@@ -2489,7 +2495,6 @@ class TestFieldInheritance:
                 ("field_d", fields.String()),
             ]
         )
-
         # Diamond inheritance graph
         # MRO: D -> B -> C -> A
 


### PR DESCRIPTION
Solves the issue documented here, where combining two schemas, each with different `SCHEMA_OPTS`, need to be combined: https://github.com/marshmallow-code/marshmallow-jsonapi/issues/3

My solution automatically creates a new `SchemaOpts` subclass that inherits from both parents whenever you subclass a `Schema` with two parents. I could have implemented the metaclass to always do this, but this would break downstream code that might depend on the `SchemaOpts` not properly inheriting. Thus, I've added a new class constructor parameter called `combine_opts=True`.

An example usage for the issue above is this:

```python
from marshmallow_jsonapi import schema as ja_schema
from marshmallow_sqlalchemy import schema as sql_schema

class ArtistSchema(sql_schema.ModelSchema, ja_schema.Schema, combine_opts=True):
    class Meta:
        model = models.Artist
        type_ = 'artists'
```

I've also added a test for this parameter