### PR TITLE
Fix: TimeDelta Precision Errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 3.14.0 (unreleased)
 *******************
 
+Bug fixes:
+
+- Fix ``fields.TimeDelta`` serialization precision (:issue:`1865`).
+  Thanks :user:`yarsanich` for reporting.
+
 Other changes:
 
 - Fix type-hints for ```data``` arg in ```Schema.validate``` to accept

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1471,7 +1471,9 @@ class TimeDelta(Field):
         if value is None:
             return None
         base_unit = dt.timedelta(**{self.precision: 1})
-        return int(value.total_seconds() / base_unit.total_seconds())
+        delta = utils.timedelta_to_microseconds(value)
+        unit = utils.timedelta_to_microseconds(base_unit)
+        return delta // unit
 
     def _deserialize(self, value, attr, data, **kwargs):
         try:

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -323,3 +323,11 @@ def resolve_field_instance(cls_or_instance):
         if not isinstance(cls_or_instance, FieldABC):
             raise FieldInstanceResolutionError
         return cls_or_instance
+
+
+def timedelta_to_microseconds(value: dt.timedelta) -> int:
+    """Compute the total microseconds of a timedelta
+
+    https://github.com/python/cpython/blob/bb3e0c240bc60fe08d332ff5955d54197f79751c/Lib/datetime.py#L665-L667  # noqa: B950
+    """
+    return (value.days * (24 * 3600) + value.seconds) * 1000000 + value.microseconds

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -712,6 +712,15 @@ class TestFieldSerialization:
         user.d7 = None
         assert field.serialize("d7", user) is None
 
+        # https://github.com/marshmallow-code/marshmallow/issues/1856
+        user.d8 = dt.timedelta(milliseconds=345)
+        field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
+        assert field.serialize("d8", user) == 345
+
+        user.d9 = dt.timedelta(milliseconds=1999)
+        field = fields.TimeDelta(fields.TimeDelta.SECONDS)
+        assert field.serialize("d9", user) == 1
+
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.utcnow(), dt.datetime.now()])
         field = fields.List(fields.DateTime)


### PR DESCRIPTION
Use microsecond integer arithmetic to fix high precision timedelta errors.

Fixes #1865 