### PR TITLE
Add format option for fields.Time

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1295,6 +1295,9 @@ class AwareDateTime(DateTime):
 class Time(Field):
     """ISO8601-formatted time string.
 
+    :param format: ISO8601 string format of the value. Can either be
+        ``"hh"``, ``"hh:mm"``, ``"hh:mm:ss"``, or ``"hh:mm:ss.sss"``.
+        If not specified, defaults to built-in ``isoformat`` de/serialization.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
@@ -1304,10 +1307,14 @@ class Time(Field):
         "format": '"{input}" cannot be formatted as a time.',
     }
 
+    def __init__(self, format: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self.format = format
+
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:
             return None
-        ret = value.isoformat()
+        ret = utils.to_iso_time(value, self.format)
         if value.microsecond:
             return ret[:15]
         return ret
@@ -1317,7 +1324,7 @@ class Time(Field):
         if not value:  # falsy values are invalid
             raise self.make_error("invalid")
         try:
-            return utils.from_iso_time(value)
+            return utils.from_iso_time(value, self.format)
         except (AttributeError, TypeError, ValueError) as error:
             raise self.make_error("invalid") from error
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1295,8 +1295,7 @@ class AwareDateTime(DateTime):
 class Time(Field):
     """ISO8601-formatted time string.
 
-    :param format: ISO8601 string format of the value. Can either be
-        ``"hh"``, ``"hh:mm"``, ``"hh:mm:ss"``, or ``"hh:mm:ss.sss"``.
+    :param format: ISO8601 strftime format of the value.
         If not specified, defaults to built-in ``isoformat`` de/serialization.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
@@ -1304,12 +1303,23 @@ class Time(Field):
     #: Default error messages.
     default_error_messages = {
         "invalid": "Not a valid time.",
+        "iso_format": "Not a valid ISO8601 format",
         "format": '"{input}" cannot be formatted as a time.',
     }
 
