### PR TITLE
Modify Nested field to handle the combination of many=True and allow_…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -143,3 +143,4 @@ Contributors (chronological)
 - Taneli Hukkinen `@hukkinj1 <https://github.com/hukkinj1>`_
 - `@Reskov <https://github.com/Reskov>`_
 - Albert Tugushev `@atugushev <https://github.com/atugushev>`_
+- Jonathan Gayvallet `@Meallia <https://github.com/Meallia>`_

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -38,6 +38,24 @@ class TestDeserializingNone:
         field = fields.Tuple([fields.String()], allow_none=True)
         assert field.deserialize(None) is None
 
+    def test_list_of_nested_allow_none_deserialize_none_to_none(self):
+        field = fields.List(fields.Nested(Schema(), allow_none=True))
+        assert field.deserialize([None, {}]) == [None, {}]
+
+    def test_nested_multiple_allow_none_deserialize_none_to_none(self):
+        field = fields.Nested(Schema(), allow_none=True, many=True)
+        assert field.deserialize([None, {}]) == [None, {}]
+
+    def test_list_of_nested_non_allow_none_deserialize_none_to_validation_error(self):
+        field = fields.List(fields.Nested(Schema(), allow_none=False))
+        with pytest.raises(ValidationError):
+            field.deserialize([None])
+
+    def test_nested_multiple_non_allow_none_deserialize_none_to_validation_error(self):
+        field = fields.Nested(Schema(), allow_none=True, many=False)
+        with pytest.raises(ValidationError):
+            field.deserialize([None])
+
 
 class TestFieldDeserialization:
     def test_float_field_deserialization(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -727,6 +727,16 @@ class TestFieldSerialization:
         res = field.serialize("foo", {"foo": None})
         assert res is None
 
+    def test_list_of_nested_allow_none_serialize_none_to_none(self):
+        field = fields.List(fields.Nested(Schema(), allow_none=True))
+        res = field.serialize("foo", {"foo": [None, {}]})
+        assert res == [None, {}]
+
+    def test_nested_multiple_allow_none_serialize_none_to_none(self):
+        field = fields.Nested(Schema(), allow_none=True, many=True)
+        res = field.serialize("foo", {"foo": [None, {}]})
+        assert res == [None, {}]
+
 
 class TestSchemaSerialization:
     def test_serialize_with_missing_param_value(self):


### PR DESCRIPTION
Fix for #1497 
Hi,

I tried to fix the issue by modifying `Schema` as suggested in the issue discussion but it would fail to detect validation errors when `[None]` is passed to a `Nested(many=True, allow_none=False)` field as the schema is not aware of `allow_none`. 

Instead, I made the `Nested` field check when (de-)serializing if `many` and `allow_none` are both set to `True`. in that case, we simply pass the non-`None` values to the underlying schema then insert `None` values back in the resulting list.


