### PR TITLE
Type hinted all the decorators in marshmallow/decorators.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -161,3 +161,4 @@ Contributors (chronological)
 - Stephen Eaton `@madeinoz67 <https://github.com/madeinoz67>`_
 - Antonio Lassandro `@lassandroan <https://github.com/lassandroan>`_
 - Javier Fernández `@jfernandz <https://github.com/jfernandz>`_
+- Michael Dimchuk  `@michaeldimchuk <https://github.com/michaeldimchuk>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Features:
 
 - Add ``validate.And`` (:issue:`1768`).
   Thanks :user:`rugleb` for the suggestion.
-- Add type annotations to ``marshmallow.decorators`` (:pr:`1789`).
+- Add type annotations to ``marshmallow.decorators`` (:issue:`1788`, :pr:`1789`).
   Thanks :user:`michaeldimchuk` for the PR.
 - Let ``Field``\s be accessed by name as ``Schema`` attributes (:pr:`1631`).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 3.12.0 (unreleased)
 *******************
 
+Features:
+
+- Add type annotations to ``marshmallow.decorators`` (:pr:`1789`).
+  Thanks :user:`michaeldimchuk` for the PR.
+
 Other changes:
 
 - Improve types in ``marshmallow.validate``.


### PR DESCRIPTION
Added a bunch of type hints to the `decorators` module making it easier to use `marshmallow` alongside `mypy` running in strict mode

close #1788