### PR TITLE
Fix: Don't expose Schema fields by name as class/instance attributes

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -42,6 +42,7 @@ def _get_fields(attrs, ordered=False):
     """Get fields from a class. If ordered=True, fields will sorted by creation index.
 
     :param attrs: Mapping of class attributes
+    :param bool ordered: Sort fields by creation index
     """
     fields = [
         (field_name, field_value)
@@ -98,6 +99,10 @@ class SchemaMeta(type):
             else:
                 ordered = False
         cls_fields = _get_fields(attrs, ordered=ordered)
+        # Remove fields from list of class attributes to avoid shadowing
+        # Schema attributes/methods in case of name conflict
+        for field_name, _ in cls_fields:
+            del attrs[field_name]
         klass = super().__new__(mcs, name, bases, attrs)
         inherited_fields = _get_fields_by_mro(klass, ordered=ordered)
 


### PR DESCRIPTION
Reverts "Remove pop argument in _get_fields" from #1631.

Fixes #1837.

See discussion in #1631.

This fix is a breaking change for people relying on the fields being exposed by name, a feature introduced in 3.12. It seems this change did more harm than good and those relying on this may update their code to use the `fields` attribute.