### PR TITLE
Add fields.Iterable as a base class for collection field types

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -152,3 +152,4 @@ Contributors (chronological)
 - `@weeix <https://github.com/weeix>`_
 - Juan Norris `@juannorris <https://github.com/juannorris>`_
 - 장준영 `@jun0jang <https://github.com/jun0jang>`_
+- Kevin Fong `@Fongshway <https://github.com/Fongshway>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.8.0 (Unreleased)
+******************
+
+Features:
+
+- Add fields.Iterable as a base class for collection field types (:issue:`1263`).
+  Thanks :user:`Fongshway` for the PR.
+
 3.7.1 (2020-07-20)
 ******************
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    "tests": ["pytest", "pytz", "simplejson"],
+    "tests": ["pytest", "pytz", "simplejson", "typing-extensions"],
     "lint": [
         "mypy==0.910",
         "flake8==3.9.2",
@@ -15,6 +15,7 @@ EXTRAS_REQUIRE = {
         "alabaster==0.7.12",
         "sphinx-version-warning==1.1.2",
         "autodocsumm==0.2.6",
+        "typing-extensions==3.10.0.0",
     ],
 }
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -681,8 +681,8 @@ class Iterable(Field):
     .. versionadded:: 3.12.0
     """
 
-    serialization_type = list
-    deserialization_type = list
+    serialization_type: typing.Type[typing.Iterable] = list
+    deserialization_type: typing.Type[typing.Iterable] = list
 
     #: Default error messages.
     default_error_messages = {
@@ -712,17 +712,17 @@ class Iterable(Field):
 
     def _serialize(
         self, value, attr, obj, **kwargs
-    ) -> typing.Optional[typing.List[typing.Any]]:
+    ) -> typing.Optional[typing.Iterable[typing.Any]]:
         if value is None:
             return None
         result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
         return (
             result
             if self.serialization_type is list
-            else self.serialization_type(result)
+            else self.serialization_type(result)  # type: ignore
         )
 
-    def _deserialize(self, value, attr, data, **kwargs) -> typing.List[typing.Any]:
+    def _deserialize(self, value, attr, data, **kwargs) -> typing.Iterable[typing.Any]:
         if not utils.is_collection(value):
             raise self.make_error("invalid")
 
@@ -740,7 +740,7 @@ class Iterable(Field):
         return (
             result
             if self.deserialization_type is list
-            else self.deserialization_type(result)
+            else self.deserialization_type(result)  # type: ignore
         )
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -69,6 +69,12 @@ __all__ = [
 ]
 
 _T = typing.TypeVar("_T")
+IterableType = typing.Union[
+    typing.Type[typing.FrozenSet],
+    typing.Type[typing.List],
+    typing.Type[typing.Set],
+    typing.Type[typing.Tuple],
+]
 
 
 class Field(FieldABC):
@@ -666,8 +672,8 @@ class Iterable(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid iterable."}
 
-    serialization_type = list  # type: typing.Type[typing.Iterable[typing.Any]]
-    deserialization_type = list  # type: typing.Type[typing.Iterable[typing.Any]]
+    serialization_type = list  # type: IterableType
+    deserialization_type = list  # type: IterableType
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)
@@ -698,7 +704,7 @@ class Iterable(Field):
         result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
         if self.serialization_type is list:
             return result
-        return self.serialization_type(result)  # type: ignore
+        return self.serialization_type(result)
 
     def _deserialize(self, value, attr, data, **kwargs) -> typing.Iterable[typing.Any]:
         if not utils.is_collection(value):
@@ -717,7 +723,7 @@ class Iterable(Field):
             raise ValidationError(errors, valid_data=result)
         if self.deserialization_type is list:
             return result
-        return self.deserialization_type(result)  # type: ignore
+        return self.deserialization_type(result)
 
 
 class List(Iterable):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -11,6 +11,7 @@ import math
 import typing
 import warnings
 from collections.abc import Mapping as _Mapping
+from typing_extensions import Protocol
 
 from marshmallow import validate, utils, class_registry, types
 from marshmallow.base import FieldABC, SchemaABC
@@ -69,12 +70,6 @@ __all__ = [
 ]
 
 _T = typing.TypeVar("_T")
-IterableType = typing.Union[
-    typing.Type[typing.FrozenSet],
-    typing.Type[typing.List],
-    typing.Type[typing.Set],
-    typing.Type[typing.Tuple],
-]
 
 
 class Field(FieldABC):
@@ -654,6 +649,16 @@ class Pluck(Nested):
         return self._load(value, data, partial=partial)
 
 
+class _SerializationType(Protocol):
+    def __call__(self, value: typing.List) -> typing.Iterable:
+        pass
+
+
+class _DeserializationType(Protocol):
+    def __call__(self, value: typing.List) -> typing.Iterable:
+        pass
+
+
 class Iterable(Field):
     """An abstract class for iterables.
 
@@ -672,8 +677,8 @@ class Iterable(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid iterable."}
 
-    serialization_type = list  # type: IterableType
-    deserialization_type = list  # type: IterableType
+    serialization_type = list  # type: typing.ClassVar[_SerializationType]
+    deserialization_type = list  # type: typing.ClassVar[_DeserializationType]
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -675,16 +675,18 @@ class Iterable(Field):
     Example: ::
 
         class FrozenSet(Iterable):
-            iterable_type = frozenset
+            serialization_type = frozenset
+            deserialization_type = frozenset
 
     .. versionadded:: 3.12.0
     """
 
-    iterable_type = list
+    serialization_type = list
+    deserialization_type = list
 
     #: Default error messages.
     default_error_messages = {
-        "invalid": "Not a valid {}.".format(iterable_type.__name__)
+        "invalid": "Not a valid {}.".format(deserialization_type.__name__)
     }
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
@@ -714,7 +716,11 @@ class Iterable(Field):
         if value is None:
             return None
         result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
-        return result if self.iterable_type == list else self.iterable_type(result)
+        return (
+            result
+            if self.serialization_type is list
+            else self.serialization_type(result)
+        )
 
     def _deserialize(self, value, attr, data, **kwargs) -> typing.List[typing.Any]:
         if not utils.is_collection(value):
@@ -731,7 +737,11 @@ class Iterable(Field):
                 errors.update({idx: error.messages})
         if errors:
             raise ValidationError(errors, valid_data=result)
-        return result if self.iterable_type == list else self.iterable_type(result)
+        return (
+            result
+            if self.deserialization_type is list
+            else self.deserialization_type(result)
+        )
 
 
 class List(Iterable):
@@ -756,7 +766,8 @@ class List(Iterable):
         Inherits from Iterable instead of Field.
     """
 
-    iterable_type = list
+    serialization_type = list
+    deserialization_type = list
 
 
 class Tuple(Field):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -661,7 +661,7 @@ class Iterable(Field):
         class FrozenSet(Iterable):
             iterable_type = frozenset
 
-    .. versionadded:: 3.X.Y
+    .. versionadded:: 3.8.0
     """
 
     iterable_type = list
@@ -735,7 +735,7 @@ class List(Iterable):
     .. versionchanged:: 3.0.0rc9
         Does not serialize scalar values to single-item lists.
 
-    .. versionchanged:: 3.X.Y
+    .. versionchanged:: 3.8.0
         Inherits from Iterable instead of Field.
     """
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -684,8 +684,8 @@ class Iterable(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid iterable."}
 
-    serialization_type: typing.Type[typing.Iterable[typing.Any]] = list
-    deserialization_type: typing.Type[typing.Iterable[typing.Any]] = list
+    serialization_type = list  # type: typing.Type[typing.Iterable[typing.Any]]
+    deserialization_type = list  # type: typing.Type[typing.Iterable[typing.Any]]
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -660,7 +660,7 @@ class Iterable(Field):
             serialization_type = frozenset
             deserialization_type = frozenset
 
-    .. versionadded:: 3.12.0
+    .. versionadded:: 3.13.0
     """
 
     #: Default error messages.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -681,9 +681,6 @@ class Iterable(Field):
     .. versionadded:: 3.12.0
     """
 
-    serialization_type: typing.Type[typing.Iterable] = list
-    deserialization_type: typing.Type[typing.Iterable] = list
-
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid iterable."}
 
@@ -714,11 +711,8 @@ class Iterable(Field):
         if value is None:
             return None
         result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
-        return (
-            result
-            if self.serialization_type is list
-            else self.serialization_type(result)  # type: ignore
-        )
+        serialization_type = getattr(self, "serialization_type", list)
+        return result if serialization_type is list else serialization_type(result)
 
     def _deserialize(self, value, attr, data, **kwargs) -> typing.Iterable[typing.Any]:
         if not utils.is_collection(value):
@@ -735,11 +729,8 @@ class Iterable(Field):
                 errors.update({idx: error.messages})
         if errors:
             raise ValidationError(errors, valid_data=result)
-        return (
-            result
-            if self.deserialization_type is list
-            else self.deserialization_type(result)  # type: ignore
-        )
+        deserialization_type = getattr(self, "deserialization_type", list)
+        return result if deserialization_type is list else deserialization_type(result)
 
 
 class List(Iterable):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -737,9 +737,6 @@ class List(Iterable):
 
     .. versionchanged:: 3.0.0rc9
         Does not serialize scalar values to single-item lists.
-
-    .. versionchanged:: 3.12.0
-        Inherits from Iterable instead of Field.
     """
 
     #: Default error messages.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -684,6 +684,9 @@ class Iterable(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid iterable."}
 
+    serialization_type: typing.Type[typing.Iterable[typing.Any]] = list
+    deserialization_type: typing.Type[typing.Iterable[typing.Any]] = list
+
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)
         try:
@@ -711,8 +714,9 @@ class Iterable(Field):
         if value is None:
             return None
         result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
-        serialization_type = getattr(self, "serialization_type", list)
-        return result if serialization_type is list else serialization_type(result)
+        if self.serialization_type is list:
+            return result
+        return self.serialization_type(result)  # type: ignore
 
     def _deserialize(self, value, attr, data, **kwargs) -> typing.Iterable[typing.Any]:
         if not utils.is_collection(value):
@@ -729,8 +733,9 @@ class Iterable(Field):
                 errors.update({idx: error.messages})
         if errors:
             raise ValidationError(errors, valid_data=result)
-        deserialization_type = getattr(self, "deserialization_type", list)
-        return result if deserialization_type is list else deserialization_type(result)
+        if self.deserialization_type is list:
+            return result
+        return self.deserialization_type(result)  # type: ignore
 
 
 class List(Iterable):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -677,7 +677,7 @@ class Iterable(Field):
         class FrozenSet(Iterable):
             iterable_type = frozenset
 
-    .. versionadded:: 3.8.0
+    .. versionadded:: 3.12.0
     """
 
     iterable_type = list
@@ -752,7 +752,7 @@ class List(Iterable):
     .. versionchanged:: 3.0.0rc9
         Does not serialize scalar values to single-item lists.
 
-    .. versionchanged:: 3.8.0
+    .. versionchanged:: 3.12.0
         Inherits from Iterable instead of Field.
     """
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -685,9 +685,7 @@ class Iterable(Field):
     deserialization_type: typing.Type[typing.Iterable] = list
 
     #: Default error messages.
-    default_error_messages = {
-        "invalid": "Not a valid {}.".format(deserialization_type.__name__)
-    }
+    default_error_messages = {"invalid": "Not a valid iterable."}
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)
@@ -765,6 +763,9 @@ class List(Iterable):
     .. versionchanged:: 3.12.0
         Inherits from Iterable instead of Field.
     """
+
+    #: Default error messages.
+    default_error_messages = {"invalid": "Not a valid list."}
 
     serialization_type = list
     deserialization_type = list

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -701,9 +701,8 @@ class Iterable(Field):
     ) -> typing.Optional[typing.List[typing.Any]]:
         if value is None:
             return None
-        return self.iterable_type(
-            self.inner._serialize(each, attr, obj, **kwargs) for each in value
-        )
+        result = [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
+        return result if self.iterable_type == list else self.iterable_type(result)
 
     def _deserialize(self, value, attr, data, **kwargs) -> typing.List[typing.Any]:
         if not utils.is_collection(value):
@@ -720,7 +719,7 @@ class Iterable(Field):
                 errors.update({idx: error.messages})
         if errors:
             raise ValidationError(errors, valid_data=result)
-        return self.iterable_type(result)
+        return result if self.iterable_type == list else self.iterable_type(result)
 
 
 class List(Iterable):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -667,7 +667,9 @@ class Iterable(Field):
     iterable_type = list
 
     #: Default error messages.
-    default_error_messages = {"invalid": f"Not a valid {iterable_type.__name__}."}
+    default_error_messages = {
+        "invalid": "Not a valid {}.".format(iterable_type.__name__)
+    }
 
     def __init__(self, cls_or_instance: typing.Union[Field, type], **kwargs):
         super().__init__(**kwargs)

--- a/tests/base.py
+++ b/tests/base.py
@@ -327,3 +327,9 @@ class mockjson:  # noqa
     @staticmethod
     def loads(val):
         return {"foo": 42}
+
+
+class FrozenSet(fields.Iterable):
+    serialization_type = frozenset
+    deserialization_type = frozenset
+    default_error_messages = {"invalid": "Not a valid frozenset."}

--- a/tests/frozenset_field.py
+++ b/tests/frozenset_field.py
@@ -1,0 +1,7 @@
+from marshmallow import fields
+
+
+class FrozenSet(fields.Iterable):
+    serialization_type = frozenset
+    deserialization_type = frozenset
+    default_error_messages = {"invalid": "Not a valid frozenset."}

--- a/tests/frozenset_field.py
+++ b/tests/frozenset_field.py
@@ -1,7 +1,0 @@
-from marshmallow import fields
-
-
-class FrozenSet(fields.Iterable):
-    serialization_type = frozenset
-    deserialization_type = frozenset
-    default_error_messages = {"invalid": "Not a valid frozenset."}

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -10,8 +10,13 @@ from marshmallow import EXCLUDE, INCLUDE, RAISE, fields, Schema, validate
 from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Equal
 
-from tests.base import assert_date_equal, assert_time_equal, central, ALL_FIELDS
-from tests.frozenset_field import FrozenSet
+from tests.base import (
+    assert_date_equal,
+    assert_time_equal,
+    central,
+    ALL_FIELDS,
+    FrozenSet,
+)
 
 
 class TestDeserializingNone:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -49,7 +49,24 @@ class TestDeserializingNone:
             field.deserialize([None])
 
 
+class FrozenSet(fields.Iterable):
+    serialization_type = frozenset
+    deserialization_type = frozenset
+
+
 class TestFieldDeserialization:
+    @pytest.mark.parametrize(
+        ("field_type", "value", "expected"),
+        [
+            (fields.String(), ["1", "2", "3"], frozenset(["1", "2", "3"])),
+            (fields.Integer(), ["1", 2, "3"], frozenset([1, 2, 3])),
+            (fields.Float(), [1, "2", 3.0], frozenset([1.0, 2.0, 3.0])),
+        ],
+    )
+    def test_frozenset_field_deserialization(self, field_type, value, expected):
+        field = FrozenSet(field_type)
+        assert field.deserialize(value) == expected
+
     def test_float_field_deserialization(self):
         field = fields.Float()
         assert math.isclose(field.deserialize("12.3"), 12.3)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -11,6 +11,7 @@ from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Equal
 
 from tests.base import assert_date_equal, assert_time_equal, central, ALL_FIELDS
+from tests.frozenset_field import FrozenSet
 
 
 class TestDeserializingNone:
@@ -47,12 +48,6 @@ class TestDeserializingNone:
         field = fields.List(fields.Nested(Schema(), allow_none=False))
         with pytest.raises(ValidationError):
             field.deserialize([None])
-
-
-class FrozenSet(fields.Iterable):
-    serialization_type = frozenset
-    deserialization_type = frozenset
-    default_error_messages = {"invalid": "Not a valid frozenset."}
 
 
 class TestFieldDeserialization:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -52,6 +52,7 @@ class TestDeserializingNone:
 class FrozenSet(fields.Iterable):
     serialization_type = frozenset
     deserialization_type = frozenset
+    default_error_messages = {"invalid": "Not a valid frozenset."}
 
 
 class TestFieldDeserialization:
@@ -66,6 +67,11 @@ class TestFieldDeserialization:
     def test_frozenset_field_deserialization(self, field_type, value, expected):
         field = FrozenSet(field_type)
         assert field.deserialize(value) == expected
+
+    def test_invalid_frozenset_field_deserialization(self):
+        field = FrozenSet(fields.String())
+        with pytest.raises(ValidationError, match="Not a valid frozenset."):
+            field.deserialize(100)
 
     def test_float_field_deserialization(self):
         field = fields.Float()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -97,6 +97,7 @@ class TestParentAndName:
     class MySchema(Schema):
         foo = fields.Field()
         bar = fields.List(fields.Str())
+        bat = fields.Iterable(fields.Str())
         baz = fields.Tuple([fields.Str(), fields.Int()])
         bax = fields.Mapping(fields.Str(), fields.Int())
 
@@ -124,6 +125,10 @@ class TestParentAndName:
     def test_list_field_inner_parent_and_name(self, schema):
         assert schema.fields["bar"].inner.parent == schema.fields["bar"]
         assert schema.fields["bar"].inner.name == "bar"
+
+    def test_iterable_field_inner_parent_and_name(self, schema):
+        assert schema.fields["bat"].inner.parent == schema.fields["bat"]
+        assert schema.fields["bat"].inner.name == "bat"
 
     def test_tuple_field_inner_parent_and_name(self, schema):
         for field in schema.fields["baz"].tuple_fields:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -34,7 +34,7 @@ class TestFieldSerialization:
     def user(self):
         return User("Foo", email="foo@bar.com", age=42)
 
-    def test_frozenset_field_deserialization(self, user):
+    def test_frozenset_field_serialization(self, user):
         field = FrozenSet(fields.String())
         user.aliases = ["bar", "baz", "bat"]
         assert field.serialize("aliases", user) == frozenset(user.aliases)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -28,10 +28,20 @@ class DateTimeIntegerTuple:
         self.dtime_int = dtime_int
 
 
+class FrozenSet(fields.Iterable):
+    serialization_type = frozenset
+    deserialization_type = frozenset
+
+
 class TestFieldSerialization:
     @pytest.fixture
     def user(self):
         return User("Foo", email="foo@bar.com", age=42)
+
+    def test_frozenset_field_deserialization(self, user):
+        field = FrozenSet(fields.String())
+        user.aliases = ["bar", "baz", "bat"]
+        assert field.serialize("aliases", user) == frozenset(user.aliases)
 
     @pytest.mark.parametrize(
         ("value", "expected"), [(42, float(42)), (0, float(0)), (None, None)]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,8 +10,7 @@ import pytest
 
 from marshmallow import Schema, fields, missing as missing_
 
-from tests.base import User, ALL_FIELDS, central
-from tests.frozenset_field import FrozenSet
+from tests.base import User, ALL_FIELDS, central, FrozenSet
 
 
 class DateTimeList:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,6 +11,7 @@ import pytest
 from marshmallow import Schema, fields, missing as missing_
 
 from tests.base import User, ALL_FIELDS, central
+from tests.frozenset_field import FrozenSet
 
 
 class DateTimeList:
@@ -26,11 +27,6 @@ class IntegerList:
 class DateTimeIntegerTuple:
     def __init__(self, dtime_int):
         self.dtime_int = dtime_int
-
-
-class FrozenSet(fields.Iterable):
-    serialization_type = frozenset
-    deserialization_type = frozenset
 
 
 class TestFieldSerialization:


### PR DESCRIPTION
Resolves https://github.com/marshmallow-code/marshmallow/issues/1263, based on what @deckar01 proposed in https://github.com/marshmallow-code/marshmallow/issues/1263#issuecomment-503755620. This PR also helps address https://github.com/marshmallow-code/marshmallow/issues/1549.

- `fields.List` is updated to inherent from `fields.Iterable`, since the majority of the `fields.List` code could be reused.
- Example of creating custom iterable field classes:

```python
from marshmallow import fields

class FrozenSet(fields.Iterable):
    iterable_type = frozenset

class ImmutableList(fields.Iterable):
    iterable_type = tuple

```
