### PR TITLE
Make tests not depend on execution order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytest-randomly", "pytz", "simplejson"],
+    "tests": ["pytest", "pytz", "simplejson"],
     "lint": [
         "mypy==0.770",
         "flake8==3.7.9",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytz", "simplejson"],
+    "tests": ["pytest", "pytest-randomly", "pytz", "simplejson"],
     "lint": [
         "mypy==0.770",
         "flake8==3.7.9",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -127,17 +127,17 @@ class C:
 
 class ASchema(Schema):
     id = fields.Integer()
-    b = fields.Nested("BSchema", exclude=("a",))
+    b = fields.Nested("tests.test_registry.BSchema", exclude=("a",))
 
 
 class BSchema(Schema):
     id = fields.Integer()
-    a = fields.Nested("ASchema")
+    a = fields.Nested("tests.test_registry.ASchema")
 
 
 class CSchema(Schema):
     id = fields.Integer()
-    bs = fields.Nested("BSchema", many=True)
+    bs = fields.Nested("tests.test_registry.BSchema", many=True)
 
 
 def test_two_way_nesting():


### PR DESCRIPTION
### Issue description
Two test cases in `test_registry`, namely `test_two_way_nesting` and `test_nesting_with_class_name_many` fail if `test_serialization` test module runs before them in the same pytest invocation. This is due to `test_serialization` declaring a schema class called `ASchema` and the tests in `test_registry` assuming that a class with this name only exists in `test_registry` module.

Unit tests usually should not rely on a certain execution order.

### The fix
Make the execution order dependent tests look for `tests.test_registry.ASchema` with the full path instead of just `ASchema`.

Also add `pytest-randomly` plugin to catch these sorts of flaws in tests.