### PR TITLE
Remove useless hasattr / gettatr checks in `Field`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Features:
   ``IPv6Interface`` (:issue:`1733`). Thanks :user:`madeinoz67`
   for the suggestion and the PR.
 
+Other changes:
+
+- Remove unnecessary ``hasattr`` and ``getattr`` checks in ``Field`` (:pr:`1770`).
+
 3.10.0 (2020-12-19)
 *******************
 


### PR DESCRIPTION
Minor code simplification.

Shouldn't break anything unless someone's been naughty deleting those attributes.

 