### PR TITLE
Use pprint from stdlib in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,9 @@ marshmallow: simplified object serialization
 .. code-block:: python
 
     from datetime import date
-    from marshmallow import Schema, fields, pprint
+    from pprint import pprint
+
+    from marshmallow import Schema, fields
 
 
     class ArtistSchema(Schema):

--- a/docs/about.rst.inc
+++ b/docs/about.rst.inc
@@ -3,18 +3,23 @@
 .. code-block:: python
 
     from datetime import date
-    from marshmallow import Schema, fields, pprint
+    from pprint import pprint
+
+    from marshmallow import Schema, fields
+
 
     class ArtistSchema(Schema):
         name = fields.Str()
+
 
     class AlbumSchema(Schema):
         title = fields.Str()
         release_date = fields.Date()
         artist = fields.Nested(ArtistSchema())
 
-    bowie = dict(name='David Bowie')
-    album = dict(artist=bowie, title='Hunky Dory', release_date=date(1971, 12, 17))
+
+    bowie = dict(name="David Bowie")
+    album = dict(artist=bowie, title="Hunky Dory", release_date=date(1971, 12, 17))
 
     schema = AlbumSchema()
     result = schema.dump(album)

--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -26,7 +26,7 @@ Use a :class:`Nested <marshmallow.fields.Nested>` field to represent the relatio
 
 .. code-block:: python
 
-    from marshmallow import Schema, fields, pprint
+    from marshmallow import Schema, fields
 
 
     class UserSchema(Schema):
@@ -42,6 +42,8 @@ Use a :class:`Nested <marshmallow.fields.Nested>` field to represent the relatio
 The serialized blog will have the nested user representation.
 
 .. code-block:: python
+
+    from pprint import pprint
 
     user = User(name="Monty", email="monty@python.org")
     blog = Blog(title="Something Completely Different", author=user)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -63,7 +63,7 @@ Serialize objects by passing them to your schema's :meth:`dump <marshmallow.Sche
 
 .. code-block:: python
 
-    from marshmallow import pprint
+    from pprint import pprint
 
     user = User(name="Monty", email="monty@python.org")
     schema = UserSchema()
@@ -529,8 +529,9 @@ To maintain field ordering, set the ``ordered`` option to `True`. This will inst
 .. code-block:: python
 
     from collections import OrderedDict
+    from pprint import pprint
 
-    from marshmallow import Schema, fields, pprint
+    from marshmallow import Schema, fields
 
 
     class UserSchema(Schema):

--- a/examples/package_json_example.py
+++ b/examples/package_json_example.py
@@ -1,8 +1,9 @@
 import sys
 import json
 from packaging import version
+from pprint import pprint
 
-from marshmallow import Schema, fields, INCLUDE, pprint, ValidationError
+from marshmallow import Schema, fields, INCLUDE, ValidationError
 
 
 class Version(fields.Field):


### PR DESCRIPTION
`marshmallow.pprint` hasn't been useful since we stopped serializing to `OrderedDict`s by default (which was in 1.0!). Worse, it's not even correct--`bool`s won't be displayed correctly when printing `OrderedDict`.

We should consider deprecating/removing it. For now, I'm just removing it from the docs.