### PR TITLE
Remove unnecessary list cast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Other changes:
 
 - Improve types in ``marshmallow.validate``.
 - Make `marshmallow.validate.Validator` an abstract base class.
+- Remove unnecessary list cast (:pr:`1785`).
 
 3.11.1 (2021-03-29)
 *******************

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -32,7 +32,6 @@ from marshmallow.utils import (
     get_value,
     is_collection,
     is_instance_or_subclass,
-    is_iterable_but_not_string,
 )
 from marshmallow.warnings import RemovedInMarshmallow4Warning
 
@@ -545,9 +544,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             Validation no longer occurs upon serialization.
         """
         many = self.many if many is None else bool(many)
-        if many and is_iterable_but_not_string(obj):
-            obj = list(obj)
-
         if self._has_processors(PRE_DUMP):
             processed_obj = self._invoke_dump_processors(
                 PRE_DUMP, obj, many=many, original_data=obj


### PR DESCRIPTION
Thanks to https://github.com/marshmallow-code/marshmallow/pull/810, it's no longer necessary to read the first item in iterable when `many=True`, so reading the iterable as a list here can be removed.

Also discussed in https://github.com/marshmallow-code/marshmallow/issues/1696