### PR TITLE
Bind the root schema to the field to avoid the parent attribute being overwritten

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+3.12.1 (unreleased)
+*******************
+
+Bug fixes:
+
+- Fix bug that raised an ``AttributeError`` when instantiating a
+  ``Schema`` with a field named ``parent`` (:issue:`1808`).
+  Thanks :user:`flying-sheep` for reporting and helping with the fix.
+
 3.12.0 (2021-05-09)
 *******************
 

--- a/src/marshmallow/base.py
+++ b/src/marshmallow/base.py
@@ -15,6 +15,7 @@ class FieldABC:
 
     parent = None
     name = None
+    root = None
 
     def serialize(self, attr, obj, accessor=None):
         raise NotImplementedError

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -352,7 +352,7 @@ class Field(FieldABC):
         :meth:`Schema._bind_field <marshmallow.Schema._bind_field>`.
 
         :param str field_name: Field name set in schema.
-        :param Schema schema: Parent schema.
+        :param Schema|Field parent: Parent object.
         """
         self.parent = self.parent or schema
         self.name = self.name or field_name

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -352,10 +352,13 @@ class Field(FieldABC):
         :meth:`Schema._bind_field <marshmallow.Schema._bind_field>`.
 
         :param str field_name: Field name set in schema.
-        :param Schema|Field parent: Parent object.
+        :param Schema|Field schema: Parent object.
         """
         self.parent = self.parent or schema
         self.name = self.name or field_name
+        self.root = self.root or (
+            self.parent.root if isinstance(self.parent, FieldABC) else self.parent
+        )
 
     def _serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
         """Serializes ``value`` to a basic Python datatype. Noop by default.
@@ -407,17 +410,6 @@ class Field(FieldABC):
     def context(self):
         """The context dictionary for the parent :class:`Schema`."""
         return self.parent.context
-
-    @property
-    def root(self):
-        """Reference to the `Schema` that this field belongs to even if it is buried in a
-        container field (e.g. `List`).
-        Return `None` for unbound fields.
-        """
-        ret = self
-        while hasattr(ret, "parent"):
-            ret = ret.parent
-        return ret if isinstance(ret, SchemaABC) else None
 
 
 class Raw(Field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -187,6 +187,14 @@ class TestParentAndName:
         for field_name in ("bar", "qux"):
             assert schema.fields[field_name].tuple_fields[0].format == "iso8601"
 
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/1808
+    def test_field_named_parent_has_root(self, schema):
+        class MySchema(Schema):
+            parent = fields.Field()
+
+        schema = MySchema()
+        assert schema.fields["parent"].root == schema
+
 
 class TestMetadata:
     @pytest.mark.parametrize("FieldClass", ALL_FIELDS)


### PR DESCRIPTION
Fixes #1808
Close #1809 

Bind the root schema to the field to avoid the parent attribute being overwritten and unusable at runtime. Update the docs to reflect the bind argument can be a field (since 2.1.0).