### PR TITLE
Add serialization with timezone to AwareDateTime

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1284,6 +1284,8 @@ class AwareDateTime(DateTime):
     :param default_timezone: Used on deserialization. If `None`, naive
         datetimes are rejected. If not `None`, naive datetimes are set this
         timezone.
+    :param bool use_serialization: If `True`, naive datetimes are set to
+        `default_timezone` on serialization. If `False`, datetimes are not changed.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
 
     .. versionadded:: 3.0.0rc9
@@ -1296,10 +1298,12 @@ class AwareDateTime(DateTime):
         format: typing.Optional[str] = None,
         *,
         default_timezone: typing.Optional[dt.tzinfo] = None,
+        use_serialization: bool = False,
         **kwargs
     ):
         super().__init__(format=format, **kwargs)
         self.default_timezone = default_timezone
+        self.use_serialization = use_serialization
 
     def _deserialize(self, value, attr, data, **kwargs):
         ret = super()._deserialize(value, attr, data, **kwargs)
@@ -1312,6 +1316,12 @@ class AwareDateTime(DateTime):
                 )
             ret = ret.replace(tzinfo=self.default_timezone)
         return ret
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if self.use_serialization:
+            if value is not None and not is_aware(value):
+                value = value.replace(tzinfo=self.default_timezone)
+        return super()._serialize(value, attr, obj, **kwargs)
 
 
 class Time(Field):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -533,6 +533,26 @@ class TestFieldSerialization:
         field = fields.DateTime(format=format)
         assert field.serialize("created", user) == user.created.strftime(format)
 
+    @pytest.mark.parametrize(
+        ("timezone", "value", "expected"),
+        [
+            (None, dt.datetime(2013, 11, 10, 1, 23, 45), "2013-11-10T01:23:45"),
+            (
+                dt.timezone.utc,
+                dt.datetime(2013, 11, 10, 1, 23, 45),
+                "2013-11-10T01:23:45+00:00",
+            ),
+            (
+                dt.timezone(offset=dt.timedelta(hours=3)),
+                dt.datetime(2013, 11, 10, 1, 23, 45),
+                "2013-11-10T01:23:45+03:00",
+            ),
+        ],
+    )
+    def test_aware_datetime_use_serialization(self, timezone, value, expected):
+        field = fields.AwareDateTime(default_timezone=timezone, use_serialization=True)
+        assert field.serialize("d", {"d": value}) == expected
+
     def test_string_field(self):
         field = fields.String()
         user = User(name=b"foo")


### PR DESCRIPTION
Allows AwareDateTime field to optionally serialize naive `datetime` with default timezone.
Behaviour is optional and enabled with `use_serialization=True` in ctor.

For example, if date-time is stored in a database without a timezone and we want to treat it as UTC datetime, new serializer helps a lot.