### PR TITLE
Fix treatment of dotted keys when unknown=INCLUDE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.11.1 (unreleased)
+*******************
+
+Bug fixes:
+
+- Fix treatment of dotted keys when unknown=INCLUDE (:issue:`1506`).
+  Thanks :user:`rbu` for reporting and thanks :user:`sirosen` for the fix (:pr:`1745`).
+
 3.11.0 (2021-03-28)
 *******************
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -682,7 +682,12 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 for key in set(data) - fields:
                     value = data[key]
                     if unknown == INCLUDE:
-                        set_value(typing.cast(typing.Dict, ret), key, value)
+                        set_value(
+                            typing.cast(typing.Dict, ret),
+                            key,
+                            value,
+                            allow_dotted=False,
+                        )
                     elif unknown == RAISE:
                         error_store.store_error(
                             [self.error_messages["unknown"]],

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -616,9 +616,9 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         if many:
             if not is_collection(data):
                 error_store.store_error([self.error_messages["type"]], index=index)
-                ret = []  # type: typing.List[_T]
+                ret_l = []  # type: typing.List[_T]
             else:
-                ret = [
+                ret_l = [
                     typing.cast(
                         _T,
                         self._deserialize(
@@ -632,8 +632,8 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     )
                     for idx, d in enumerate(data)
                 ]
-            return ret
-        ret = self.dict_class()
+            return ret_l
+        ret_d = self.dict_class()
         # Check data is a dict
         if not isinstance(data, Mapping):
             error_store.store_error([self.error_messages["type"]], index=index)
@@ -673,7 +673,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 )
                 if value is not missing:
                     key = field_obj.attribute or attr_name
-                    set_value(typing.cast(typing.Dict, ret), key, value)
+                    set_value(ret_d, key, value)
             if unknown != EXCLUDE:
                 fields = {
                     field_obj.data_key if field_obj.data_key is not None else field_name
@@ -682,19 +682,14 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 for key in set(data) - fields:
                     value = data[key]
                     if unknown == INCLUDE:
-                        set_value(
-                            typing.cast(typing.Dict, ret),
-                            key,
-                            value,
-                            allow_dotted=False,
-                        )
+                        ret_d[key] = value
                     elif unknown == RAISE:
                         error_store.store_error(
                             [self.error_messages["unknown"]],
                             key,
                             (index if index_errors else None),
                         )
-        return ret
+        return ret_d
 
     def load(
         self,

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -258,9 +258,15 @@ def _get_value_for_key(obj, key, default):
         return getattr(obj, key, default)
 
 
-def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any):
+def set_value(
+    dct: typing.Dict[str, typing.Any],
+    key: str,
+    value: typing.Any,
+    allow_dotted: bool = True,
+):
     """Set a value in a dict. If `key` contains a '.', it is assumed
     be a path (i.e. dot-delimited string) to the value's location.
+    `allow_dotted=False` disables this behavior.
 
     ::
 
@@ -269,7 +275,7 @@ def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any):
         >>> d
         {'foo': {'bar': 42}}
     """
-    if "." in key:
+    if "." in key and allow_dotted:
         head, rest = key.split(".", 1)
         target = dct.setdefault(head, {})
         if not isinstance(target, dict):

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -258,15 +258,9 @@ def _get_value_for_key(obj, key, default):
         return getattr(obj, key, default)
 
 
-def set_value(
-    dct: typing.Dict[str, typing.Any],
-    key: str,
-    value: typing.Any,
-    allow_dotted: bool = True,
-):
+def set_value(dct: typing.Dict[str, typing.Any], key: str, value: typing.Any):
     """Set a value in a dict. If `key` contains a '.', it is assumed
     be a path (i.e. dot-delimited string) to the value's location.
-    `allow_dotted=False` disables this behavior.
 
     ::
 
@@ -275,7 +269,7 @@ def set_value(
         >>> d
         {'foo': {'bar': 42}}
     """
-    if "." in key and allow_dotted:
+    if "." in key:
         head, rest = key.split(".", 1)
         target = dct.setdefault(head, {})
         if not isinstance(target, dict):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1729,6 +1729,22 @@ class TestSchemaDeserialization:
         data = MySchema(unknown=INCLUDE).load({"foo": "LOL"})
         assert data["foo"] == "LOL"
 
+    def test_unknown_fields_do_not_unpack_dotted_names(self):
+        class MySchema(Schema):
+            class Meta:
+                unknown = INCLUDE
+
+            foo = fields.Str()
+            bar = fields.Str(data_key="bar.baz")
+
+        # dotted names are still supported
+        data = MySchema().load({"foo": "hi", "bar.baz": "okay"})
+        assert data == {"foo": "hi", "bar": "okay"}
+
+        # but extra keys included via unknown=INCLUDE are not transformed into nested dicts
+        data = MySchema().load({"foo": "hi", "bar.baz": "okay", "alpha.beta": "woah!"})
+        assert data == {"foo": "hi", "bar": "okay", "alpha.beta": "woah!"}
+
 
 validators_gen = (func for func in [lambda x: x <= 24, lambda x: 18 <= x])
 


### PR DESCRIPTION
resolves #1506

When `unknown=INCLUDE`, dotted keys are currently unpacked into nested dicts.
i.e. `{"foo.bar": "baz"} => {"foo": {"bar": "baz"}}` when `foo.bar` is not a known fieldname.

With this fix in place, dotted keys are only unpacked during field loading, not when loading additional fields for `INCLUDE`


In #1506, @deckar01 suggested using Field to do this, but I'm not sure I understood properly. This seems simpler to me and sufficient? Is there maybe a test-case with a Dict or other more complex fields that would require more sophisticated treatment.

This is a bugfix, so there's an argument for just releasing it as-is. However, I considered adding an option to schema opts for controlling this behavior. Something like `allow_dotted_unknown = True` by default, and then pass that to `allow_dotted` in `set_value`. I don't think that's worth it? But I could easily be convinced if one of the maintainers feels strongly about being _really strictly_ backwards compatible.