### PR TITLE
Split-up API documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -147,3 +147,4 @@ Contributors (chronological)
 - Tim Gates `@timgates42 <https://github.com/timgates42>`_
 - Nathan `@nbanmp <https://github.com/nbanmp>`_
 - Ronan Murphy `@Resinderate <https://github.com/Resinderate>`_
+- Laurie Opperman `@EpicWink <https://github.com/EpicWink>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Support:
 - Documentation: improve custom fields example (:issue:`1538`).
   Thanks :user:`pablospizzamiglio` for reporting the problem with the
   old example and thanks :user:`Resinderate` for the PR.
+- Documentation: Split up API reference into multiple pages and 
+  add summary tables (:pr:`1587`). Thanks :user:`EpicWink` for the PR.
 
 3.6.0 (2020-05-08)
 ******************

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -6,59 +6,12 @@ API Reference
 
 .. module:: marshmallow
 
-Schema
-======
-
-
-.. autoclass:: marshmallow.Schema
-    :inherited-members:
-
-.. autoclass:: marshmallow.SchemaOpts
-
-.. _api_fields:
-
-Fields
-======
-
-.. automodule:: marshmallow.fields
-    :members:
-    :private-members:
-
-Decorators
-==========
-
-.. automodule:: marshmallow.decorators
-    :members:
-
-.. _api_validators:
-
-Validators
-==========
-
-.. automodule:: marshmallow.validate
-    :members:
-
-Utility Functions
-=================
-
-.. automodule:: marshmallow.utils
-    :members:
-
-Error Store
-===========
-
-.. automodule:: marshmallow.error_store
-    :members:
-    :private-members:
-
-Class Registry
-==============
-
-.. automodule:: marshmallow.class_registry
-    :members:
-
-Exceptions
-==========
-
-.. automodule:: marshmallow.exceptions
-    :members:
+.. toctree::
+    marshmallow.schema
+    marshmallow.fields
+    marshmallow.decorators
+    marshmallow.validate
+    marshmallow.utils
+    marshmallow.error_store
+    marshmallow.class_registry
+    marshmallow.exceptions

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -4,8 +4,6 @@
 API Reference
 *************
 
-.. module:: marshmallow
-
 .. toctree::
     marshmallow.schema
     marshmallow.fields
@@ -15,3 +13,13 @@ API Reference
     marshmallow.error_store
     marshmallow.class_registry
     marshmallow.exceptions
+
+.. automodule:: marshmallow
+   :members:
+   :undoc-members:
+   :autosummary:
+
+.. data:: EXCLUDE
+.. data:: INCLUDE
+.. data:: RAISE
+.. data:: missing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ extensions = [
     "alabaster",
     "sphinx_issues",
     "versionwarning.extension",
+    "autodocsumm",
 ]
 
 primary_domain = "py"

--- a/docs/marshmallow.class_registry.rst
+++ b/docs/marshmallow.class_registry.rst
@@ -1,0 +1,5 @@
+Class Registry
+==============
+
+.. automodule:: marshmallow.class_registry
+    :members:

--- a/docs/marshmallow.decorators.rst
+++ b/docs/marshmallow.decorators.rst
@@ -1,0 +1,5 @@
+Decorators
+==========
+
+.. automodule:: marshmallow.decorators
+    :members:

--- a/docs/marshmallow.decorators.rst
+++ b/docs/marshmallow.decorators.rst
@@ -3,3 +3,4 @@ Decorators
 
 .. automodule:: marshmallow.decorators
     :members:
+    :autosummary:

--- a/docs/marshmallow.error_store.rst
+++ b/docs/marshmallow.error_store.rst
@@ -1,0 +1,6 @@
+Error Store
+===========
+
+.. automodule:: marshmallow.error_store
+    :members:
+    :private-members:

--- a/docs/marshmallow.exceptions.rst
+++ b/docs/marshmallow.exceptions.rst
@@ -1,0 +1,5 @@
+Exceptions
+==========
+
+.. automodule:: marshmallow.exceptions
+    :members:

--- a/docs/marshmallow.fields.rst
+++ b/docs/marshmallow.fields.rst
@@ -6,3 +6,4 @@ Fields
 .. automodule:: marshmallow.fields
     :members:
     :private-members:
+    :autosummary:

--- a/docs/marshmallow.fields.rst
+++ b/docs/marshmallow.fields.rst
@@ -1,0 +1,8 @@
+.. _api_fields:
+
+Fields
+======
+
+.. automodule:: marshmallow.fields
+    :members:
+    :private-members:

--- a/docs/marshmallow.schema.rst
+++ b/docs/marshmallow.schema.rst
@@ -3,5 +3,6 @@ Schema
 
 .. autoclass:: marshmallow.Schema
     :inherited-members:
+    :autosummary:
 
 .. autoclass:: marshmallow.SchemaOpts

--- a/docs/marshmallow.schema.rst
+++ b/docs/marshmallow.schema.rst
@@ -1,0 +1,7 @@
+Schema
+======
+
+.. autoclass:: marshmallow.Schema
+    :inherited-members:
+
+.. autoclass:: marshmallow.SchemaOpts

--- a/docs/marshmallow.schema.rst
+++ b/docs/marshmallow.schema.rst
@@ -1,8 +1,8 @@
 Schema
 ======
 
-.. autoclass:: marshmallow.Schema
+.. autoclass:: marshmallow.schema.Schema
     :inherited-members:
     :autosummary:
 
-.. autoclass:: marshmallow.SchemaOpts
+.. autoclass:: marshmallow.schema.SchemaOpts

--- a/docs/marshmallow.utils.rst
+++ b/docs/marshmallow.utils.rst
@@ -1,0 +1,5 @@
+Utility Functions
+=================
+
+.. automodule:: marshmallow.utils
+    :members:

--- a/docs/marshmallow.validate.rst
+++ b/docs/marshmallow.validate.rst
@@ -1,0 +1,7 @@
+.. _api_validators:
+
+Validators
+==========
+
+.. automodule:: marshmallow.validate
+    :members:

--- a/docs/marshmallow.validate.rst
+++ b/docs/marshmallow.validate.rst
@@ -5,3 +5,4 @@ Validators
 
 .. automodule:: marshmallow.validate
     :members:
+    :autosummary:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ EXTRAS_REQUIRE = {
         "sphinx-issues==1.2.0",
         "alabaster==0.7.12",
         "sphinx-version-warning==1.1.2",
+        "autodocsumm==0.1.13",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]


### PR DESCRIPTION
Split API reference documentation up into multiple pages, and include member summary table using `autosummary`