### PR TITLE
Fix nested schema context thread-safety

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -512,7 +512,7 @@ class Nested(Field):
 
             if isinstance(nested, SchemaABC):
                 self._schema = copy.copy(nested)
-                self._schema.context.update(context)
+                self._schema.context = context
                 # Respect only and exclude passed from parent and re-initialize fields
                 set_class = self._schema.set_class
                 if self.only is not None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2580,6 +2580,25 @@ class TestContext:
         obj = {"inner": {"foo": 42}}
         assert outer.dump(obj)
 
+    def test_context_thread_safe(self):
+        class InnerSchema(Schema):
+            i = fields.Integer()
+
+        class OuterSchema(Schema):
+            inner = fields.Nested(InnerSchema)
+
+        outer_1 = OuterSchema()
+        outer_1.context = {1: 1}
+        outer_1.dump({"inner": {"i": 1}})
+        outer_2 = OuterSchema()
+        outer_2.context = {2: 2}
+        outer_2.dump({"inner": {"i": 1}})
+
+        assert outer_1.context == {1: 1}
+        assert outer_2.context == {2: 2}
+        assert outer_1.fields["inner"].context == {1: 1}
+        assert outer_2.fields["inner"].context == {2: 2}
+
 
 def test_serializer_can_specify_nested_object_as_attribute(blog):
     class BlogUsernameSchema(Schema):


### PR DESCRIPTION
Fixes #1617.
Closes #1791.

This fixes the thread-safety issue but might be a breaking change for people relying on the update: parent schema updates nested schema context. See #1791.