### PR TITLE
Fix type-hints for `data` arg in `Schema.validate`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -163,3 +163,4 @@ Contributors (chronological)
 - Javier Fernández `@jfernandz <https://github.com/jfernandz>`_
 - Michael Dimchuk  `@michaeldimchuk <https://github.com/michaeldimchuk>`_
 - Jochen Kupperschmidt  `@homeworkprod <https://github.com/homeworkprod>`_
+- `@yourun-proger <https://github.com/yourun-proger>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Features:
 - Replace ``missing``/``default`` field parameters with
   ``load_default``/``dump_default`` (:pr:`1742`).
   Thanks :user:`sirosen` for the PR.
+- Fix type-hints for ```data``` arg in ```Schema.validate``` to accept
+  list of dictionaries (:issue:`1790`, :pr:`1868`).
+  Thanks  :user:`yourun-proger` for PR
 
 Deprecations:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ Changelog
 
 Other changes:
 
+- Fix type-hints for ```data``` arg in ```Schema.validate``` to accept
+  list of dictionaries (:issue:`1790`, :pr:`1868`).
+  Thanks  :user:`yourun-proger` for PR
 - Don't build universal wheels. We don't support Python 2 anymore.
   (:issue:`1860`) Thanks :user:`YKdvd` for reporting.
 - Make the build reproducible (:pr:`1862`).
-
 - Drop support for Python 3.5 (:pr:`1863`).
 - Test against Python 3.10 (:pr:`1888`).
 
@@ -21,9 +23,6 @@ Features:
 - Replace ``missing``/``default`` field parameters with
   ``load_default``/``dump_default`` (:pr:`1742`).
   Thanks :user:`sirosen` for the PR.
-- Fix type-hints for ```data``` arg in ```Schema.validate``` to accept
-  list of dictionaries (:issue:`1790`, :pr:`1868`).
-  Thanks  :user:`yourun-proger` for PR
 
 Deprecations:
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -774,7 +774,10 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
     def validate(
         self,
-        data: typing.Mapping,
+        data: typing.Union[
+            typing.Mapping[str, typing.Any],
+            typing.Iterable[typing.Mapping[str, typing.Any]],
+        ],
         *,
         many: typing.Optional[bool] = None,
         partial: typing.Optional[typing.Union[bool, types.StrSequenceOrSet]] = None


### PR DESCRIPTION
fixes #1790

Checklist:
- [x] `pre-commit` tests passed
- [x] `CI` passed
- [x] Update `CHANGELOG.rst`
- [x] Add myself to `AUTHORS.rst`