### PR TITLE
Two minor typo fixes

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -15,7 +15,7 @@ Marshmallow makes no assumption about web frameworks or database layers. It will
 Concise, familiar syntax.
 -------------------------
 
-If you have used `Django REST Framework`_ or  `WTForms <https://wtforms.readthedocs.io/en/stable/>`_, marshmallow's :class:`Schema <marshmallow.Schema>` syntax will feel familiar to you. Class-level field attributes define the schema for formatting your data. Configuration is added using the ``class Meta`` paradigm. Configuration options can be overriden at application runtime by passing arguments to the `Schema <marshmallow.Schema>` constructor. The :meth:`dump <marshmallow.Schema.dump>` and :meth:`load <marshmallow.Schema.load>` methods are used for serialization and deserialization (of course!).
+If you have used `Django REST Framework`_ or  `WTForms <https://wtforms.readthedocs.io/en/stable/>`_, marshmallow's :class:`Schema <marshmallow.Schema>` syntax will feel familiar to you. Class-level field attributes define the schema for formatting your data. Configuration is added using the ``class Meta`` paradigm. Configuration options can be overridden at application runtime by passing arguments to the `Schema <marshmallow.Schema>` constructor. The :meth:`dump <marshmallow.Schema.dump>` and :meth:`load <marshmallow.Schema.load>` methods are used for serialization and deserialization (of course!).
 
 Class-based schemas allow for code reuse and configuration.
 -----------------------------------------------------------

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1758,7 +1758,7 @@ class IPInterface(Field):
 
     see https://python.readthedocs.io/en/latest/library/ipaddress.html#interface-objects
 
-    :parm bool exploded: If `True`, serialize ipv6 interface in long form, ie. with groups
+    :param bool exploded: If `True`, serialize ipv6 interface in long form, ie. with groups
         consisting entirely of zeros included.
     """
 


### PR DESCRIPTION
I've been fiddling with a project for checking python code for typos, and it spotted these two.