-    def __init__(self, format: str = "", **kwargs):
+    VALID_ISO_STRFTIME_FORMATS: typing.List[str] = [
+        "%H",
+        "%H:%M",
+        "%H:%M:%S",
+        "%H:%M:%S.%f",
+    ]
+
+    def __init__(self, format: typing.Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.format = format
+
+        if self.format and self.format not in Time.VALID_ISO_STRFTIME_FORMATS:
+            raise ValueError("Not a valid ISO8601 strftime format")
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -134,15 +134,24 @@ _iso8601_time_seconds_format = r"(?P<second>\d{1,2})"
 _iso8601_time_microseconds_format = r"(?P<microsecond>\d{1,6})"
 
 _iso8601_time_format_re = {
-    "hh": re.compile(fr"{_iso8601_time_hours_format}$"),
+    "hh": re.compile(r"{}$".format(_iso8601_time_hours_format)),
     "hh:mm": re.compile(
-        fr"{_iso8601_time_hours_format}:{_iso8601_time_minutes_format}$"
+        r"{}:{}$".format(_iso8601_time_hours_format, _iso8601_time_minutes_format,)
     ),
     "hh:mm:ss": re.compile(
-        fr"{_iso8601_time_hours_format}:{_iso8601_time_minutes_format}:{_iso8601_time_seconds_format}$"
+        r"{}:{}:{}$".format(
+            _iso8601_time_hours_format,
+            _iso8601_time_minutes_format,
+            _iso8601_time_seconds_format,
+        ),
     ),
     "hh:mm:ss.sss": re.compile(
-        fr"{_iso8601_time_hours_format}:{_iso8601_time_minutes_format}:{_iso8601_time_seconds_format}.{_iso8601_time_microseconds_format}$"
+        r"{}:{}:{}.{}$".format(
+            _iso8601_time_hours_format,
+            _iso8601_time_minutes_format,
+            _iso8601_time_seconds_format,
+            _iso8601_time_microseconds_format,
+        ),
     ),
 }  # type: typing.Dict[str, typing.Pattern]
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,40 +120,10 @@ _iso8601_datetime_re = re.compile(
 
 _iso8601_date_re = re.compile(r"(?P<year>\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$")
 
-_iso8601_time_default_re = re.compile(
+_iso8601_time_re = re.compile(
     r"(?P<hour>\d{1,2}):(?P<minute>\d{1,2})"
     r"(?::(?P<second>\d{1,2})(?:\.(?P<microsecond>\d{1,6})\d{0,6})?)?"
 )
-
-_iso8601_time_hours_format = r"(?P<hour>\d{1,2})"
-
-_iso8601_time_minutes_format = r"(?P<minute>\d{1,2})"
-
-_iso8601_time_seconds_format = r"(?P<second>\d{1,2})"
-
-_iso8601_time_microseconds_format = r"(?P<microsecond>\d{1,6})"
-
-_iso8601_time_format_re = {
-    "hh": re.compile(r"{}$".format(_iso8601_time_hours_format)),
-    "hh:mm": re.compile(
-        r"{}:{}$".format(_iso8601_time_hours_format, _iso8601_time_minutes_format,)
-    ),
-    "hh:mm:ss": re.compile(
-        r"{}:{}:{}$".format(
-            _iso8601_time_hours_format,
-            _iso8601_time_minutes_format,
-            _iso8601_time_seconds_format,
-        ),
-    ),
-    "hh:mm:ss.sss": re.compile(
-        r"{}:{}:{}.{}$".format(
-            _iso8601_time_hours_format,
-            _iso8601_time_minutes_format,
-            _iso8601_time_seconds_format,
-            _iso8601_time_microseconds_format,
-        ),
-    ),
-}  # type: typing.Dict[str, typing.Pattern]
 
 
 def get_fixed_timezone(offset: typing.Union[int, float, dt.timedelta]) -> dt.timezone:
@@ -191,22 +161,28 @@ def from_iso_datetime(value):
     return dt.datetime(**kw)
 
 
-def from_iso_time(value, format: str = ""):
+def from_iso_time(value, format: typing.Optional[str] = None):
     """Parse a string and return a datetime.time.
 
     This function doesn't support time zone offsets.
     """
-    regex_exp = _iso8601_time_format_re.get(format) or _iso8601_time_default_re
-    match = regex_exp.match(value)
+    invalid_format_value_error = ValueError("Not a valid ISO8601-formatted time string")
+
+    if format:
+        try:
+            return dt.datetime.strptime(value, format).time()
+        except ValueError:
+            raise invalid_format_value_error
+
+    match = _iso8601_time_re.match(value)
     if not match:
-        raise ValueError("Not a valid ISO8601-formatted time string")
+        raise invalid_format_value_error
 
     kw = {}  # type: typing.Dict[str, typing.Any]
     kw = match.groupdict()
-    if kw.get("microsecond"):
-        kw["microsecond"] = kw["microsecond"] and kw["microsecond"].ljust(6, "0")
+    kw["microsecond"] = kw["microsecond"] and kw["microsecond"].ljust(6, "0")
 
-    kw = {k: int(v) for k, v in kw.items() if v is not None}
+    kw = {k: int(v) for k, v in kw.items() if v is not None}  # type: ignore
     return dt.time(**kw)
 
 
@@ -231,21 +207,14 @@ def to_iso_date(date: dt.date) -> str:
     return dt.date.isoformat(date)
 
 
-def to_iso_time(time: dt.time, format: str = "") -> str:
+def to_iso_time(time: dt.time, format: typing.Optional[str] = None) -> str:
     """Return the ISO8601-formatted representation of a time object.
 
     :param time: The time.
     :param format: An ISO8601 time format string.
     """
     if format:
-        format_exp = {
-            "hh": "%H",
-            "hh:mm": "%H:%M",
-            "hh:mm:ss": "%H:%M:%S",
-            "hh:mm:ss.sss": "%H:%M:%S.%f",
-        }.get(format)
-        if format_exp:
-            return time.strftime(format_exp)
+        return time.strftime(format)
 
     return time.isoformat()
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -581,6 +581,26 @@ class TestFieldDeserialization:
         result2 = field.deserialize(t2_formatted)
         assert_time_equal(result2, t2)
 
+    @pytest.mark.parametrize(
+        ("format", "input", "expected"),
+        [
+            ("hh", "09", dt.time(9)),
+            ("hh:mm", "09:26", dt.time(9, 26)),
+            ("hh:mm:ss", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+            (
+                "hh:mm:ss.sss",
+                dt.time(9, 26, 45, 123456).isoformat(),
+                dt.time(9, 26, 45, 123456),
+            ),
+            ("nonsense", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+        ],
+    )
+    def test_formatted_time_field_deserialization(self, format, input, expected):
+        field = fields.Time(format=format)
+        result = field.deserialize(input)
+        assert isinstance(result, dt.time)
+        assert_time_equal(result, expected)
+
     @pytest.mark.parametrize("in_data", ["badvalue", "", [], 42])
     def test_invalid_time_field_deserialization(self, in_data):
         field = fields.Time()

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -584,15 +584,14 @@ class TestFieldDeserialization:
     @pytest.mark.parametrize(
         ("format", "input", "expected"),
         [
-            ("hh", "09", dt.time(9)),
-            ("hh:mm", "09:26", dt.time(9, 26)),
-            ("hh:mm:ss", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+            ("%H", "09", dt.time(9)),
+            ("%H:%M", "09:26", dt.time(9, 26)),
+            ("%H:%M:%S", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
             (
-                "hh:mm:ss.sss",
+                "%H:%M:%S.%f",
                 dt.time(9, 26, 45, 123456).isoformat(),
                 dt.time(9, 26, 45, 123456),
             ),
-            ("nonsense", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
         ],
     )
     def test_formatted_time_field_deserialization(self, format, input, expected):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -187,6 +187,14 @@ class TestParentAndName:
         for field_name in ("bar", "qux"):
             assert schema.fields[field_name].tuple_fields[0].format == "iso8601"
 
+    def test_time_invalid_format(self):
+        with pytest.raises(ValueError) as excinfo:
+
+            class MySchema(Schema):
+                foo = fields.Time(format="%I:%M:%S")
+
+        assert excinfo.value.args[0] == "Not a valid ISO8601 strftime format"
+
 
 class TestMetadata:
     @pytest.mark.parametrize("FieldClass", ALL_FIELDS)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -502,6 +502,21 @@ class TestFieldSerialization:
         user.time_registered = None
         assert field.serialize("time_registered", user) is None
 
+    @pytest.mark.parametrize(
+        ("format", "expected"),
+        [
+            ("hh", "08"),
+            ("hh:mm", "08:55"),
+            ("hh:mm:ss", "08:55:31"),
+            ("hh:mm:ss.sss", "08:55:31.123456"),
+            ("nonsense", "08:55:31.123456"),
+        ],
+    )
+    def test_formatted_time_field(self, format, expected):
+        t = dt.time(8, 55, 31, 123456, tzinfo=dt.timezone.utc)
+        field = fields.Time(format=format)
+        assert field.serialize("t", {"t": t}) == expected
+
     def test_date_field(self, user):
         field = fields.Date()
         assert field.serialize("birthdate", user) == user.birthdate.isoformat()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -505,11 +505,11 @@ class TestFieldSerialization:
     @pytest.mark.parametrize(
         ("format", "expected"),
         [
-            ("hh", "08"),
-            ("hh:mm", "08:55"),
-            ("hh:mm:ss", "08:55:31"),
-            ("hh:mm:ss.sss", "08:55:31.123456"),
-            ("nonsense", "08:55:31.123456"),
+            ("%H", "08"),
+            ("%H:%M", "08:55"),
+            ("%H:%M:%S", "08:55:31"),
+            ("%H:%M:%S.%f", "08:55:31.123456"),
+            (None, "08:55:31.123456"),
         ],
     )
     def test_formatted_time_field(self, format, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,6 +156,23 @@ def test_isoformat(value, expected):
 
 
 @pytest.mark.parametrize(
+    ("format", "expected"),
+    [
+        ("hh", "08"),
+        ("hh:mm", "08:55"),
+        ("hh:mm:ss", "08:55:31"),
+        ("hh:mm:ss.sss", "08:55:31.240000"),
+        ("nonsense", "08:55:31.240000+00:00"),
+    ],
+)
+def test_to_iso_time(format, expected):
+    t = dt.time(8, 55, 31, 240000, tzinfo=dt.timezone.utc)
+    formatted_result = utils.to_iso_time(time=t, format=format)
+    assert type(formatted_result) == str
+    assert formatted_result == expected
+
+
+@pytest.mark.parametrize(
     ("value", "expected"),
     [
         ("Sun, 10 Nov 2013 01:23:45 -0000", dt.datetime(2013, 11, 10, 1, 23, 45)),
@@ -218,6 +235,27 @@ def test_from_iso_time_without_microseconds():
     result = utils.from_iso_time(formatted)
     assert type(result) == dt.time
     assert_time_equal(result, t)
+
+
+@pytest.mark.parametrize(
+    ("format", "input", "expected"),
+    [
+        ("hh", "09", dt.time(9)),
+        ("hh:mm", "09:26", dt.time(9, 26)),
+        ("hh:mm:ss", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+        (
+            "hh:mm:ss.sss",
+            dt.time(9, 26, 45, 123456).isoformat(),
+            dt.time(9, 26, 45, 123456),
+        ),
+        ("nonsense", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+    ],
+)
+def test_from_iso_time_formatted(format, input, expected):
+    result = utils.from_iso_time(input, format)
+    print(result)
+    assert type(result) == dt.time
+    assert_time_equal(result, expected)
 
 
 def test_from_iso_date():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,11 +158,11 @@ def test_isoformat(value, expected):
 @pytest.mark.parametrize(
     ("format", "expected"),
     [
-        ("hh", "08"),
-        ("hh:mm", "08:55"),
-        ("hh:mm:ss", "08:55:31"),
-        ("hh:mm:ss.sss", "08:55:31.240000"),
-        ("nonsense", "08:55:31.240000+00:00"),
+        ("%H", "08"),
+        ("%H:%M", "08:55"),
+        ("%H:%M:%S", "08:55:31"),
+        ("%H:%M:%S.%f", "08:55:31.240000"),
+        (None, "08:55:31.240000+00:00"),
     ],
 )
 def test_to_iso_time(format, expected):
@@ -240,20 +240,19 @@ def test_from_iso_time_without_microseconds():
 @pytest.mark.parametrize(
     ("format", "input", "expected"),
     [
-        ("hh", "09", dt.time(9)),
-        ("hh:mm", "09:26", dt.time(9, 26)),
-        ("hh:mm:ss", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+        ("%H", "09", dt.time(9)),
+        ("%H:%M", "09:26", dt.time(9, 26)),
+        ("%H:%M:%S", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
         (
-            "hh:mm:ss.sss",
+            "%H:%M:%S.%f",
             dt.time(9, 26, 45, 123456).isoformat(),
             dt.time(9, 26, 45, 123456),
         ),
-        ("nonsense", dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
+        (None, dt.time(9, 26, 45).isoformat(), dt.time(9, 26, 45)),
     ],
 )
 def test_from_iso_time_formatted(format, input, expected):
     result = utils.from_iso_time(input, format)
-    print(result)
     assert type(result) == dt.time
     assert_time_equal(result, expected)
 


### PR DESCRIPTION
Addresses https://github.com/marshmallow-code/marshmallow/issues/686

Adding a `format` param to the `Time` field, which supports the following formats:
- `hh`
- `hh:mm`
- `hh:mm:ss`
- `hh:mm:ss.sss`