### PR TITLE
add a duplication validation

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -583,20 +583,20 @@ class ContainsNoneOf(NoneOf):
 
 class NoDuplicates(Validator):
     """
-    Validator which succeeds if the `value` is an `iterable` and has no duplicate
+    Validator which succeeds if the ``value`` is an ``iterable`` and has no duplicate
     elements. In case of a list of objects, it can easy check an internal
-    attribute by passing the `attribute` parameter.
+    attribute by passing the ``attribute`` parameter.
 
-    Validator which fails if `value` is not a member of `iterable`.
+    Validator which fails if ``value`` is not a member of ``iterable``.
 
-    :param attribute: The name of the attribute of the object you want to check.
+    :param str attribute: The name of the attribute of the object you want to check.
     """
 
     default_message = "Invalid input. Supported lists or str."
     error = "Found a duplicate value: {value}."
     attribute_error = "Found a duplicate object attribute ({attribute}): {value}."
 
-    def __init__(self, *, attribute: typing.Optional[str] = None):
+    def __init__(self, attribute: typing.Optional[str] = None):
         self.attribute = attribute
 
     def _repr_args(self) -> str:

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -600,7 +600,7 @@ class NoDuplicates(Validator):
         self.attribute = attribute
 
     def _repr_args(self) -> str:
-        return f"attribute={self.attribute!r}"
+        return "attribute={!r}".format(self.attribute)
 
     def _format_error(self, value) -> str:
         if self.attribute:

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -579,3 +579,49 @@ class ContainsNoneOf(NoneOf):
             if val in self.iterable:
                 raise ValidationError(self._format_error(value))
         return value
+
+
+class NoDuplicates(Validator):
+    """
+    Validator which succeeds if the `value` is an `iterable` and has no duplicate
+    elements. In case of a list of objects, it can easy check an internal
+    attribute by passing the `attribute` parameter.
+
+    Validator which fails if `value` is not a member of `iterable`.
+
+    :param attribute: The name of the attribute of the object you want to check.
+    """
+
+    default_message = "Invalid input. Supported lists or str."
+    error = "Found a duplicate value: {value}."
+    attribute_error = "Found a duplicate object attribute ({attribute}): {value}."
+
+    def __init__(self, *, attribute: typing.Optional[str] = None):
+        self.attribute = attribute
+
+    def _repr_args(self) -> str:
+        return f"attribute={self.attribute!r}"
+
+    def _format_error(self, value) -> str:
+        if self.attribute:
+            return self.attribute_error.format(attribute=self.attribute, value=value)
+        return self.error.format(value=value)
+
+    def __call__(self, value):
+        set_item = set()
+        try:
+            for item in value:
+                if self.attribute:
+                    attribute = getattr(item, self.attribute)
+                    if attribute in set_item:
+                        raise ValidationError(self._format_error(attribute))
+                    set_item.add(attribute)
+                else:
+                    if item in set_item:
+                        raise ValidationError(self._format_error(item))
+                    set_item.add(item)
+
+        except TypeError as error:
+            raise ValidationError(self.default_message) from error
+
+        return value

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -890,3 +890,39 @@ def test_containsnoneof_mixing_types():
 
     with pytest.raises(ValidationError):
         validate.ContainsNoneOf([1, 2, 3])((1,))
+
+
+def test_noduplicates():
+    class Mock:
+        def __init__(self, name):
+            self.name = name
+
+    mock_object_1 = Mock("a")
+    mock_object_2 = Mock("b")
+
+    assert validate.NoDuplicates()("d") == "d"
+    assert validate.NoDuplicates()([]) == []
+    assert validate.NoDuplicates()({}) == {}
+    assert validate.NoDuplicates()(["a", "b"]) == ["a", "b"]
+    assert validate.NoDuplicates()([1, 2]) == [1, 2]
+    assert validate.NoDuplicates(attribute="name")([mock_object_1, mock_object_2]) == [
+        mock_object_1,
+        mock_object_2,
+    ]
+
+    with pytest.raises(ValidationError, match="Invalid input."):
+        validate.NoDuplicates()(3)
+    with pytest.raises(ValidationError, match="Invalid input."):
+        validate.NoDuplicates()(1.1)
+    with pytest.raises(ValidationError, match="Invalid input."):
+        validate.NoDuplicates()(True)
+    with pytest.raises(ValidationError, match="Invalid input."):
+        validate.NoDuplicates()(None)
+    with pytest.raises(ValidationError, match="Found a duplicate value: 1."):
+        validate.NoDuplicates()([1, 1, 2])
+    with pytest.raises(ValidationError, match="Found a duplicate value: a."):
+        validate.NoDuplicates()("aab")
+    with pytest.raises(ValidationError, match="Found a duplicate value: a."):
+        validate.NoDuplicates()(["a", "a", "b"])
+    with pytest.raises(ValidationError, match="Found a duplicate object attribute"):
+        validate.NoDuplicates(attribute="name")([mock_object_1, mock_object_1])


### PR DESCRIPTION
I've encountered that `marshmallow` did not have any duplicate validator. I found it might be useful so I'm sharing the  implementation I'm using so that could be merged as a new validator in a future marshmallow release.

This new validator is designed to work only with iterables.

In case the value is a list of objects which makes it difficult to check if one is repeated, you can use an `attribute` of the object to check if it is repeated or not.

I've also added a simple `pytest`. 

Hope it can be reviewed and at some point included in a future release.