### PR TITLE
decorator validates add order parameter

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -157,3 +157,4 @@ Contributors (chronological)
 - Nadège Michel `@nadege <https://github.com/nadege>`_
 - Tamara `@infinityxxx <https://github.com/infinityxxx>`_
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
+- Ficapy `@ficapy <https://github.com/ficapy>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -299,6 +299,8 @@ It is sometimes convenient to write validators as methods. Use the `validates <m
     class ItemSchema(Schema):
         quantity = fields.Integer()
 
+        # You can use the order parameter to allow validations to be executed first
+        # If the order value is large, execute first, and the default value of order is 0
         @validates("quantity")
         def validate_quantity(self, value):
             if value < 0:

--- a/src/marshmallow/__init__.py
+++ b/src/marshmallow/__init__.py
@@ -13,7 +13,7 @@ from marshmallow.utils import EXCLUDE, INCLUDE, RAISE, pprint, missing
 from marshmallow.exceptions import ValidationError
 from distutils.version import LooseVersion
 
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 __version_info__ = tuple(LooseVersion(__version__).version)
 __all__ = [
     "EXCLUDE",

--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -69,12 +69,17 @@ VALIDATES = "validates"
 VALIDATES_SCHEMA = "validates_schema"
 
 
-def validates(field_name: str):
+def validates(field_name: str, order: int = 0):
     """Register a field validator.
 
     :param str field_name: Name of the field that the method validates.
+    :param int order: In the same schema,the larger value is executed first.
+
+    .. warning::
+
+        The order parameter cannot be used across schema
     """
-    return set_hook(None, VALIDATES, field_name=field_name)
+    return set_hook(None, VALIDATES, field_name=field_name, order=order)
 
 
 def validates_schema(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2912,3 +2912,30 @@ def test_class_registry_returns_schema_type():
 
     SchemaClass = class_registry.get_class(DefinitelyUniqueSchema.__name__)
     assert SchemaClass is DefinitelyUniqueSchema
+
+
+def test_validates_order():
+    class User(Schema):
+        name = fields.Str()
+        age = fields.Int()
+        sex = fields.Int()
+
+        @validates("name", order=1)
+        def validate_name(self, value):
+            self.context["order"] += "1"
+            return value
+
+        @validates("age", order=2)
+        def validate_age(self, value):
+            self.context["order"] += "2"
+            return value
+
+        @validates("sex")
+        def validate_sex(self, value):
+            self.context["order"] += "0"
+            return value
+
+    schema = User()
+    schema.context["order"] = ""
+    schema.load({"name": "name", "age": 24, "sex": 1})
+    assert schema.context["order"] == "210"


### PR DESCRIPTION
### This allows validate to be executed in order

For example, if field A needs to query the database when validating, and field B relies on the results of field A's query, 
then validation function A needs to query the database and validation function B needs to query the database if there is no guarantee that A will be executed first. 
Or merge validation functions A, B together, or some other very ugly solution

Adding the order parameter would look like this

```python
class User(Schema):
    name = fields.Str()
    age = fields.Int()
    sex = fields.Int()

    @validates("name", order=1)
    def validate_name(self, value):
        self.context["order"] += "1"
        return value

    @validates("age", order=2)
    def validate_age(self, value):
        self.context["order"] += "2"
        return value

    @validates("sex")
    def validate_sex(self, value):
        self.context["order"] += "0"
        return value

schema = User()
schema.context["order"] = ""
schema.load({"name": "name", "age": 24, "sex": 1})
assert schema.context["order"] == "210"
```