### PR TITLE
Implements IPInterface fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -157,3 +157,4 @@ Contributors (chronological)
 - Nadège Michel `@nadege <https://github.com/nadege>`_
 - Tamara `@infinityxxx <https://github.com/infinityxxx>`_
 - Stephen Rosen `@sirosen <https://github.com/sirosen>`_
+- Stephen Eaton `@madeinoz67 <https://github.com/madeinoz67>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+3.11.0 (unreleased)
+*******************
+
+Features:
+
+- Add ``fields.IPInterface``, ``fields.IPv4Interface``, and
+  ``IPv6Interface`` (:issue:`1733`). Thanks :user:`madeinoz67`
+  for the suggestion and the PR.
+
 3.10.0 (2020-12-19)
 *******************
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,6 +27,12 @@ ALL_FIELDS = [
     fields.Email,
     fields.UUID,
     fields.Decimal,
+    fields.IP,
+    fields.IPv4,
+    fields.IPv6,
+    fields.IPInterface,
+    fields.IPv4Interface,
+    fields.IPv6Interface,
 ]
 
 ##### Custom asserts #####

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -194,6 +194,66 @@ class TestFieldSerialization:
         assert isinstance(field_exploded.serialize("ipv6", user), str)
         assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
 
+    def test_ip_interface_field(self, user):
+
+        ipv4interface_string = "192.168.0.1/24"
+        ipv6interface_string = "ffff::ffff/128"
+        ipv6interface_exploded_string = ipaddress.ip_interface(
+            "ffff::ffff/128"
+        ).exploded
+
+        user.ipv4interface = ipaddress.ip_interface(ipv4interface_string)
+        user.ipv6interface = ipaddress.ip_interface(ipv6interface_string)
+        user.empty_ipinterface = None
+
+        field_compressed = fields.IPInterface()
+        assert isinstance(field_compressed.serialize("ipv4interface", user), str)
+        assert field_compressed.serialize("ipv4interface", user) == ipv4interface_string
+        assert isinstance(field_compressed.serialize("ipv6interface", user), str)
+        assert field_compressed.serialize("ipv6interface", user) == ipv6interface_string
+        assert field_compressed.serialize("empty_ipinterface", user) is None
+
+        field_exploded = fields.IPInterface(exploded=True)
+        assert isinstance(field_exploded.serialize("ipv6interface", user), str)
+        assert (
+            field_exploded.serialize("ipv6interface", user)
+            == ipv6interface_exploded_string
+        )
+
+    def test_ipv4_interface_field(self, user):
+
+        ipv4interface_string = "192.168.0.1/24"
+
+        user.ipv4interface = ipaddress.ip_interface(ipv4interface_string)
+        user.empty_ipinterface = None
+
+        field = fields.IPv4Interface()
+        assert isinstance(field.serialize("ipv4interface", user), str)
+        assert field.serialize("ipv4interface", user) == ipv4interface_string
+        assert field.serialize("empty_ipinterface", user) is None
+
+    def test_ipv6_interface_field(self, user):
+
+        ipv6interface_string = "ffff::ffff/128"
+        ipv6interface_exploded_string = ipaddress.ip_interface(
+            "ffff::ffff/128"
+        ).exploded
+
+        user.ipv6interface = ipaddress.ip_interface(ipv6interface_string)
+        user.empty_ipinterface = None
+
+        field_compressed = fields.IPv6Interface()
+        assert isinstance(field_compressed.serialize("ipv6interface", user), str)
+        assert field_compressed.serialize("ipv6interface", user) == ipv6interface_string
+        assert field_compressed.serialize("empty_ipinterface", user) is None
+
+        field_exploded = fields.IPv6Interface(exploded=True)
+        assert isinstance(field_exploded.serialize("ipv6interface", user), str)
+        assert (
+            field_exploded.serialize("ipv6interface", user)
+            == ipv6interface_exploded_string
+        )
+
     def test_decimal_field(self, user):
         user.m1 = 12
         user.m2 = "12.355"


### PR DESCRIPTION
Implements IPInterface fields that are a non-strict version of IPNetwork Types, where the IPInterfaces will always accept arbitrary host addresses and Mask, while IPNetwork will not allow this.

Implement in this PR are the following new fields:

- IPInterface
- IPv4Interface
- IPv6Interface

see <https://python.readthedocs.io/en/latest/library/ipaddress.html#interface-objects> for more information around these underlying types

closes #1733 

