### PR TITLE
Added support for single character TLDs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -93,3 +93,4 @@ Contributors (chronological)
 - Bryce Drennan `@brycedrennan <https://github.com/brycedrennan>`_
 - Cristi Scoarta `@cristi23 <https://github.com/cristi23>`_
 - Nathan `@nbanmp <https://github.com/nbanmp>`_
+- Gautam Krishna R `@gautamkrishnar <https://github.com/gautamkrishnar>`_

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -128,7 +128,7 @@ class Email(Validator):
     DOMAIN_REGEX = re.compile(
         # domain
         r'(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+'
-        r'(?:[A-Z]{2,6}|[A-Z0-9-]{2,})\Z'
+        r'(?:[A-Z]{1,6}|[A-Z0-9-]+)\Z'
         # literal form, ipv4 address (SMTP 4.1.3)
         r'|^\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)'
         r'(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]\Z', re.IGNORECASE | re.UNICODE)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -502,6 +502,13 @@ def test_email_field(SchemaClass):
     s = SchemaClass().dump(u)
     assert s.data['email'] == "john@example.com"
 
+@pytest.mark.parametrize('SchemaClass',
+    [UserSchema, UserMetaSchema])
+def test_email_single_character_tld(SchemaClass):
+    u = User("John", email="john@a.a")
+    s = SchemaClass().dump(u)
+    assert s.data['email'] == "john@a.a"
+
 def test_stored_invalid_email():
     u = {'name': 'John', 'email': 'johnexample.com'}
     s = UserSchema().load(u)


### PR DESCRIPTION
Added support for single character TLDs for the email and domain validation. It will now support TLDs like `a.a`. Refer #1844  for more detaills.

fixes: #1844