### PR TITLE
Propagate `unknown` when an explicit flag is set, in the form `unknown=...|PROPAGATE`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,24 +8,16 @@ Features:
 
 - The behavior of the ``unknown`` option can be further customized with a new
   value, ``PROPAGATE``. If ``unknown=EXCLUDE | PROPAGATE`` is set, then the
-  value of ``unknown=EXCLUDE | PROPAGATE`` will be passed to any nested
-  schemas which do not explicitly set ``unknown`` in ``Nested`` or schema
-  options. This works for ``INCLUDE | PROPAGATE`` and ``RAISE | PROPAGATE`` as
-  well.
+  value of ``unknown=EXCLUDE | PROPAGATE`` will be passed to any nested schemas.
+  This works for ``INCLUDE | PROPAGATE`` and ``RAISE | PROPAGATE`` as well.
   (:issue:`1490`, :issue:`1428`)
-  Thanks :user:`lmignon` and :user:`mahenzon`.
 
 .. note::
 
-  When a schema is being loaded with ``unknown=... | PROPAGATE``, you can still
-  set ``unknown`` explicitly on child schemas. However, be aware that such a
-  value may turn off propagation at that point in the schema hierarchy.
-
-  For example, a schema which specifies ``unknown=EXCLUDE`` will set
-  ``EXCLUDE`` for itself. But because the value is ``EXCLUDE`` rather than
-  ``EXCLUDE | PROPAGATE``, that setting will not be propagated to its
-  children, even if there is a parent schema which sets
-  ``unknown=EXCLUDE | PROPAGATE``.
+  When a schema is being loaded with ``unknown=... | PROPAGATE``, this will
+  override any values set for ``unknown`` in child schemas. Therefore,
+  ``PROPAGATE`` should only be used in cases in which you want to change
+  the behavior of an entire schema heirarchy.
 
 3.7.1 (2020-07-20)
 ******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,34 @@
 Changelog
 ---------
 
+3.8.0 (Unreleased)
+******************
+
+Features:
+
+- The behavior of the ``unknown`` option can be further customized with a
+  second option, ``propagate_unknown``. When set to ``True``, any nested
+  schemas will receive the same ``unknown`` value as their parent if they did
+  not set an ``unknown`` value explicitly.
+  ``propagate_unknown`` itself propagates across any number of layers of
+  nesting and cannot be disabled by a child schema if it enabled in its parent.
+  (:issue:`1490`, :issue:`1428`)
+  Thanks :user:`lmignon` and :user:`mahenzon`.
+
+.. note::
+
+  In order to retain flexibility, when a schema is being loaded with
+  ``propagate_unknown=True``, you can still set ``unknown`` explicitly on child
+  schemas. However, be aware that such a value will be propagated to any of its
+  descendants.
+
+  For example, a schema which specifies ``unknown=EXCLUDE`` will set
+  ``EXCLUDE`` in all of its children. If one of the children specifies
+  ``unknown=IGNORE``, then ``IGNORE`` will be passed to the relevant
+  grandchildren.
+  Other children of the original schema could specify ``unknown=RAISE``, and
+  this would apply to them equally well.
+
 3.7.1 (2020-07-20)
 ******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,28 +6,26 @@ Changelog
 
 Features:
 
-- The behavior of the ``unknown`` option can be further customized with a
-  second option, ``propagate_unknown``. When set to ``True``, any nested
-  schemas will receive the same ``unknown`` value as their parent if they did
-  not set an ``unknown`` value explicitly.
-  ``propagate_unknown`` itself propagates across any number of layers of
-  nesting and cannot be disabled by a child schema if it enabled in its parent.
+- The behavior of the ``unknown`` option can be further customized with a new
+  value, ``PROPAGATE``. If ``unknown=EXCLUDE | PROPAGATE`` is set, then the
+  value of ``unknown=EXCLUDE | PROPAGATE`` will be passed to any nested
+  schemas which do not explicitly set ``unknown`` in ``Nested`` or schema
+  options. This works for ``INCLUDE | PROPAGATE`` and ``RAISE | PROPAGATE`` as
+  well.
   (:issue:`1490`, :issue:`1428`)
   Thanks :user:`lmignon` and :user:`mahenzon`.
 
 .. note::
 
