### PR TITLE
Add `embed` schema parameter and `embed_only` field option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -160,3 +160,4 @@ Contributors (chronological)
 - Vladimir Mikhaylov `@vemikhaylov <https://github.com/vemikhaylov>`_
 - Stephen Eaton `@madeinoz67 <https://github.com/madeinoz67>`_
 - Antonio Lassandro `@lassandroan <https://github.com/lassandroan>`_
+- Brady Neumann `@bpneumann <https://github.com/bpneumann>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -162,6 +162,7 @@ class Field(FieldABC):
         allow_none: typing.Optional[bool] = None,
         load_only: bool = False,
         dump_only: bool = False,
+        embed_only: bool = False,
         error_messages: typing.Optional[typing.Dict[str, str]] = None,
         metadata: typing.Optional[typing.Mapping[str, typing.Any]] = None,
         **additional_metadata
@@ -187,6 +188,7 @@ class Field(FieldABC):
         self.allow_none = missing is None if allow_none is None else allow_none
         self.load_only = load_only
         self.dump_only = dump_only
+        self.embed_only = embed_only
         if required is True and missing is not missing_:
             raise ValueError("'missing' must not be set for required fields.")
         self.required = required
@@ -488,6 +490,7 @@ class Nested(Field):
         default: typing.Any = missing_,
         only: typing.Optional[types.StrSequenceOrSet] = None,
         exclude: types.StrSequenceOrSet = (),
+        embed: types.StrSequenceOrSet = (),
         many: bool = False,
         unknown: typing.Optional[str] = None,
         **kwargs
@@ -508,6 +511,7 @@ class Nested(Field):
         self.nested = nested
         self.only = only
         self.exclude = exclude
+        self.embed = embed
         self.many = many
         self.unknown = unknown
         self._schema = None  # Cached Schema instance
@@ -542,6 +546,9 @@ class Nested(Field):
                 if self.exclude:
                     original = self._schema.exclude
                     self._schema.exclude = set_class(self.exclude) | set_class(original)
+                if self.embed:
+                    original = self._schema.embed
+                    self._schema.embed = set_class(self.embed) | set_class(original)
                 self._schema._init_fields()
             else:
                 if isinstance(nested, type) and issubclass(nested, SchemaABC):
@@ -558,6 +565,7 @@ class Nested(Field):
                 self._schema = schema_class(
                     many=self.many,
                     only=self.only,
+                    embed=self.embed,
                     exclude=self.exclude,
                     context=context,
                     load_only=self._nested_normalized_option("load_only"),

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -103,6 +103,7 @@ class Field(FieldABC):
     :param dump_only: If `True` skip this field during deserialization, otherwise
         its value will be present in the deserialized object. In the context of an
         HTTP API, this effectively marks the field as "read-only".
+    :param embed_only: If `True`, exclude this field from serialization unles explicitly included in the `embed` option of the schema.
     :param dict error_messages: Overrides for `Field.default_error_messages`.
     :param metadata: Extra information to be stored as field metadata.
 
@@ -474,6 +475,7 @@ class Nested(Field):
     :param exclude: A list or tuple of fields to exclude.
     :param only: A list or tuple of fields to marshal. If `None`, all fields are marshalled.
         This parameter takes precedence over ``exclude``.
+    :param embed: A list of `embed_only` field names to include in the output of the nested serializer.
     :param many: Whether the field is a collection of objects.
     :param unknown: Whether to exclude, include, or raise an error for unknown
         fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -935,7 +935,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 [field for field in self.exclude if "." not in field]
             )
         if self.embed:
-            # Apply the exclude option to nested fields.
+            # Apply the embed option to nested fields.
             self.__apply_nested_option("embed", self.embed, "union")
             # Remove the child field names from the embed option.
             self.embed = self.set_class(

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -983,7 +983,16 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             field_names = available_field_names
 
         invalid_fields |= self.embed_only - available_field_names
-        embed_only_fields = self.set_class([field_name for field_name, field_obj in self.declared_fields.items() if getattr(field_obj, 'embed_only', False)]) | self.embed_only
+        embed_only_fields = (
+            self.set_class(
+                [
+                    field_name
+                    for field_name, field_obj in self.declared_fields.items()
+                    if getattr(field_obj, "embed_only", False)
+                ]
+            )
+            | self.embed_only
+        )
         non_embedded_fields = embed_only_fields - self.embed
         field_names = field_names - non_embedded_fields
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -269,6 +269,8 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         when instantiating the Schema. If a field appears in both `only` and
         `exclude`, it is not used. Nested fields can be represented with dot
         delimiters.
+    :param embed: List of `embed_only` field names to include in the serialized
+        output. Nested fields can be represented with dot delimiters.
     :param many: Should be set to `True` if ``obj`` is a collection
         so that the object will be serialized to a list.
     :param context: Optional context passed to :class:`fields.Method` and
@@ -357,6 +359,8 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             of invalid items in a collection.
         - ``load_only``: Tuple or list of fields to exclude from serialized results.
         - ``dump_only``: Tuple or list of fields to exclude from deserialization
+        - ``embed_only``: Tuple or list of fields to exclude from serialized results
+            unless explicitly included in the `embed` option of the schema.
         - ``unknown``: Whether to exclude, include, or raise an error for unknown
             fields in the data. Use `EXCLUDE`, `INCLUDE` or `RAISE`.
         - ``register``: Whether to register the `Schema` with marshmallow's internal

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -983,7 +983,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             field_names = available_field_names
 
         invalid_fields |= self.embed_only - available_field_names
-        embed_only_fields = {field_name for field_name, field_obj in self.declared_fields.items() if getattr(field_obj, 'embed_only', False)} | self.embed_only
+        embed_only_fields = self.set_class([field_name for field_name, field_obj in self.declared_fields.items() if getattr(field_obj, 'embed_only', False)]) | self.embed_only
         non_embedded_fields = embed_only_fields - self.embed
         field_names = field_names - non_embedded_fields
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1594,9 +1594,8 @@ def test_only_and_exclude_as_string(param):
 
 def test_embed_only_in_meta_excludes_field():
     class MySchema(Schema):
-
         class Meta:
-            embed_only = ['foo']
+            embed_only = ["foo"]
 
         foo = fields.Field()
 
@@ -1606,13 +1605,12 @@ def test_embed_only_in_meta_excludes_field():
 
 def test_embed_only_in_meta_includes_field():
     class MySchema(Schema):
-
         class Meta:
-            embed_only = ['foo']
+            embed_only = ["foo"]
 
         foo = fields.Field()
 
-    sch = MySchema(embed=['foo'])
+    sch = MySchema(embed=["foo"])
     assert "foo" in sch.dump({"foo": "bar"})
 
 
@@ -1628,8 +1626,9 @@ def test_embed_only_on_field_includes_field():
     class MySchema(Schema):
         foo = fields.Field(embed_only=True)
 
-    sch = MySchema(embed=['foo'])
+    sch = MySchema(embed=["foo"])
     assert "foo" in sch.dump({"foo": "bar"})
+
 
 def test_embed_only_nested():
     class ChildSchema(Schema):
@@ -1639,7 +1638,7 @@ def test_embed_only_nested():
     class ParentSchema(Schema):
         foo = fields.Nested(ChildSchema(), embed_only=True)
 
-    sch = ParentSchema(embed=['foo.bar'])
+    sch = ParentSchema(embed=["foo.bar"])
     dump = sch.dump({"foo": {"bar": "val", "baz": "val"}})
     assert "foo" in dump
     assert "bar" in dump["foo"]
@@ -1652,9 +1651,9 @@ def test_embed_only_nested_child_field():
         baz = fields.Field(embed_only=True)
 
     class ParentSchema(Schema):
-        foo = fields.Nested(ChildSchema(), embed=['bar'], embed_only=True)
+        foo = fields.Nested(ChildSchema(), embed=["bar"], embed_only=True)
 
-    sch = ParentSchema(embed=['foo'])
+    sch = ParentSchema(embed=["foo"])
     dump = sch.dump({"foo": {"bar": "val", "baz": "val"}})
     assert "foo" in dump
     assert "bar" in dump["foo"]
@@ -1667,9 +1666,9 @@ def test_embed_only_nested_child_schema():
         baz = fields.Field(embed_only=True)
 
     class ParentSchema(Schema):
-        foo = fields.Nested(ChildSchema(embed=['bar']), embed_only=True)
+        foo = fields.Nested(ChildSchema(embed=["bar"]), embed_only=True)
 
-    sch = ParentSchema(embed=['foo'])
+    sch = ParentSchema(embed=["foo"])
     dump = sch.dump({"foo": {"bar": "val", "baz": "val"}})
     assert "foo" in dump
     assert "bar" in dump["foo"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1675,6 +1675,18 @@ def test_embed_only_nested_child_schema():
     assert "baz" not in dump["foo"]
 
 
+def test_embed_only_with_load():
+    class MySchema(Schema):
+        foo = fields.Field(embed_only=True)
+        bar = fields.Field()
+
+    sch = MySchema()
+    data = {"foo": "val", "bar": "val"}
+    obj = sch.load(data)
+    assert "foo" in obj
+    assert "bar" in obj
+
+
 def test_nested_with_sets():
     class Inner(Schema):
         foo = fields.Field()


### PR DESCRIPTION
Implements the functionality described in https://github.com/marshmallow-code/marshmallow/issues/151.
Similar to the functionality of `only`, but  allows fields to be marked as `embed_only`. A common use case for this is for schemas which contain large collections which should only be serialized in specific cases. 

Add support for `embed_only` option on fields, and as a Meta option in schema classes.

If a field is marked as `embed_only`, the field will only be serialized if it is included in `embed` schema parameter.

Example:

```python
    class MySchema(Schema):
        foo = fields.Field(embed_only=True)

    sch = MySchema()
    assert "foo" not in sch.dump({"foo": "bar"})

    sch = MySchema(embed=['foo'])
    assert "foo" in sch.dump({"foo": "bar"})
```

This also supports nested fields using the same dotted identifiers used by the `only` option.

```python
    class ChildSchema(Schema):
        bar = fields.Field(embed_only=True)
        baz = fields.Field(embed_only=True)

    class ParentSchema(Schema):
        foo = fields.Nested(ChildSchema())

    sch = ParentSchema(embed=['foo.bar'])
    dump = sch.dump({"foo": {"bar": "val", "baz": "val"}})
    assert "foo" in dump
    assert "bar" in dump["foo"]
    assert "baz" not in dump["foo"] 
```