### PR TITLE
Return a field’s root schema as soon as it is found

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -417,7 +417,9 @@ class Field(FieldABC):
         ret = self
         while hasattr(ret, "parent"):
             ret = ret.parent
-        return ret if isinstance(ret, SchemaABC) else None
+            if isinstance(ret, SchemaABC):
+                return ret
+        return None
 
 
 class Raw(Field):


### PR DESCRIPTION
This prevents accessing a schema’s `.parent` attribute if it has one (e.g. a field called `parent`)

Fixes #1808, I think.