-  In order to retain flexibility, when a schema is being loaded with
-  ``propagate_unknown=True``, you can still set ``unknown`` explicitly on child
-  schemas. However, be aware that such a value will be propagated to any of its
-  descendants.
+  When a schema is being loaded with ``unknown=... | PROPAGATE``, you can still
+  set ``unknown`` explicitly on child schemas. However, be aware that such a
+  value may turn off propagation at that point in the schema hierarchy.
 
   For example, a schema which specifies ``unknown=EXCLUDE`` will set
-  ``EXCLUDE`` in all of its children. If one of the children specifies
-  ``unknown=IGNORE``, then ``IGNORE`` will be passed to the relevant
-  grandchildren.
-  Other children of the original schema could specify ``unknown=RAISE``, and
-  this would apply to them equally well.
+  ``EXCLUDE`` for itself. But because the value is ``EXCLUDE`` rather than
+  ``EXCLUDE | PROPAGATE``, that setting will not be propagated to its
+  children, even if there is a parent schema which sets
+  ``unknown=EXCLUDE | PROPAGATE``.
 
 3.7.1 (2020-07-20)
 ******************

--- a/src/marshmallow/__init__.py
+++ b/src/marshmallow/__init__.py
@@ -9,7 +9,7 @@ from marshmallow.decorators import (
     validates,
     validates_schema,
 )
-from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, pprint, missing
+from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, PROPAGATE, pprint, missing
 from marshmallow.exceptions import ValidationError
 from distutils.version import LooseVersion
 
