### PR TITLE
Deprecate metadata as additional field kwargs, support explicit `metadata=...`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+3.10.0 (Unreleased)
+*******************
+
+Deprecations:
+
+- Passing field metadata via keyword arguments is deprecated and will be
+  removed in marshmallow 4 (:issue:`1350`). Use the explicit `metadata=...`
+  argument instead.
+
 3.9.1 (2020-11-07)
 ******************
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -101,7 +101,7 @@ class Field(FieldABC):
         its value will be present in the deserialized object. In the context of an
         HTTP API, this effectively marks the field as "read-only".
     :param dict error_messages: Overrides for `Field.default_error_messages`.
-    :param metadata: Extra arguments to be stored as metadata.
+    :param metadata: Extra information to be stored as field metadata.
 
     .. versionchanged:: 2.0.0
         Removed `error` parameter. Use ``error_messages`` instead.
@@ -160,7 +160,8 @@ class Field(FieldABC):
         load_only: bool = False,
         dump_only: bool = False,
         error_messages: typing.Optional[typing.Dict[str, str]] = None,
-        **metadata
+        metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
+        **additional_metadata
     ) -> None:
         self.default = default
         self.attribute = attribute
@@ -187,7 +188,19 @@ class Field(FieldABC):
             raise ValueError("'missing' must not be set for required fields.")
         self.required = required
         self.missing = missing
-        self.metadata = metadata
+
+        # intentionally shallow-copy so that more data can be added without changing
+        # the original mapping object, but objects can be referenced from field
+        # metadata
+        self.metadata = dict(metadata) if metadata is not None else {}
+        if additional_metadata:
+            self.metadata.update(additional_metadata)
+            warnings.warn(
+                "Passing field metadata as a keyword arg is deprecated. Use the "
+                "explicit `metadata=...` argument instead.",
+                RemovedInMarshmallow4Warning,
+            )
+
         self._creation_index = Field._creation_index
         Field._creation_index += 1
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -189,12 +189,9 @@ class Field(FieldABC):
         self.required = required
         self.missing = missing
 
-        # intentionally shallow-copy so that more data can be added without changing
-        # the original mapping object, but objects can be referenced from field
-        # metadata
-        self.metadata = dict(metadata) if metadata is not None else {}
+        metadata = metadata or {}
+        self.metadata = {**metadata, **additional_metadata}
         if additional_metadata:
-            self.metadata.update(additional_metadata)
             warnings.warn(
                 "Passing field metadata as a keyword arg is deprecated. Use the "
                 "explicit `metadata=...` argument instead.",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -197,9 +197,25 @@ class TestMetadata:
             required=True,
             default=None,
             validate=lambda v: True,
-            description="foo",
-            widget="select",
+            metadata={"description": "foo", "widget": "select"},
         )
+        assert field.metadata == {"description": "foo", "widget": "select"}
+
+    @pytest.mark.parametrize("FieldClass", ALL_FIELDS)
+    def test_field_metadata_added_in_deprecated_style_warns(self, FieldClass):  # noqa
+        # just the old style
+        with pytest.warns(DeprecationWarning):
+            field = FieldClass(description="Just a normal field.")
+            assert field.metadata["description"] == "Just a normal field."
+        # mixed styles
+        with pytest.warns(DeprecationWarning):
+            field = FieldClass(
+                required=True,
+                default=None,
+                validate=lambda v: True,
+                description="foo",
+                metadata={"widget": "select"},
+            )
         assert field.metadata == {"description": "foo", "widget": "select"}
 
 


### PR DESCRIPTION
I'm opening this to kickstart discussion (and volunteer to do any necessary work). I haven't rewritten any tests or added new tests or updated docs yet.

Add `metadata=...` as an explicit keyword argument, which dict-ifies a mapping, and treat any additional kwargs as "added metadata" which triggers a deprecation warning.

This is backwards compatible *except* in the case where someone is already using `metadata` as the name of a metadata field. Which is probably never intentional if it's done at all.

resolves #1350

---

Questions/TODOs on this:

- [x] Is it okay to add `metadata=...` to kwargs in 3.x or does this whole change have to wait for 4.x ? (I don't think so, maybe others disagree.)
- [x] Is doing the shallow-copy with `dict(metadata)` the right thing? Should we maybe do nothing with the input?
- [x] Rewrite tests to use explicit `metadata` now
- [x] Update docs within `marshmallow`
- [x] Should I prepare PRs on apispec and other `marshmallow-code` projects to update `metadata` style in docs when this merges?