### PR TITLE
Boolean can handle unhashable type

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -151,3 +151,4 @@ Contributors (chronological)
 - Ram Rachum `@cool-RR <https://github.com/cool-RR>`_
 - `@weeix <https://github.com/weeix>`_
 - Juan Norris `@juannorris <https://github.com/juannorris>`_
+- 장준영 `@jun0jang <https://github.com/jun0jang>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.7.1 (unreleased)
+******************
+
+Bug fixes:
+
+- ``fields.Boolean`` correctly serializes non-hashable types (:pr:`1633`).
+  Thanks :user:`jun0jang` for the PR.
+
 3.7.0 (2020-07-08)
 ******************
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1112,10 +1112,14 @@ class Boolean(Field):
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return None
-        elif value in self.truthy:
-            return True
-        elif value in self.falsy:
-            return False
+
+        try:
+            if value in self.truthy:
+                return True
+            elif value in self.falsy:
+                return False
+        except TypeError:
+            pass
 
         return bool(value)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -162,6 +162,16 @@ def test_dump_many():
     assert data[0] == s.dump(u1)
 
 
+@pytest.mark.parametrize("value", [[], {}, [1], {1: 1}])
+def test_boolean_can_dump_unhashable(value):
+    class MySchema(Schema):
+        has_items = fields.Boolean()
+
+    schema = MySchema()
+    data = schema.dump({"has_items": value})
+    assert data["has_items"] is bool(value)
+
+
 def test_multiple_errors_can_be_stored_for_a_given_index():
     class MySchema(Schema):
         foo = fields.Str(validate=lambda x: len(x) > 3)


### PR DESCRIPTION
Excepted: 
```python
class BrandSchema():
    has_new_product = fields.Boolean(attribute="new_products")

res = BrandSchema().dump({"new_products": [Product(), ...])
# {"has_new_product": True}
```

but it raise unhashable type exception because `value in self.truthy`.
so add defense code. thank you.