### PR TITLE
Optimise dumping to reduce unnecessary overhead

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -167,3 +167,4 @@ Contributors (chronological)
 - Ryan Morehart `@traherom <https://github.com/traherom>`_
 - Ben Windsor `@bwindsor <https://github.com/bwindsor>`_
 - Kevin Kirsche `@kkirsche <https://github.com/kkirsche>`_
+- Dusko Simidzija `@dsimidzija <https://github.com/dsimidzija>`_


### PR DESCRIPTION
**NB:** Please take this MR more as a "starting a discussion" than "production-ready" code, because I hacked a lot of things.

When dumping many objects, marshmallow is calling the same field methods
over and over again, which return the same values. Parts of this process
can be called only once per dump, which reduces python method call
overhead significantly.

`Field.get_serializer` returns the optimized serializer for the current
dump operation, avoiding the expensive lookups for properties which will
not change during a single dump (such as `data_key`, `default`, etc)

Also, the default `Schema.get_attribute` is also not used because all it
does is calling `utils._get_value_for_key(s)`.

Benchmarks show around 30-35% improvement, which is quite significant even for this hacky patch:

```
T1: python benchmark.py
  Before: 395.60 usec/dump
  After:  261.04 usec/dump
T2: python benchmark.py --object-count 1000
  Before: 22508.80 usec/dump
  After:  14610.63 usec/dump
T3: python benchmark.py --iterations=5 --repeat=5 --object-count 20000
  Before: 442295.61 usec/dump
  After:  288202.98 usec/dump
T3: python benchmark.py --iterations=10 --repeat=10 --object-count 10000
  Before: 220163.94 usec/dump
  After:  142475.76 usec/dump
```

My motivation here is that marshmallow is excellent when it comes to schema validation, but according to the [benchmarks](https://voidfiles.github.io/python-serialization-benchmark/), there is a lot of overhead in there. The question is, is there a better way of improving serialization performance without sacrificing all the good things about marshmallow?