### PR TITLE
Add optional 'abs_tol' and `rel_tol` arguments to validate.Range

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -232,7 +232,7 @@ class Range(Validator):
             self._rel_tol_default = is_close.get("rel_tol").default  # type: ignore
             self._abs_tol_default = is_close.get("abs_tol").default  # type: ignore
         except ValueError:
-            self._rel_tol_default, self._abs_tol_default = None, None
+            self._rel_tol_default, self._abs_tol_default = 1e-09, 0.0
         self.rel_tol = self._rel_tol_default if rel_tol is None else rel_tol
         self.abs_tol = self._abs_tol_default if abs_tol is None else abs_tol
         self.error = error

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -245,11 +245,11 @@ class Range(Validator):
         rel = ""
         abs = ""
         if self.rel_tol and self.rel_tol != self._rel_tol_default:
-            rel = f"a relative tolerance of {self.rel_tol:.1e}"
+            rel = "a relative tolerance of {:.1e}".format(self.rel_tol)
         if self.abs_tol and self.abs_tol != self._rel_tol_default:
-            abs = f"an absolute tolerance of {self.abs_tol:.1e}"
-        msg = f"{rel} and {abs}" if rel and abs else rel or abs
-        return f" (equality with {msg})"
+            abs = "an absolute tolerance of {:.1e}".format(self.abs_tol)
+        msg = "{rel} and {abs}".format(rel=rel, abs=abs) if rel and abs else rel or abs
+        return " (equality with {msg})".format(msg=msg)
 
     def _repr_args(self) -> str:
         msg = "min={!r}, max={!r}, min_inclusive={!r}, max_inclusive={!r}".format(
@@ -268,12 +268,16 @@ class Range(Validator):
     def _format_error(self, value, for_min=True) -> str:
         if self.error is None and for_min:
             op = "greater than or equal to" if self.min_inclusive else "greater than"
-            message_min = f"{op} {{min}}"
-            self.error = f"{{input}} must be {message_min}{self.tolerance}."
+            message_min = "{op} {{min}}".format(op=op)
+            self.error = "{{input}} must be {message_min}{tol}.".format(
+                message_min=message_min, tol=self.tolerance
+            )
         elif self.error is None:
             op = "less than or equal to" if self.max_inclusive else "less than"
-            message_max = f"{op} {{max}}"
-            self.error = f"{{input}} must be {message_max}{self.tolerance}."
+            message_max = "{op} {{max}}".format(op=op)
+            self.error = "{{input}} must be {message_max}{tol}.".format(
+                message_max=message_max, tol=self.tolerance
+            )
         return self.error.format(input=value, min=self.min, max=self.max)
 
     def __should_be_bigger(self, value):


### PR DESCRIPTION
Hello,

I think this could be merged in marshmallow as it's an optional argument that should not disturb existing code and make sense in Range().

There are more use cases in the tests but the basic principle is this:
```python
assert validate.Range(1, 8.450, abs_tol=0.4)(8.005) == 8.005
assert validate.Range(1, 8.450, abs_tol=0.4)(8.455) == 8.450

with pytest.raises(ValidationError) as exc:
    validate.Range(2, 3, abs_tol=1e-4)(1.999)
assert "must be greater than or equal to 2" in str(exc.value)
assert "(equality with an absolute tolerance of 1.0e-04)" in str(exc.value)

with pytest.raises(ValidationError) as exc:
    validate.Range(100, 200, rel_tol=1e-2)(95)
assert "95 must be greater than or equal to 100 (" in str(exc.value)
assert "(equality with a relative tolerance of 1.0e-02)" in str(exc.value)
 ```
