### PR TITLE
Add `extra` argument to load/dump for extensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.11.0 (Unreleased)
+*******************
+
+Features:
+
+- Add ``extra`` argument to ``Schema.load`` and ``Schema.dump`` as an extension
+  point for libraries built on marshmallow
+
 3.10.0 (2020-12-19)
 *******************
 


### PR DESCRIPTION
resolves #1726 

I want to make some changes in `marshmallow-oneofschema` to support hooks (currently unsupported) and simplify the code.
Although it's [just a PR](https://github.com/marshmallow-code/marshmallow-oneofschema/pull/130), one of the issues I see with it is that it will not play nicely with `marshmallow-sqlalchemy` and there isn't a trivial way to get the information I need in `_deserialize` and `_serialize`.

I've been thinking about this on and off for a while and this approach is what I came up with.
It involves `marshmallow` being aware that someone might want to extend `Schema` by overloading `_serialize` and `_deserialize`, and a single new parameter to `load(s)` and `dump(s)` called `extra`. (Name inspired by stdlib `logging`'s use of `extra`.)

Although neither `marshmallow-oneofschema` nor `marshmallow-sqlalchemy` are part of the core project, they're both important parts of a healthy ecosystem of marshmallow extension packages. Supporting their interplay is valuable.

---

The purpose of `extra` is to allow libraries built on top of `marshmallow` to interact with one another cleanly by providing a space for additional data to be passed which `marshmallow` knows about.

In particular, at present the functionality of `marshmallow-sqlalchemy` relies upon adding keyword arguments to `load`, and a proposed refactor of `marshmallow-oneofschema` would not be able to pass through these additional arguments to child schemas.
At the crux of this is a desire in `marshmallow-oneofschema` to override the behavior of `_serialize` and `_deserialize` to take advantage of the hooks provided by marshmallow. This would simplify OneOfSchema and provide additional features, but cannot handle the extra arguments added by `marshmallow-sqlalchemy`.

One option is for these external libraries to coordinate in order to support one another via some other (indeterminate) mechanism. However, in order for `marshmallow` to support such 3rd-party libraries, the key issue here is that there is no way to take extensible data from `load()` calls and pass it down through to the inner (de)serialization methods.

`extra` could be exposed in additional contexts, for example in field loading, hook evaluation, error handling, and so forth. However, the current issue in these third party libraries only requires the addition of `extra` to be passed down to `_deserialize` and `_serialize`. Therefore, this feature addition is restricted to only this context for now.

For this particular problem, this will allow a new major version of `marshmallow-oneofschema` to support usage with marshmallow-sqlalchemy something like so:

    load(..., extra={"child_load_kwargs": {"transient": True}})

which is then unpacked and passed to a child sqlalchemy schema as `load(..., transient=True)`.

In a future version, if `marshmallow-sqlalchemy` started using `extra` instead of added keyword arguments, `marshmallow-oneofschema` could pass through the `extra` data it received or define other sophisticated behaviors.