### PR TITLE
Drop Python 3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+2.21.0 (unreleased)
++++++++++++++++++++
+
+Other changes:
+
+- Drop support for Python 3.4 (:pr:`1525`).
+
+
 2.20.5 (2019-09-15)
 +++++++++++++++++++
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ resources:
 jobs:
 - template: job--python-tox.yml@sloria
   parameters:
-    toxenvs: [lint, py27, py34, py35, py36, py37, docs]
+    toxenvs: [lint, py27, py35, py36, py37, docs]
     os: linux
 - template: job--pypi-release.yml@sloria
   parameters:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27,py34,py35,py36,py37,docs
+envlist = lint,py27,py35,py36,py37,docs
 
 [testenv]
 extras = tests,reco


### PR DESCRIPTION
Python 3.4 is EOL : https://www.python.org/downloads/release/python-3410/.

It is not provided by Azure DevOps:

```
Version spec 3.4 for architecture x64 did not match any version in Agent.ToolsDirectory.
Versions in /opt/hostedtoolcache:

2.7.17 (x64)
3.5.9 (x64)
3.6.10 (x64)
3.7.6 (x64)
3.8.1 (x64)
```