### PR TITLE
Remove :rtype: declarations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -157,3 +157,4 @@ Contributors (chronological)
 - Nadège Michel `@nadege <https://github.com/nadege>`_
 - Tamara `@infinityxxx <https://github.com/infinityxxx>`_
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
+- Vladimir Mikhaylov `@vemikhaylov <https://github.com/vemikhaylov>`_

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -534,8 +534,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param obj: The object to serialize.
         :param many: Whether to serialize `obj` as a collection. If `None`, the value
             for `self.many` is used.
-        :return: A dict of serialized data
-        :rtype: dict
+        :return: Serialized data
 
         .. versionadded:: 1.0.0
         .. versionchanged:: 3.0.0b7
@@ -574,7 +573,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param many: Whether to serialize `obj` as a collection. If `None`, the value
             for `self.many` is used.
         :return: A ``json`` string
-        :rtype: str
 
         .. versionadded:: 1.0.0
         .. versionchanged:: 3.0.0b7


### PR DESCRIPTION
Resolves: #1728

The `dump` method doesn't return only dictionaries right now, but `:rtype:` can be used by some type checkers in spite of Sphinx annotations being "rejected alternative".

In the issue decided with @deckar01 to remove two `:rtype:` declarations from the project. It resolves the problem with the Pycharm's type checker, which fallbacks to the `Any` type when an annotation is missing. 