@@ -19,6 +19,7 @@ __all__ = [
     "EXCLUDE",
     "INCLUDE",
     "RAISE",
+    "PROPAGATE",
     "Schema",
     "SchemaOpts",
     "fields",

--- a/src/marshmallow/base.py
+++ b/src/marshmallow/base.py
@@ -39,24 +39,11 @@ class SchemaABC:
         raise NotImplementedError
 
     def load(
-        self,
-        data,
-        *,
-        many: bool = None,
-        partial=None,
-        unknown=None,
-        propagate_unknown=None
+        self, data, *, many: bool = None, partial=None, unknown=None
     ):
         raise NotImplementedError
 
     def loads(
-        self,
-        json_data,
-        *,
-        many: bool = None,
-        partial=None,
-        unknown=None,
-        propagate_unknown=None,
-        **kwargs
+        self, json_data, *, many: bool = None, partial=None, unknown=None, **kwargs
     ):
         raise NotImplementedError

--- a/src/marshmallow/base.py
+++ b/src/marshmallow/base.py
@@ -38,9 +38,7 @@ class SchemaABC:
     def dumps(self, obj, *, many: bool = None):
         raise NotImplementedError
 
-    def load(
-        self, data, *, many: bool = None, partial=None, unknown=None
-    ):
+    def load(self, data, *, many: bool = None, partial=None, unknown=None):
         raise NotImplementedError
 
     def loads(

--- a/src/marshmallow/base.py
+++ b/src/marshmallow/base.py
@@ -38,10 +38,25 @@ class SchemaABC:
     def dumps(self, obj, *, many: bool = None):
         raise NotImplementedError
 
-    def load(self, data, *, many: bool = None, partial=None, unknown=None):
+    def load(
+        self,
+        data,
+        *,
+        many: bool = None,
+        partial=None,
+        unknown=None,
+        propagate_unknown=None
+    ):
         raise NotImplementedError
 
     def loads(
-        self, json_data, *, many: bool = None, partial=None, unknown=None, **kwargs
+        self,
+        json_data,
+        *,
+        many: bool = None,
+        partial=None,
+        unknown=None,
+        propagate_unknown=None,
+        **kwargs
     ):
         raise NotImplementedError

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -571,16 +571,18 @@ class Nested(Field):
         if many and not utils.is_collection(value):
             raise self.make_error("type", input=value, type=value.__class__.__name__)
 
-    def _load(self, value, data, partial=None):
+    def _load(self, value, data, partial=None, unknown=None):
         try:
-            valid_data = self.schema.load(value, unknown=self.unknown, partial=partial)
+            valid_data = self.schema.load(
+                value, unknown=unknown or self.unknown, partial=partial,
+            )
         except ValidationError as error:
             raise ValidationError(
                 error.messages, valid_data=error.valid_data
             ) from error
         return valid_data
 
-    def _deserialize(self, value, attr, data, partial=None, **kwargs):
+    def _deserialize(self, value, attr, data, partial=None, unknown=None, **kwargs):
         """Same as :meth:`Field._deserialize` with additional ``partial`` argument.
 
         :param bool|tuple partial: For nested schemas, the ``partial``
@@ -590,7 +592,7 @@ class Nested(Field):
             Add ``partial`` parameter.
         """
         self._test_collection(value)
-        return self._load(value, data, partial=partial)
+        return self._load(value, data, partial=partial, unknown=unknown)
 
 
 class Pluck(Nested):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -494,7 +494,7 @@ class Nested(Field):
         self.only = only
         self.exclude = exclude
         self.many = many
-        self.unknown = UnknownParam.parse_if_str(unknown) if unknown else None
+        self.unknown = UnknownParam.parse_if_str(unknown)
         self._schema = None  # Cached Schema instance
         super().__init__(default=default, **kwargs)
 
@@ -575,7 +575,7 @@ class Nested(Field):
     def _load(self, value, data, partial=None, unknown=None):
         try:
             valid_data = self.schema.load(
-                value, unknown=unknown if unknown else self.unknown, partial=partial,
+                value, unknown=unknown or self.unknown, partial=partial,
             )
         except ValidationError as error:
             raise ValidationError(
@@ -593,18 +593,7 @@ class Nested(Field):
             Add ``partial`` parameter.
         """
         self._test_collection(value)
-        # check if self.unknown or self.schema.unknown is set
-        # however, we should only respect `self.schema.unknown` if
-        # `auto_unknown` is False, meaning that it was set explicitly on the
-        # schema class or instance
-        explicit_unknown = (
-            self.unknown
-            if self.unknown
-            else (self.schema.unknown if not self.schema.auto_unknown else None)
-        )
-        if explicit_unknown:
-            unknown = explicit_unknown
-        return self._load(value, data, partial=partial, unknown=unknown,)
+        return self._load(value, data, partial=partial, unknown=unknown)
 
 
 class Pluck(Nested):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -459,6 +459,10 @@ class Nested(Field):
     :param many: Whether the field is a collection of objects.
     :param unknown: Whether to exclude, include, or raise an error for unknown
         fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
+    :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+        applied to any ``Nested`` fields within the nested schema. Propagates down and allows
+        ``Nested`` fields to apply their own ``unknown`` value. Note that this
+        only has an effect when there are multiple layers of nesting
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -608,6 +608,15 @@ class Nested(Field):
             Add ``partial`` parameter.
         """
         self._test_collection(value)
+        # check if self.unknown or self.schema.unknown is set
+        # however, we should only respect `self.schema.unknown` if
+        # `auto_unknown` is False, meaning that it was set explicitly on the
+        # schema class or instance
+        explicit_unknown = self.unknown or (
+            self.schema.unknown if not self.schema.auto_unknown else None
+        )
+        if explicit_unknown:
+            unknown = explicit_unknown
         return self._load(
             value,
             data,

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -287,6 +287,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         will be ignored. Use dot delimiters to specify nested fields.
     :param unknown: Whether to exclude, include, or raise an error for unknown
         fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
+    :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+        applied to all ``Nested`` fields. Propagates down and allows
+        ``Nested`` fields to apply their own ``unknown`` value
 
     .. versionchanged:: 3.0.0
         `prefix` parameter removed.
@@ -364,6 +367,10 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         - ``dump_only``: Tuple or list of fields to exclude from deserialization
         - ``unknown``: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
+        - ``propagate_unknown`` If ``True``, the value for ``unknown`` will be
+           applied to all ``Nested`` fields. Propagates down, but if a ``Nested``
+           field sets ``unknown``, it will begin to propagate that value, not the
+           where this is set.
         - ``register``: Whether to register the `Schema` with marshmallow's internal
             class registry. Must be `True` if you intend to refer to this `Schema`
             by class name in `Nested` fields. Only set this to `False` when memory
@@ -619,6 +626,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             will be ignored. Use dot delimiters to specify nested fields.
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
+        :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+            applied to all ``Nested`` fields. Propagates down and allows
+            ``Nested`` fields to apply their own ``unknown`` value
         :param int index: Index of the item being serialized (for storing errors) if
             serializing a collection, otherwise `None`.
         :return: A dictionary of the deserialized data.
@@ -733,6 +743,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
             If `None`, the value for `self.unknown` is used.
+        :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+            applied to all ``Nested`` fields. Propagates down and allows
+            ``Nested`` fields to apply their own ``unknown`` value
         :return: Deserialized data
 
         .. versionadded:: 1.0.0
@@ -772,6 +785,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
             If `None`, the value for `self.unknown` is used.
+        :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+            applied to all ``Nested`` fields. Propagates down and allows
+            ``Nested`` fields to apply their own ``unknown`` value
         :return: Deserialized data
 
         .. versionadded:: 1.0.0
@@ -864,6 +880,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param unknown: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
             If `None`, the value for `self.unknown` is used.
+        :param propagate_unknown: If ``True``, the value for ``unknown`` will be
+            applied to all ``Nested`` fields. Propagates down and allows
+            ``Nested`` fields to apply their own ``unknown`` value
         :param postprocess: Whether to run post_load methods..
         :return: Deserialized data
         """

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -659,6 +659,13 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     d_kwargs["partial"] = sub_partial
                 else:
                     d_kwargs["partial"] = partial
+
+                try:
+                    if self.context["propagate_unknown_to_nested"]:
+                        d_kwargs["unknown"] = unknown
+                except KeyError:
+                    pass
+
                 getter = lambda val: field_obj.deserialize(
                     val, field_name, data, **d_kwargs
                 )
@@ -836,6 +843,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         error_store = ErrorStore()
         errors = {}  # type: typing.Dict[str, typing.List[str]]
         many = self.many if many is None else bool(many)
+        self.context["propagate_unknown_to_nested"] = unknown is not None
         unknown = unknown or self.unknown
         if partial is None:
             partial = self.partial

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -1,7 +1,7 @@
 """Utility methods for marshmallow."""
 import collections
-import functools
 import datetime as dt
+import functools
 import inspect
 import json
 import re
@@ -15,9 +15,52 @@ from marshmallow.base import FieldABC
 from marshmallow.exceptions import FieldInstanceResolutionError
 from marshmallow.warnings import RemovedInMarshmallow4Warning
 
-EXCLUDE = "exclude"
-INCLUDE = "include"
-RAISE = "raise"
+
+class UnknownParam:
+    good_values = ("exclude", "include", "raise")
+
+    def __init__(self, stringval=None, *, value=None, propagate=None):
+        self.value = value
+        self.propagate = propagate
+
+        if stringval:
+            for x in stringval.lower().split("|"):
+                x = x.strip()
+                if x in self.good_values and not self.value:
+                    self.value = x
+                if x == "propagate":
+                    self.propagate = True
+
+    def __or__(self, other):
+        return UnknownParam(
+            value=self.value or other.value, propagate=self.propagate or other.propagate
+        )
+
+    def __str__(self):
+        parts = [self.value] if self.value else []
+        if self.propagate:
+            parts.append("propagate")
+        if self.value or self.propagate:
+            return "|".join(parts)
+        return "null"
+
+    def __repr__(self):
+        return "UnknownParam(value={!r}, propagate={!r})".format(
+            self.value, self.propagate
+        )
+
+    @classmethod
+    def parse_if_str(cls, value):
+        """Given a string or UnknownParam, convert to an UnknownParam"""
+        if isinstance(value, str):
+            return cls(value)
+        return value
+
+
+EXCLUDE = UnknownParam("exclude")
+INCLUDE = UnknownParam("include")
+RAISE = UnknownParam("raise")
+PROPAGATE = UnknownParam("propagate")
 
 
 class _Missing:
@@ -41,8 +84,7 @@ missing = _Missing()
 
 
 def is_generator(obj) -> bool:
-    """Return True if ``obj`` is a generator
-    """
+    """Return True if ``obj`` is a generator"""
     return inspect.isgeneratorfunction(obj) or inspect.isgenerator(obj)
 
 
@@ -279,8 +321,7 @@ def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any):
 
 
 def callable_or_raise(obj):
-    """Check that an object is callable, else raise a :exc:`ValueError`.
-    """
+    """Check that an object is callable, else raise a :exc:`ValueError`."""
     if not callable(obj):
         raise ValueError("Object {!r} is not callable.".format(obj))
     return obj

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -51,7 +51,10 @@ class UnknownParam:
 
     @classmethod
     def parse_if_str(cls, value):
-        """Given a string or UnknownParam, convert to an UnknownParam"""
+        """Given a string or UnknownParam, convert to an UnknownParam
+
+        Preserves None, which is important for making sure that it can be used
+        blindly on `unknown` which may be a user-supplied value or a default"""
         if isinstance(value, str):
             return cls(value)
         return value

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,7 @@ from marshmallow import (
     ValidationError,
     EXCLUDE,
     INCLUDE,
+    PROPAGATE,
     RAISE,
     missing,
 )
@@ -317,10 +318,11 @@ class TestNestedFieldPropagatesUnknown:
     @pytest.mark.parametrize(
         "schema_kwargs,load_kwargs",
         [
-            ({}, {"propagate_unknown": True, "unknown": INCLUDE}),
-            ({"propagate_unknown": True}, {"unknown": INCLUDE}),
-            ({"propagate_unknown": True, "unknown": INCLUDE}, {}),
-            ({"unknown": INCLUDE}, {"propagate_unknown": True}),
+            ({}, {"unknown": INCLUDE | PROPAGATE}),
+            ({}, {"unknown": "INCLUDE | PROPAGATE"}),
+            ({"unknown": RAISE}, {"unknown": INCLUDE | PROPAGATE}),
+            ({"unknown": RAISE}, {"unknown": "include|propagate"}),
+            ({"unknown": INCLUDE | PROPAGATE}, {}),
         ],
     )
     def test_propagate_unknown_include(
@@ -344,10 +346,11 @@ class TestNestedFieldPropagatesUnknown:
     @pytest.mark.parametrize(
         "schema_kwargs,load_kwargs",
         [
-            ({}, {"propagate_unknown": True, "unknown": EXCLUDE}),
-            ({"propagate_unknown": True}, {"unknown": EXCLUDE}),
-            ({"propagate_unknown": True, "unknown": EXCLUDE}, {}),
-            ({"unknown": EXCLUDE}, {"propagate_unknown": True}),
+            ({}, {"unknown": EXCLUDE | PROPAGATE}),
+            ({}, {"unknown": "exclude | propagate"}),
+            ({"unknown": RAISE}, {"unknown": EXCLUDE | PROPAGATE}),
+            ({"unknown": PROPAGATE | EXCLUDE}, {}),
+            ({"unknown": "propagate|exclude"}, {}),
         ],
     )
     def test_propagate_unknown_exclude(

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -308,56 +308,70 @@ class TestNestedFieldPropagatesUnknown:
 
     @pytest.fixture
     def data_nested_unknown(self):
-        return {
-            "spam": {"meat": "pork", "add-on": "eggs"},
-        }
+        return {"spam": {"meat": "pork", "add-on": "eggs"}}
 
     @pytest.fixture
     def multi_nested_data_with_unknown(self, data_nested_unknown):
-        return {
-            "can": data_nested_unknown,
+        return {"can": data_nested_unknown, "box": {"foo": "bar"}}
+
+    @pytest.mark.parametrize(
+        "schema_kwargs,load_kwargs",
+        [
+            ({}, {"propagate_unknown": True, "unknown": INCLUDE}),
+            ({"propagate_unknown": True}, {"unknown": INCLUDE}),
+            ({"propagate_unknown": True, "unknown": INCLUDE}, {}),
+            ({"unknown": INCLUDE}, {"propagate_unknown": True}),
+        ],
+    )
+    def test_propagate_unknown_include(
+        self,
+        schema_kwargs,
+        load_kwargs,
+        data_nested_unknown,
+        multi_nested_data_with_unknown,
+    ):
+        data = self.ShelfSchema(**schema_kwargs).load(
+            multi_nested_data_with_unknown, **load_kwargs
+        )
+        assert data == {
+            "can": {"spam": {"meat": "pork", "add-on": "eggs"}},
             "box": {"foo": "bar"},
         }
 
+        data = self.CanSchema(**schema_kwargs).load(data_nested_unknown, **load_kwargs)
+        assert data == {"spam": {"meat": "pork", "add-on": "eggs"}}
+
+    @pytest.mark.parametrize(
+        "schema_kwargs,load_kwargs",
+        [
+            ({}, {"propagate_unknown": True, "unknown": EXCLUDE}),
+            ({"propagate_unknown": True}, {"unknown": EXCLUDE}),
+            ({"propagate_unknown": True, "unknown": EXCLUDE}, {}),
+            ({"unknown": EXCLUDE}, {"propagate_unknown": True}),
+        ],
+    )
+    def test_propagate_unknown_exclude(
+        self,
+        schema_kwargs,
+        load_kwargs,
+        data_nested_unknown,
+        multi_nested_data_with_unknown,
+    ):
+        data = self.ShelfSchema(**schema_kwargs).load(
+            multi_nested_data_with_unknown, **load_kwargs
+        )
+        assert data == {"can": {"spam": {"meat": "pork"}}}
+
+        data = self.CanSchema(**schema_kwargs).load(data_nested_unknown, **load_kwargs)
+        assert data == {"spam": {"meat": "pork"}}
+
     @pytest.mark.parametrize("schema_kw", ({}, {"unknown": INCLUDE}))
     def test_raises_when_unknown_passed_to_first_level_nested(
-        self, schema_kw, data_nested_unknown,
+        self, schema_kw, data_nested_unknown
     ):
         with pytest.raises(ValidationError) as exc_info:
             self.CanSchema(**schema_kw).load(data_nested_unknown)
         assert exc_info.value.messages == {"spam": {"add-on": ["Unknown field."]}}
-
-    @pytest.mark.parametrize(
-        "load_kw,expected_data",
-        (
-            ({"unknown": INCLUDE}, {"spam": {"meat": "pork", "add-on": "eggs"}}),
-            ({"unknown": EXCLUDE}, {"spam": {"meat": "pork"}}),
-        ),
-    )
-    def test_processes_when_unknown_stated_directly(
-        self, load_kw, data_nested_unknown, expected_data,
-    ):
-        data = self.CanSchema().load(data_nested_unknown, **load_kw)
-        assert data == expected_data
-
-    @pytest.mark.parametrize(
-        "load_kw,expected_data",
-        (
-            (
-                {"unknown": INCLUDE},
-                {
-                    "can": {"spam": {"meat": "pork", "add-on": "eggs"}},
-                    "box": {"foo": "bar"},
-                },
-            ),
-            ({"unknown": EXCLUDE}, {"can": {"spam": {"meat": "pork"}}}),
-        ),
-    )
-    def test_propagates_unknown_to_multi_nested_fields(
-        self, load_kw, expected_data, multi_nested_data_with_unknown,
-    ):
-        data = self.ShelfSchema().load(multi_nested_data_with_unknown, **load_kw)
-        assert data == expected_data
 
 
 class TestListNested:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -296,6 +296,70 @@ class TestNestedField:
         }
 
 
+class TestNestedFieldPropagatesUnknown:
+    class SpamSchema(Schema):
+        meat = fields.String()
+
+    class CanSchema(Schema):
+        spam = fields.Nested("SpamSchema")
+
+    class ShelfSchema(Schema):
+        can = fields.Nested("CanSchema")
+
+    @pytest.fixture
+    def data_nested_unknown(self):
+        return {
+            "spam": {"meat": "pork", "add-on": "eggs"},
+        }
+
+    @pytest.fixture
+    def multi_nested_data_with_unknown(self, data_nested_unknown):
+        return {
+            "can": data_nested_unknown,
+            "box": {"foo": "bar"},
+        }
+
+    @pytest.mark.parametrize("schema_kw", ({}, {"unknown": INCLUDE}))
+    def test_raises_when_unknown_passed_to_first_level_nested(
+        self, schema_kw, data_nested_unknown,
+    ):
+        with pytest.raises(ValidationError) as exc_info:
+            self.CanSchema(**schema_kw).load(data_nested_unknown)
+        assert exc_info.value.messages == {"spam": {"add-on": ["Unknown field."]}}
+
+    @pytest.mark.parametrize(
+        "load_kw,expected_data",
+        (
+            ({"unknown": INCLUDE}, {"spam": {"meat": "pork", "add-on": "eggs"}}),
+            ({"unknown": EXCLUDE}, {"spam": {"meat": "pork"}}),
+        ),
+    )
+    def test_processes_when_unknown_stated_directly(
+        self, load_kw, data_nested_unknown, expected_data,
+    ):
+        data = self.CanSchema().load(data_nested_unknown, **load_kw)
+        assert data == expected_data
+
+    @pytest.mark.parametrize(
+        "load_kw,expected_data",
+        (
+            (
+                {"unknown": INCLUDE},
+                {
+                    "can": {"spam": {"meat": "pork", "add-on": "eggs"}},
+                    "box": {"foo": "bar"},
+                },
+            ),
+            ({"unknown": EXCLUDE}, {"can": {"spam": {"meat": "pork"}}}),
+        ),
+    )
+    def test_propagates_unknown_to_multi_nested_fields(
+        self, load_kw, expected_data, multi_nested_data_with_unknown,
+    ):
+        data = self.ShelfSchema().load(multi_nested_data_with_unknown, **load_kw)
+        assert data == expected_data
+
+
 class TestListNested:
     @pytest.mark.parametrize("param", ("only", "exclude", "dump_only", "load_only"))
     def test_list_nested_only_exclude_dump_only_load_only_propagated_to_nested(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2904,12 +2904,11 @@ def test_class_registry_returns_schema_type():
     assert SchemaClass is DefinitelyUniqueSchema
 
 
-def test_propagate_unknown_stops_at_explicit_value_for_nested():
-    # PROPAGATE should traverse any "auto_unknown" values and
-    # replace them with the "unknown" value from the parent context (schema or
-    # load arguments)
-    # this test makes sure that it stops when a nested field or schema has
-    # "unknown" set explicitly (so auto_unknown=False)
+def test_propagate_unknown_overrides_explicit_value_for_nested():
+    # PROPAGATE should traverse any schemas and replace them with the
+    # "unknown" value from the parent context (schema or load arguments)
+    # this test makes sure that it takes precedence when a nested field
+    # or schema has "unknown" set explicitly
 
     class Bottom(Schema):
         x = fields.Str()
@@ -2933,14 +2932,13 @@ def test_propagate_unknown_stops_at_explicit_value_for_nested():
     assert result == {
         "x": "hi",
         "y": "bye",
-        "child": {"x": "hi", "y": "bye", "child": {"x": "hi"}},
+        "child": {"x": "hi", "y": "bye", "child": {"x": "hi", "y": "bye"}},
     }
 
 
-def test_propagate_unknown_stops_at_explicit_value_for_meta():
-    # this is the same as the above test of unknown propagation stopping where
-    # auto_unknown=False, but it checks that this applies when `unknown` is set
-    # by means of `Meta`
+def test_propagate_unknown_overrides_explicit_value_for_meta():
+    # this is the same as the above test of unknown propagation, but it checks that
+    # this applies when `unknown` is set by means of `Meta` as well
 
     class Bottom(Schema):
         x = fields.Str()
@@ -2949,20 +2947,12 @@ def test_propagate_unknown_stops_at_explicit_value_for_meta():
         x = fields.Str()
         child = fields.Nested(Bottom)
 
-        # set unknown explicitly here, so auto_unknown will be
-        # false going into Bottom, and also set propagate to make it propagate
-        # in this case
         class Meta:
-            unknown = EXCLUDE | PROPAGATE
+            unknown = EXCLUDE
 
     class Top(Schema):
         x = fields.Str()
         child = fields.Nested(Middle)
-
-    # sanity-check that auto-unknown is being set correctly
-    assert Top().auto_unknown
-    assert not Top(unknown=INCLUDE | PROPAGATE).auto_unknown
-    assert not Middle().auto_unknown
 
     data = {
         "x": "hi",
@@ -2970,4 +2960,8 @@ def test_propagate_unknown_stops_at_explicit_value_for_meta():
         "child": {"x": "hi", "y": "bye", "child": {"x": "hi", "y": "bye"}},
     }
     result = Top(unknown=INCLUDE | PROPAGATE).load(data)
-    assert result == {"x": "hi", "y": "bye", "child": {"x": "hi", "child": {"x": "hi"}}}
+    assert result == {
+        "x": "hi",
+        "y": "bye",
+        "child": {"x": "hi", "y": "bye", "child": {"x": "hi", "y": "bye"}},
+    }


### PR DESCRIPTION
This is based upon the work in #1490 , but with some significant modifications.
In retrospect, it might have been simpler to base it on #1429 , or just do the work from scratch, but I'm not sure.
closes #1428, #1429, #1490, and #1575

The biggest change from #1490 or #1429 I've made is that the behavior is never implied by certain usages -- it's always explicit. There's no distinction between `unknown` being passed at load time, to `Nested`, at schema instantiation, or via schema options. Instead, all of these contexts will support `propagate_unknown=True`, which turns on propagation.
This approach might not be all that elegant -- it somewhat bloats the public interface -- but it is guaranteed to be backwards compatible. Because the behavior is opt-in, nobody should have behavior change on them unexpectedly with this update.

Quick note: I wasn't sure if it is desirable to allow `propagate_unknown` in all of these contexts, especially `Nested`. I included it for now, but would be open to removing it.

`propagate_unknown` as written does not respect setting `propagate_unknown=False` in a nested schema. It's not something I considered particularly important (since the whole point is to "turn the feature on") but I can look at tweaking that if it's likely to be confusing.

One important bit of this is that I wanted `propagate_unknown` to understand the difference between `unknown=RAISE` being set because it's the default, and someone writing `fields.Nested(MySchema(unknown=RAISE))`, in which case they're asking for it explicitly. To handle this, `__init__` checks before setting `unknown`. If no value was passed, in addition to setting `unknown=RAISE`, it will set a new value, `auto_unknown=True`.
During loading, whenever `propagate_unknown=True` and `auto_unknown=False`, the `unknown` value for the nested schema in question will be respected. Furthermore, that value will start to propagate. The same happens, though without use of `auto_unknown`, wherever `fields.Nested.unknown` is set.

Reading [this comment on #1429](https://github.com/marshmallow-code/marshmallow/pull/1429#issuecomment-558815824), my understanding was that handling these kinds of scenarios was considered to be necessary. With the `auto_unknown` tracking and behavior, it's possible to support cases like this one:
```python
class D(Schema):
    x = fields.Str()
class C(Schema):
    x = fields.Str()
class B(Schema):
    d = fields.Nested(D(unknown=EXCLUDE))
    c = fields.Nested(C)
class A(Schema):
    b1 = fields.Nested(B(unknown=INCLUDE))
    b2 = fields.Nested(B())

A(propagate_unknown=True, unknown=RAISE).load(...)
```

In the above, everything should "percolate down" in a relatively intuitive way. Importantly, that top-level value for `unknown=RAISE` doesn't override the use of `unknown=INCLUDE` and `unknown=EXCLUDE` in descendant schemas.

I've added a few simple tests, but I haven't aimed to be completely comprehensive because there are too many scenarios to think about. It's hard to tell what's important to test this way and what is not. If there's something I ought to be testing which is missing, just say that word and I'm happy to add more test cases.

---

This is my first time touching `marshmallow`, and I'm changing the interfaces for `Schema`, `fields.Nested`, and schema opts. So I would not be at all surprised if I've missed something significant -- please just let me know if so.