### PR TITLE
Add IP address field type.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -141,3 +141,4 @@ Contributors (chronological)
 - `@jceresini <https://github.com/jceresini>`_
 - Nikolay Shebanov `@killthekitten <https://github.com/killthekitten>`_
 - Taneli Hukkinen `@hukkinj1 <https://github.com/hukkinj1>`_
+- Michał Getka `@mgetka <https://github.com/mgetka>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -146,7 +146,6 @@ Contributors (chronological)
 - `@dfirst <https://github.com/dfirst>`_
 - Tim Gates `@timgates42 <https://github.com/timgates42>`_
 - Nathan `@nbanmp <https://github.com/nbanmp>`_
-- Michał Getka `@mgetka <https://github.com/mgetka>`_
 - Ronan Murphy `@Resinderate <https://github.com/Resinderate>`_
 - Laurie Opperman `@EpicWink <https://github.com/EpicWink>`_
 - Ram Rachum `@cool-RR <https://github.com/cool-RR>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1635,14 +1635,7 @@ class IP(Field):
         if value is None:
             return None
         try:
-            if not isinstance(value, str):
-                # ip_address function is flexible in the terms of input value. In the case of
-                # marshalling, integer and binary address representation parsing may lead to
-                # confusion.
-                raise TypeError(
-                    "Only dot-decimal and hexadecimal groups notations are supported."
-                )
-            return ipaddress.ip_address(value)
+            return ipaddress.ip_address(utils.ensure_text_type(value))
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
@@ -1658,9 +1651,7 @@ class IPv4(IP):
         if value is None:
             return None
         try:
-            if not isinstance(value, str):
-                raise TypeError("Only dot-decimal notation is supported.")
-            return ipaddress.IPv4Address(value)
+            return ipaddress.IPv4Address(utils.ensure_text_type(value))
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
@@ -1676,9 +1667,7 @@ class IPv6(IP):
         if value is None:
             return None
         try:
-            if not isinstance(value, str):
-                raise TypeError("Only hexadecimal groups notation is supported.")
-            return ipaddress.IPv6Address(value)
+            return ipaddress.IPv6Address(utils.ensure_text_type(value))
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
@@ -1767,7 +1756,7 @@ class Function(Field):
             typing.Callable[[typing.Any], typing.Any],
             typing.Callable[[typing.Any, typing.Dict], typing.Any],
         ] = None,
-        **kwargs
+        **kwargs,
     ):
         # Set dump_only and load_only based on arguments
         kwargs["dump_only"] = bool(serialize) and not bool(deserialize)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -52,6 +52,8 @@ __all__ = [
     "URL",
     "Email",
     "IP",
+    "IPv4",
+    "IPv6",
     "Method",
     "Function",
     "Str",

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1642,8 +1642,6 @@ class IP(String):
         """Format the value or raise a :exc:`ValidationError` if an error occurs."""
         if value is None:
             return None
-        if isinstance(value, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-            return value
         try:
             if isinstance(value, (int, bytes)):
                 # ip_address function is flexible in the terms of input value. In the case of

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1645,7 +1645,7 @@ class IP(Field):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if not isinstance(value, str):
                 # ip_address function is flexible in the terms of input value. In the case of
                 # marshalling, integer and binary address representation parsing may lead to
                 # confusion.
@@ -1668,7 +1668,7 @@ class IPv4(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if not isinstance(value, str):
                 raise TypeError("Only dot-decimal notation is supported.")
             return ipaddress.IPv4Address(value)
         except (ValueError, TypeError) as error:
@@ -1686,7 +1686,7 @@ class IPv6(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if not isinstance(value, str):
                 raise TypeError("Only hexadecimal groups notation is supported.")
             return ipaddress.IPv6Address(value)
         except (ValueError, TypeError) as error:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1646,10 +1646,16 @@ class IP(Field):
         super().__init__(*args, **kwargs)
         self.exploded = exploded
 
-    def _validated(
-        self, value
+    def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
+        if value is None:
+            return None
+        if self.exploded:
+            return value.exploded
+        return value.compressed
+
+    def _deserialize(
+        self, value, attr, data, **kwargs
     ) -> typing.Optional[typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:
-        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
         if value is None:
             return None
         try:
@@ -1664,26 +1670,15 @@ class IP(Field):
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
-    def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
-        if value is None:
-            return None
-        if self.exploded:
-            return value.exploded
-        return value.compressed
-
-    def _deserialize(
-        self, value, attr, data, **kwargs
-    ) -> typing.Optional[typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:
-        return self._validated(value)
-
 
 class IPv4(IP):
     """A IPv4 address field."""
 
     default_error_messages = {"invalid_ip": "Not a valid IPv4 address."}
 
-    def _validated(self, value) -> typing.Optional[ipaddress.IPv4Address]:
-        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
+    def _deserialize(
+        self, value, attr, data, **kwargs
+    ) -> typing.Optional[ipaddress.IPv4Address]:
         if value is None:
             return None
         try:
@@ -1693,19 +1688,15 @@ class IPv4(IP):
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
-    def _deserialize(
-        self, value, attr, data, **kwargs
-    ) -> typing.Optional[ipaddress.IPv4Address]:
-        return self._validated(value)
-
 
 class IPv6(IP):
     """A IPv6 address field."""
 
     default_error_messages = {"invalid_ip": "Not a valid IPv6 address."}
 
-    def _validated(self, value) -> typing.Optional[ipaddress.IPv6Address]:
-        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
+    def _deserialize(
+        self, value, attr, data, **kwargs
+    ) -> typing.Optional[ipaddress.IPv6Address]:
         if value is None:
             return None
         try:
@@ -1714,11 +1705,6 @@ class IPv6(IP):
             return ipaddress.IPv6Address(value)
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
-
-    def _deserialize(
-        self, value, attr, data, **kwargs
-    ) -> typing.Optional[ipaddress.IPv6Address]:
-        return self._validated(value)
 
 
 class Method(Field):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1637,6 +1637,8 @@ class IP(Field):
 
     default_error_messages = {"invalid_ip": "Not a valid IP address."}
 
+    DESERIALIZATION_CLASS: typing.Optional[typing.Type] = None
+
     def __init__(self, *args, exploded=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.exploded = exploded
@@ -1654,7 +1656,9 @@ class IP(Field):
         if value is None:
             return None
         try:
-            return ipaddress.ip_address(utils.ensure_text_type(value))
+            return (self.DESERIALIZATION_CLASS or ipaddress.ip_address)(
+                utils.ensure_text_type(value)
+            )
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
@@ -1664,15 +1668,7 @@ class IPv4(IP):
 
     default_error_messages = {"invalid_ip": "Not a valid IPv4 address."}
 
-    def _deserialize(
-        self, value, attr, data, **kwargs
-    ) -> typing.Optional[ipaddress.IPv4Address]:
-        if value is None:
-            return None
-        try:
-            return ipaddress.IPv4Address(utils.ensure_text_type(value))
-        except (ValueError, TypeError) as error:
-            raise self.make_error("invalid_ip") from error
+    DESERIALIZATION_CLASS = ipaddress.IPv4Address
 
 
 class IPv6(IP):
@@ -1680,15 +1676,7 @@ class IPv6(IP):
 
     default_error_messages = {"invalid_ip": "Not a valid IPv6 address."}
 
-    def _deserialize(
-        self, value, attr, data, **kwargs
-    ) -> typing.Optional[ipaddress.IPv6Address]:
-        if value is None:
-            return None
-        try:
-            return ipaddress.IPv6Address(utils.ensure_text_type(value))
-        except (ValueError, TypeError) as error:
-            raise self.make_error("invalid_ip") from error
+    DESERIALIZATION_CLASS = ipaddress.IPv6Address
 
 
 class Method(Field):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1624,13 +1624,16 @@ class IP(Field):
     """A IP address field.
 
     :param bool exploded: If `True`, serialize ipv6 address in long form, ie. with groups
-        consisting entirely of zeros included."""
+        consisting entirely of zeros included.
+    :param bool allow_decimal: If `True`, accept decimal IP address representations while
+        deserializing.."""
 
     default_error_messages = {"invalid_ip": "Not a valid IP address."}
 
-    def __init__(self, *args, exploded=False, **kwargs):
+    def __init__(self, *args, exploded=False, allow_decimal=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.exploded = exploded
+        self.allow_decimal = allow_decimal
 
     def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
         if value is None:
@@ -1645,7 +1648,7 @@ class IP(Field):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if isinstance(value, (int, bytes)) and not self.allow_decimal:
                 # ip_address function is flexible in the terms of input value. In the case of
                 # marshalling, integer and binary address representation parsing may lead to
                 # confusion.
@@ -1668,7 +1671,7 @@ class IPv4(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if isinstance(value, (int, bytes)) and not self.allow_decimal:
                 raise TypeError("Only dot-decimal notation is supported.")
             return ipaddress.IPv4Address(value)
         except (ValueError, TypeError) as error:
@@ -1686,7 +1689,7 @@ class IPv6(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)):
+            if isinstance(value, (int, bytes)) and not self.allow_decimal:
                 raise TypeError("Only hexadecimal groups notation is supported.")
             return ipaddress.IPv6Address(value)
         except (ValueError, TypeError) as error:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1712,7 +1712,7 @@ class IPv6(IP):
             return None
         try:
             if isinstance(value, (int, bytes)):
-                raise TypeError("Only dot-decimal notation is supported.")
+                raise TypeError("Only hexadecimal groups notation is supported.")
             return ipaddress.IPv6Address(value)
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1634,7 +1634,7 @@ class Email(String):
         self.validators = [validator] + original_validators
 
 
-class IP(String):
+class IP(Field):
     """A IP address field.
 
     :param bool exploded: If `True`, serialize ipv6 address in long form, ie. with groups
@@ -1665,9 +1665,11 @@ class IP(String):
             raise self.make_error("invalid_ip") from error
 
     def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
-        if value is not None and self.exploded:
-            value = value.exploded
-        return super()._serialize(value, attr, obj, **kwargs)
+        if value is None:
+            return None
+        if self.exploded:
+            return value.exploded
+        return value.compressed
 
     def _deserialize(
         self, value, attr, data, **kwargs

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1650,8 +1650,7 @@ class IP(String):
                 # marshalling, integer and binary address representation parsing may lead to
                 # confusion.
                 raise TypeError(
-                    "Only dot-decimal and hexadecimal groups notations are supported. "
-                    "Got %s."
+                    "Only dot-decimal and hexadecimal groups notations are supported."
                 )
             return ipaddress.ip_address(value)
         except (ValueError, TypeError) as error:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1756,7 +1756,7 @@ class Function(Field):
             typing.Callable[[typing.Any], typing.Any],
             typing.Callable[[typing.Any, typing.Dict], typing.Any],
         ] = None,
-        **kwargs,
+        **kwargs
     ):
         # Set dump_only and load_only based on arguments
         kwargs["dump_only"] = bool(serialize) and not bool(deserialize)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1656,10 +1656,6 @@ class IP(String):
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
 
-    def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
-        val = str(value) if value is not None else None
-        return super()._serialize(val, attr, obj, **kwargs)
-
     def _deserialize(
         self, value, attr, data, **kwargs
     ) -> typing.Optional[typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1632,9 +1632,16 @@ class Email(String):
 
 
 class IP(String):
-    """A IP address field."""
+    """A IP address field.
+
+    :param bool exploded: If `True`, serialize ipv6 address in long form, ie. with groups
+        consisting entirely of zeros included."""
 
     default_error_messages = {"invalid_ip": "Not a valid IP address."}
+
+    def __init__(self, *args, exploded=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exploded = exploded
 
     def _validated(
         self, value
@@ -1653,6 +1660,11 @@ class IP(String):
             return ipaddress.ip_address(value)
         except (ValueError, TypeError) as error:
             raise self.make_error("invalid_ip") from error
+
+    def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
+        if value is not None and self.exploded:
+            value = value.exploded
+        return super()._serialize(value, attr, obj, **kwargs)
 
     def _deserialize(
         self, value, attr, data, **kwargs

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1672,6 +1672,50 @@ class IP(String):
         return self._validated(value)
 
 
+class IPv4(IP):
+    """A IPv4 address field."""
+
+    default_error_messages = {"invalid_ip": "Not a valid IPv4 address."}
+
+    def _validated(self, value) -> typing.Optional[ipaddress.IPv4Address]:
+        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
+        if value is None:
+            return None
+        try:
+            if isinstance(value, (int, bytes)):
+                raise TypeError("Only dot-decimal notation is supported.")
+            return ipaddress.IPv4Address(value)
+        except (ValueError, TypeError) as error:
+            raise self.make_error("invalid_ip") from error
+
+    def _deserialize(
+        self, value, attr, data, **kwargs
+    ) -> typing.Optional[ipaddress.IPv4Address]:
+        return self._validated(value)
+
+
+class IPv6(IP):
+    """A IPv6 address field."""
+
+    default_error_messages = {"invalid_ip": "Not a valid IPv6 address."}
+
+    def _validated(self, value) -> typing.Optional[ipaddress.IPv6Address]:
+        """Format the value or raise a :exc:`ValidationError` if an error occurs."""
+        if value is None:
+            return None
+        try:
+            if isinstance(value, (int, bytes)):
+                raise TypeError("Only dot-decimal notation is supported.")
+            return ipaddress.IPv6Address(value)
+        except (ValueError, TypeError) as error:
+            raise self.make_error("invalid_ip") from error
+
+    def _deserialize(
+        self, value, attr, data, **kwargs
+    ) -> typing.Optional[ipaddress.IPv6Address]:
+        return self._validated(value)
+
+
 class Method(Field):
     """A field that takes the value returned by a `Schema` method.
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1637,7 +1637,7 @@ class IP(Field):
 
     default_error_messages = {"invalid_ip": "Not a valid IP address."}
 
-    DESERIALIZATION_CLASS: typing.Optional[typing.Type] = None
+    DESERIALIZATION_CLASS = None  # type: typing.Optional[typing.Type]
 
     def __init__(self, *args, exploded=False, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1624,16 +1624,13 @@ class IP(Field):
     """A IP address field.
 
     :param bool exploded: If `True`, serialize ipv6 address in long form, ie. with groups
-        consisting entirely of zeros included.
-    :param bool allow_decimal: If `True`, accept decimal IP address representations while
-        deserializing.."""
+        consisting entirely of zeros included."""
 
     default_error_messages = {"invalid_ip": "Not a valid IP address."}
 
-    def __init__(self, *args, exploded=False, allow_decimal=False, **kwargs):
+    def __init__(self, *args, exploded=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.exploded = exploded
-        self.allow_decimal = allow_decimal
 
     def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
         if value is None:
@@ -1648,7 +1645,7 @@ class IP(Field):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)) and not self.allow_decimal:
+            if isinstance(value, (int, bytes)):
                 # ip_address function is flexible in the terms of input value. In the case of
                 # marshalling, integer and binary address representation parsing may lead to
                 # confusion.
@@ -1671,7 +1668,7 @@ class IPv4(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)) and not self.allow_decimal:
+            if isinstance(value, (int, bytes)):
                 raise TypeError("Only dot-decimal notation is supported.")
             return ipaddress.IPv4Address(value)
         except (ValueError, TypeError) as error:
@@ -1689,7 +1686,7 @@ class IPv6(IP):
         if value is None:
             return None
         try:
-            if isinstance(value, (int, bytes)) and not self.allow_decimal:
+            if isinstance(value, (int, bytes)):
                 raise TypeError("Only hexadecimal groups notation is supported.")
             return ipaddress.IPv6Address(value)
         except (ValueError, TypeError) as error:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -854,13 +854,6 @@ class TestFieldDeserialization:
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
 
-        field = fields.IP(allow_decimal=True)
-        result = field.deserialize(1)
-        assert str(result) == "0.0.0.1"
-
-        result = field.deserialize(2 ** 128 - 1)
-        assert str(result) == "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
-
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "192.168", "ff::aa:1::2"]
     )
@@ -877,10 +870,6 @@ class TestFieldDeserialization:
         result = field.deserialize(ipv4_str)
         assert isinstance(result, ipaddress.IPv4Address)
         assert str(result) == ipv4_str
-
-        field = fields.IPv4(allow_decimal=True)
-        result = field.deserialize(1)
-        assert str(result) == "0.0.0.1"
 
     @pytest.mark.parametrize(
         "in_value",
@@ -899,10 +888,6 @@ class TestFieldDeserialization:
         result = field.deserialize(ipv6_str)
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
-
-        field = fields.IPv6(allow_decimal=True)
-        result = field.deserialize(1)
-        assert str(result) == "::1"
 
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "ff::aa:1::2", "192.168.0.1"]

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -854,6 +854,13 @@ class TestFieldDeserialization:
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
 
+        field = fields.IP(allow_decimal=True)
+        result = field.deserialize(1)
+        assert str(result) == "0.0.0.1"
+
+        result = field.deserialize(2 ** 128 - 1)
+        assert str(result) == "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"
+
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "192.168", "ff::aa:1::2"]
     )
@@ -870,6 +877,10 @@ class TestFieldDeserialization:
         result = field.deserialize(ipv4_str)
         assert isinstance(result, ipaddress.IPv4Address)
         assert str(result) == ipv4_str
+
+        field = fields.IPv4(allow_decimal=True)
+        result = field.deserialize(1)
+        assert str(result) == "0.0.0.1"
 
     @pytest.mark.parametrize(
         "in_value",
@@ -888,6 +899,10 @@ class TestFieldDeserialization:
         result = field.deserialize(ipv6_str)
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
+
+        field = fields.IPv6(allow_decimal=True)
+        result = field.deserialize(1)
+        assert str(result) == "::1"
 
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "ff::aa:1::2", "192.168.0.1"]

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -849,20 +849,10 @@ class TestFieldDeserialization:
         assert isinstance(result, ipaddress.IPv4Address)
         assert str(result) == ipv4_str
 
-        ipv4 = ipaddress.ip_address("172.217.16.206")
-        result = field.deserialize(ipv4)
-        assert isinstance(result, ipaddress.IPv4Address)
-        assert result == ipv4
-
         ipv6_str = "2a00:1450:4001:824::200e"
         result = field.deserialize(ipv6_str)
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
-
-        ipv6 = ipaddress.ip_address("2a00:1450:4001:81d::200e")
-        result = field.deserialize(ipv6)
-        assert isinstance(result, ipaddress.IPv6Address)
-        assert result == ipv6
 
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "192.168", "ff::aa:1::2"]
@@ -881,11 +871,6 @@ class TestFieldDeserialization:
         assert isinstance(result, ipaddress.IPv4Address)
         assert str(result) == ipv4_str
 
-        ipv4 = ipaddress.ip_address("172.217.16.206")
-        result = field.deserialize(ipv4)
-        assert isinstance(result, ipaddress.IPv4Address)
-        assert result == ipv4
-
     @pytest.mark.parametrize(
         "in_value",
         ["malformed", 123, b"\x01\x02\03", "192.168", "2a00:1450:4001:81d::200e"],
@@ -903,11 +888,6 @@ class TestFieldDeserialization:
         result = field.deserialize(ipv6_str)
         assert isinstance(result, ipaddress.IPv6Address)
         assert str(result) == ipv6_str
-
-        ipv6 = ipaddress.ip_address("2a00:1450:4001:81d::200e")
-        result = field.deserialize(ipv6)
-        assert isinstance(result, ipaddress.IPv6Address)
-        assert result == ipv6
 
     @pytest.mark.parametrize(
         "in_value", ["malformed", 123, b"\x01\x02\03", "ff::aa:1::2", "192.168.0.1"]

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -874,6 +874,51 @@ class TestFieldDeserialization:
 
         assert excinfo.value.args[0] == "Not a valid IP address."
 
+    def test_ipv4_field_deserialization(self):
+        field = fields.IPv4()
+        ipv4_str = "140.82.118.3"
+        result = field.deserialize(ipv4_str)
+        assert isinstance(result, ipaddress.IPv4Address)
+        assert str(result) == ipv4_str
+
+        ipv4 = ipaddress.ip_address("172.217.16.206")
+        result = field.deserialize(ipv4)
+        assert isinstance(result, ipaddress.IPv4Address)
+        assert result == ipv4
+
+    @pytest.mark.parametrize(
+        "in_value",
+        ["malformed", 123, b"\x01\x02\03", "192.168", "2a00:1450:4001:81d::200e"],
+    )
+    def test_invalid_ipv4_deserialization(self, in_value):
+        field = fields.IPv4()
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(in_value)
+
+        assert excinfo.value.args[0] == "Not a valid IPv4 address."
+
+    def test_ipv6_field_deserialization(self):
+        field = fields.IPv6()
+        ipv6_str = "2a00:1450:4001:824::200e"
+        result = field.deserialize(ipv6_str)
+        assert isinstance(result, ipaddress.IPv6Address)
+        assert str(result) == ipv6_str
+
+        ipv6 = ipaddress.ip_address("2a00:1450:4001:81d::200e")
+        result = field.deserialize(ipv6)
+        assert isinstance(result, ipaddress.IPv6Address)
+        assert result == ipv6
+
+    @pytest.mark.parametrize(
+        "in_value", ["malformed", 123, b"\x01\x02\03", "ff::aa:1::2", "192.168.0.1"]
+    )
+    def test_invalid_ipv6_deserialization(self, in_value):
+        field = fields.IPv6()
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(in_value)
+
+        assert excinfo.value.args[0] == "Not a valid IPv6 address."
+
     def test_deserialization_function_must_be_callable(self):
         with pytest.raises(ValueError):
             fields.Function(lambda x: None, deserialize="notvalid")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -165,6 +165,35 @@ class TestFieldSerialization:
         assert isinstance(field_exploded.serialize("ipv6", user), str)
         assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
 
+    def test_ipv4_address_field(self, user):
+
+        ipv4_string = "192.168.0.1"
+
+        user.ipv4 = ipaddress.ip_address(ipv4_string)
+        user.empty_ip = None
+
+        field = fields.IPv4()
+        assert isinstance(field.serialize("ipv4", user), str)
+        assert field.serialize("ipv4", user) == ipv4_string
+        assert field.serialize("empty_ip", user) is None
+
+    def test_ipv6_address_field(self, user):
+
+        ipv6_string = "ffff::ffff"
+        ipv6_exploded_string = ipaddress.ip_address("ffff::ffff").exploded
+
+        user.ipv6 = ipaddress.ip_address(ipv6_string)
+        user.empty_ip = None
+
+        field_compressed = fields.IPv6()
+        assert isinstance(field_compressed.serialize("ipv6", user), str)
+        assert field_compressed.serialize("ipv6", user) == ipv6_string
+        assert field_compressed.serialize("empty_ip", user) is None
+
+        field_exploded = fields.IPv6(exploded=True)
+        assert isinstance(field_exploded.serialize("ipv6", user), str)
+        assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
+
     def test_decimal_field(self, user):
         user.m1 = 12
         user.m2 = "12.355"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,6 +4,7 @@ import datetime as dt
 import itertools
 import decimal
 import uuid
+import ipaddress
 
 import pytest
 
@@ -142,6 +143,27 @@ class TestFieldSerialization:
         assert isinstance(field.serialize("uuid1", user), str)
         assert field.serialize("uuid1", user) == "12345678-1234-5678-1234-567812345678"
         assert field.serialize("uuid2", user) is None
+
+    def test_ip_address_field(self, user):
+
+        ipv4_string = "192.168.0.1"
+        ipv6_string = "ffff::ffff"
+        ipv6_exploded_string = ipaddress.ip_address("ffff::ffff").exploded
+
+        user.ipv4 = ipaddress.ip_address(ipv4_string)
+        user.ipv6 = ipaddress.ip_address(ipv6_string)
+        user.empty_ip = None
+
+        field_compressed = fields.IP()
+        assert isinstance(field_compressed.serialize("ipv4", user), str)
+        assert field_compressed.serialize("ipv4", user) == ipv4_string
+        assert isinstance(field_compressed.serialize("ipv6", user), str)
+        assert field_compressed.serialize("ipv6", user) == ipv6_string
+        assert field_compressed.serialize("empty_ip", user) is None
+
+        field_exploded = fields.IP(exploded=True)
+        assert isinstance(field_exploded.serialize("ipv6", user), str)
+        assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
 
     def test_decimal_field(self, user):
         user.m1 = 12


### PR DESCRIPTION
This pull request adds IPv4/IPv6 fields serialization and deserialization w/ tests included. To avoid confusion I am excluding the possibility to specify IP addresses as an integer or byte values.