### PR TITLE
Remove unnecessary typecasts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 Features:
 
 - Improve type coverage (:issue:`1479`). Thanks :user:`Reskov`.
+
+Other changes:
+
+- Remove unnecessary typecasts (:pr:`1500`). Thanks :user:`hukkinj1`. 
 - Remove useless ``_serialize`` override in ``UUID`` field (:pr:`1489`).
 
 3.3.0 (2019-12-05)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ license_files = LICENSE
 universal = 1
 
 [flake8]
-ignore = E203, E266, E501, W503, E731, B903
+extend-ignore = E203, E266, E501, E731, B903
 max-line-length = 90
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -160,20 +160,12 @@ class Field(FieldABC):
         self.attribute = attribute
         self.data_key = data_key
         self.validate = validate
-        if utils.is_iterable_but_not_string(validate):
-            if not utils.is_generator(validate):
-                self.validators = typing.cast(
-                    typing.Sequence[typing.Callable[[typing.Any], typing.Any]], validate
-                )
-            else:
-                validators = typing.cast(
-                    typing.Sequence[typing.Callable[[typing.Any], typing.Any]], validate
-                )
-                self.validators = list(validators)
+        if validate is None:
+            self.validators = []
         elif callable(validate):
             self.validators = [validate]
-        elif validate is None:
-            self.validators = []
+        elif utils.is_iterable_but_not_string(validate):
+            self.validators = list(validate)
         else:
             raise ValueError(
                 "The 'validate' parameter must be a callable "
@@ -1598,18 +1590,13 @@ class Url(String):
         self.relative = relative
         self.require_tld = require_tld
         # Insert validation into self.validators so that multiple errors can be stored.
-        original_validators = list(self.validators)
-        # FIXME: Why doesn't mypy think validate.URL is a callable here?
-        validator = typing.cast(
-            typing.Callable[[typing.Any], typing.Any],
-            validate.URL(
-                relative=self.relative,
-                schemes=schemes,
-                require_tld=self.require_tld,
-                error=self.error_messages["invalid"],
-            ),
+        validator = validate.URL(
+            relative=self.relative,
+            schemes=schemes,
+            require_tld=self.require_tld,
+            error=self.error_messages["invalid"],
         )
-        self.validators = [validator] + original_validators
+        self.validators.append(validator)
 
 
 class Email(String):
@@ -1625,9 +1612,8 @@ class Email(String):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Insert validation into self.validators so that multiple errors can be stored.
-        original_validators = list(self.validators)
         validator = validate.Email(error=self.error_messages["invalid"])
-        self.validators = [validator] + original_validators
+        self.validators.append(validator)
 
 
 class Method(Field):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1596,7 +1596,7 @@ class Url(String):
             require_tld=self.require_tld,
             error=self.error_messages["invalid"],
         )
-        self.validators.append(validator)
+        self.validators.insert(0, validator)
 
 
 class Email(String):
@@ -1613,7 +1613,7 @@ class Email(String):
         super().__init__(*args, **kwargs)
         # Insert validation into self.validators so that multiple errors can be stored.
         validator = validate.Email(error=self.error_messages["invalid"])
-        self.validators.append(validator)
+        self.validators.insert(0, validator)
 
 
 class Method(Field):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1428,7 +1428,7 @@ class TestSchemaDeserialization:
             MySchema().load({"email": "foo"})
         errors = excinfo.value.messages
         assert len(errors["email"]) == 2
-        assert "Not a valid email address." in errors["email"][0]
+        assert any("Not a valid email address." in e for e in errors["email"])
 
     def test_multiple_errors_can_be_stored_for_a_url_field(self):
         def validate_with_bool(val):
@@ -1441,7 +1441,7 @@ class TestSchemaDeserialization:
             MySchema().load({"url": "foo"})
         errors = excinfo.value.messages
         assert len(errors["url"]) == 2
-        assert "Not a valid URL." in errors["url"][0]
+        assert any("Not a valid URL." in e for e in errors["url"])
 
     def test_required_value_only_passed_to_validators_if_provided(self):
         class MySchema(Schema):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1428,7 +1428,7 @@ class TestSchemaDeserialization:
             MySchema().load({"email": "foo"})
         errors = excinfo.value.messages
         assert len(errors["email"]) == 2
-        assert any("Not a valid email address." in e for e in errors["email"])
+        assert "Not a valid email address." in errors["email"][0]
 
     def test_multiple_errors_can_be_stored_for_a_url_field(self):
         def validate_with_bool(val):
@@ -1441,7 +1441,7 @@ class TestSchemaDeserialization:
             MySchema().load({"url": "foo"})
         errors = excinfo.value.messages
         assert len(errors["url"]) == 2
-        assert any("Not a valid URL." in e for e in errors["url"])
+        assert "Not a valid URL." in errors["url"][0]
 
     def test_required_value_only_passed_to_validators_if_provided(self):
         class MySchema(Schema):


### PR DESCRIPTION
- Fix the issue in comment `# FIXME: Why doesn't mypy think validate.URL is a callable here?`
    - The problem was that we try to do `List[SubClass] + List[SuperClass]`. This is not supported by list's `+` operand, but `List[SuperClass] + List[SubClass]` is.
- Remove unnecessary typecasts
- Use `extend-ignore` instead of `ignore` in flake8 configuration to not override default ignores.