### PR TITLE
Prohibiting null character in String field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -831,6 +831,14 @@ class String(Field):
         "invalid_utf8": "Not a valid utf-8 string.",
     }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Insert validation into self.validators so that multiple errors can be stored.
+        validator = validate.ProhibitNullCharactersValidator(
+            error=self.error_messages["invalid"]
+        )
+        self.validators.insert(0, validator)
+
     def _serialize(self, value, attr, obj, **kwargs) -> typing.Optional[str]:
         if value is None:
             return None

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -185,6 +185,34 @@ class Email(Validator):
         return value
 
 
+class ProhibitNullCharactersValidator(Validator):
+    """Validate string not having Null Character
+
+    :param error: Error message to raise in case of a validation error. Can be
+        interpolated with `{input}`.
+    """
+
+    default_message = "String contains null character"
+
+    NULL_REGEX = re.compile(
+        r"\0",
+    )
+
+    def __init__(self, *, error: typing.Optional[str] = None):
+        self.error = error or self.default_message  # type: str
+
+    def _format_error(self, value) -> typing.Any:
+        return self.error.format(input=value)
+
+    def __call__(self, value) -> typing.Any:
+        message = self._format_error(value)
+
+        if value and self.NULL_REGEX.search(str(value)):
+            raise ValidationError(message)
+
+        return value
+
+
 class Range(Validator):
     """Validator which succeeds if the value passed to it is within the specified
     range. If ``min`` is not specified, or is specified as `None`,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -92,6 +92,13 @@ class TestField:
         result = MySchema().dump({"name": "Monty", "foo": 42})
         assert result == {"_NaMe": "Monty"}
 
+    def test_string_field_null_char(self):
+        class MySchema(Schema):
+            name = fields.String()
+
+        with pytest.raises(ValidationError):
+            MySchema().load({"name": "a\0b"})
+
 
 class TestParentAndName:
     class MySchema(Schema):


### PR DESCRIPTION
Motivation: The default use case is that null character is not wanted - e.g. it causes issues with database since a string containing null character cannot be passed as a string literal

( django-rest-framework has similar solution: https://github.com/encode/django-rest-framework/blob/master/rest_framework/fields.py#L788 )