### PR TITLE
Fix exception causes in 2 files

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -148,3 +148,4 @@ Contributors (chronological)
 - Nathan `@nbanmp <https://github.com/nbanmp>`_
 - Ronan Murphy `@Resinderate <https://github.com/Resinderate>`_
 - Laurie Opperman `@EpicWink <https://github.com/EpicWink>`_
+- Ram Rachum `@cool-RR <https://github.com/cool-RR>`_

--- a/examples/package_json_example.py
+++ b/examples/package_json_example.py
@@ -12,8 +12,8 @@ class Version(fields.Field):
     def _deserialize(self, value, *args, **kwargs):
         try:
             return version.Version(value)
-        except version.InvalidVersion:
-            raise ValidationError("Not a valid version.")
+        except version.InvalidVersion as e:
+            raise ValidationError("Not a valid version.") from e
 
     def _serialize(self, value, *args, **kwargs):
         return str(value)

--- a/tests/base.py
+++ b/tests/base.py
@@ -187,7 +187,7 @@ class UserSchema(Schema):
         try:
             return age > 80
         except TypeError as te:
-            raise ValidationError(str(te))
+            raise ValidationError(str(te)) from te
 
     @post_load
     def make_user(self, data, **kwargs):
@@ -216,7 +216,7 @@ class UserMetaSchema(Schema):
         try:
             return age > 80
         except TypeError as te:
-            raise ValidationError(str(te))
+            raise ValidationError(str(te)) from te
 
     class Meta:
         fields = (


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now, it seems like there's one more instance of this mistake in another file.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 