### PR TITLE
Make Number._format_num return typing.Any

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -869,7 +869,7 @@ class Number(Field):
         self.as_string = as_string
         super().__init__(**kwargs)
 
-    def _format_num(self, value) -> _T:
+    def _format_num(self, value) -> typing.Any:
         """Return the number value for value, given this field's `num_type`."""
         return self.num_type(value)
 


### PR DESCRIPTION
This allows a subclass that overrides/slash extends the method to set a more specific return type annotation.