### PR TITLE
Remove useless UUID._serialize override

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Features:
 
 - Improve type coverage (:issue:`1479`). Thanks :user:`Reskov`.
+- Remove useless ``_serialize`` override in ``UUID`` field (:pr:`1489`).
 
 3.3.0 (2019-12-05)
 ******************

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -865,10 +865,6 @@ class UUID(String):
         except (ValueError, AttributeError, TypeError) as error:
             raise self.make_error("invalid_uuid") from error
 
-    def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
-        val = str(value) if value is not None else None
-        return super()._serialize(val, attr, obj, **kwargs)
-
     def _deserialize(self, value, attr, data, **kwargs) -> typing.Optional[uuid.UUID]:
         return self._validated(value)
 


### PR DESCRIPTION
Any reason to override this method?