### PR TITLE
Rework Schema._get_fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,14 @@ Changelog
 3.12.0 (unreleased)
 *******************
 
+Features:
+
+- Let ``Field``s be accessed by name as ``Schema`` attributes (:pr:`1631`).
+
 Other changes:
 
-- Improve types in ``marshmallow.validate``.
-- Make `marshmallow.validate.Validator` an abstract base class.
+- Improve types in ``marshmallow.validate`` (:pr:`1786`).
+- Make `marshmallow.validate.Validator` an abstract base class (:pr:`1786`).
 - Remove unnecessary list cast (:pr:`1785`).
 
 3.11.1 (2021-03-29)

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -38,21 +38,17 @@ from marshmallow.warnings import RemovedInMarshmallow4Warning
 _T = typing.TypeVar("_T")
 
 
-def _get_fields(attrs, field_class, pop=False, ordered=False):
+def _get_fields(attrs, field_class, ordered=False):
     """Get fields from a class. If ordered=True, fields will sorted by creation index.
 
     :param attrs: Mapping of class attributes
     :param type field_class: Base field class
-    :param bool pop: Remove matching fields
     """
     fields = [
         (field_name, field_value)
         for field_name, field_value in attrs.items()
         if is_instance_or_subclass(field_value, field_class)
     ]
-    if pop:
-        for field_name, _ in fields:
-            del attrs[field_name]
     if ordered:
         fields.sort(key=lambda pair: pair[1]._creation_index)
     return fields
@@ -104,7 +100,7 @@ class SchemaMeta(type):
                     break
             else:
                 ordered = False
-        cls_fields = _get_fields(attrs, base.FieldABC, pop=True, ordered=ordered)
+        cls_fields = _get_fields(attrs, base.FieldABC, ordered=ordered)
         klass = super().__new__(mcs, name, bases, attrs)
         inherited_fields = _get_fields_by_mro(klass, base.FieldABC, ordered=ordered)
 


### PR DESCRIPTION
Closes #1628.

- Don't pop fields from schema class
- Hardcode base schema class to `base.FieldABC`