### PR TITLE
Revert "Bump sphinx from 3.4.3 to 3.5.3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ EXTRAS_REQUIRE = {
         "pre-commit~=2.4",
     ],
     "docs": [
-        "sphinx==3.5.3",
+        "sphinx==3.4.3",
         "sphinx-issues==1.2.0",
         "alabaster==0.7.12",
         "sphinx-version-warning==1.1.2",


### PR DESCRIPTION
Reverts marshmallow-code/marshmallow#1769

autodocsumm is incompatible with later Sphinx versions https://github.com/Chilipp/autodocsumm/pull/42