### PR TITLE
Let data_key and attribute default to field name

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -377,6 +377,7 @@ class Field(FieldABC):
         """
         self.parent = self.parent or schema
         self.name = self.name or field_name
+        self.data_key = self.data_key if self.data_key is not None else field_name
         self.root = self.root or (
             self.parent.root if isinstance(self.parent, FieldABC) else self.parent
         )
@@ -688,7 +689,7 @@ class Pluck(Nested):
     @property
     def _field_data_key(self):
         only_field = self.schema.fields[self.field_name]
-        return only_field.data_key or self.field_name
+        return only_field.data_key
 
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         ret = super()._serialize(nested_obj, attr, obj, **kwargs)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -378,6 +378,7 @@ class Field(FieldABC):
         self.parent = self.parent or schema
         self.name = self.name or field_name
         self.data_key = self.data_key if self.data_key is not None else field_name
+        self.attribute = self.attribute if self.attribute is not None else field_name
         self.root = self.root or (
             self.parent.root if isinstance(self.parent, FieldABC) else self.parent
         )

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -235,7 +235,7 @@ class Field(FieldABC):
     def __repr__(self) -> str:
         return (
             "<fields.{ClassName}(dump_default={self.dump_default!r}, "
-            "attribute={self.attribute!r}, "
+            "attribute={self.attribute!r}, data_key={self.data_key!r}, "
             "validate={self.validate}, required={self.required}, "
             "load_only={self.load_only}, dump_only={self.dump_only}, "
             "load_default={self.load_default}, allow_none={self.allow_none}, "

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -633,7 +633,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         else:
             partial_is_collection = is_collection(partial)
             for attr_name, field_obj in self.load_fields.items():
-                field_name = field_obj.data_key
+                field_name = typing.cast(str, field_obj.data_key)
                 raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -663,7 +663,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     index=index,
                 )
                 if value is not missing:
-                    key = field_obj.attribute
+                    key = typing.cast(str, field_obj.attribute)
                     set_value(ret_d, key, value)
             if unknown != EXCLUDE:
                 fields = {field_obj.data_key for field_obj in self.load_fields.values()}

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -663,7 +663,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     index=index,
                 )
                 if value is not missing:
-                    key = field_obj.attribute or attr_name
+                    key = field_obj.attribute
                     set_value(ret_d, key, value)
             if unknown != EXCLUDE:
                 fields = {field_obj.data_key for field_obj in self.load_fields.values()}
@@ -991,7 +991,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 "Check the following field names and "
                 "data_key arguments: {}".format(list(data_keys_duplicates))
             )
-        load_attributes = [obj.attribute or name for name, obj in load_fields.items()]
+        load_attributes = [obj.attribute for obj in load_fields.values()]
         if len(load_attributes) != len(set(load_attributes)):
             attributes_duplicates = {
                 x for x in load_attributes if load_attributes.count(x) > 1
@@ -1105,7 +1105,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             if many:
                 for idx, item in enumerate(data):
                     try:
-                        value = item[field_obj.attribute or field_name]
+                        value = item[field_obj.attribute]
                     except KeyError:
                         pass
                     else:
@@ -1120,7 +1120,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                             data[idx].pop(field_name, None)
             else:
                 try:
-                    value = data[field_obj.attribute or field_name]
+                    value = data[field_obj.attribute]
                 except KeyError:
                     pass
                 else:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -633,8 +633,8 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         else:
             partial_is_collection = is_collection(partial)
             for attr_name, field_obj in self.load_fields.items():
-                field_name = typing.cast(str, field_obj.data_key)
-                raw_value = data.get(field_name, missing)
+                data_key = typing.cast(str, field_obj.data_key)
+                raw_value = data.get(data_key, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
                     if partial is True or (
@@ -644,7 +644,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 d_kwargs = {}
                 # Allow partial loading of nested schemas.
                 if partial_is_collection:
-                    prefix = field_name + "."
+                    prefix = data_key + "."
                     len_prefix = len(prefix)
                     sub_partial = [
                         f[len_prefix:] for f in partial if f.startswith(prefix)
@@ -653,18 +653,18 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                 else:
                     d_kwargs["partial"] = partial
                 getter = lambda val: field_obj.deserialize(
-                    val, field_name, data, **d_kwargs
+                    val, data_key, data, **d_kwargs
                 )
                 value = self._call_and_store(
                     getter_func=getter,
                     data=raw_value,
-                    field_name=field_name,
+                    field_name=data_key,
                     error_store=error_store,
                     index=index,
                 )
                 if value is not missing:
-                    key = typing.cast(str, field_obj.attribute)
-                    set_value(ret_d, key, value)
+                    attribute = typing.cast(str, field_obj.attribute)
+                    set_value(ret_d, attribute, value)
             if unknown != EXCLUDE:
                 fields = {field_obj.data_key for field_obj in self.load_fields.values()}
                 for key in set(data) - fields:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -520,8 +520,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
             if value is missing:
                 continue
-            key = field_obj.data_key if field_obj.data_key is not None else attr_name
-            ret[key] = value
+            ret[field_obj.data_key] = value
         return ret
 
     def dump(self, obj: typing.Any, *, many: typing.Optional[bool] = None):
@@ -634,9 +633,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         else:
             partial_is_collection = is_collection(partial)
             for attr_name, field_obj in self.load_fields.items():
-                field_name = (
-                    field_obj.data_key if field_obj.data_key is not None else attr_name
-                )
+                field_name = field_obj.data_key
                 raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
@@ -669,10 +666,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     key = field_obj.attribute or attr_name
                     set_value(ret_d, key, value)
             if unknown != EXCLUDE:
-                fields = {
-                    field_obj.data_key if field_obj.data_key is not None else field_name
-                    for field_name, field_obj in self.load_fields.items()
-                }
+                fields = {field_obj.data_key for field_obj in self.load_fields.values()}
                 for key in set(data) - fields:
                     value = data[key]
                     if unknown == INCLUDE:
@@ -986,10 +980,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             if not field_obj.load_only:
                 dump_fields[field_name] = field_obj
 
-        dump_data_keys = [
-            field_obj.data_key if field_obj.data_key is not None else name
-            for name, field_obj in dump_fields.items()
-        ]
+        dump_data_keys = [field_obj.data_key for field_obj in dump_fields.values()]
         if len(dump_data_keys) != len(set(dump_data_keys)):
             data_keys_duplicates = {
                 x for x in dump_data_keys if dump_data_keys.count(x) > 1
@@ -1110,9 +1101,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     continue
                 raise ValueError(f'"{field_name}" field does not exist.') from error
 
-            data_key = (
-                field_obj.data_key if field_obj.data_key is not None else field_name
-            )
+            data_key = field_obj.data_key
             if many:
                 for idx, item in enumerate(data):
                     try:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -92,6 +92,15 @@ class TestField:
         result = MySchema().dump({"name": "Monty", "foo": 42})
         assert result == {"_NaMe": "Monty"}
 
+    def test_data_key_defaults_to_field_name(self):
+        class MySchema(Schema):
+            field_1 = fields.String(data_key="field_one")
+            field_2 = fields.String()
+
+        schema_fields = MySchema().fields
+        assert schema_fields["field_1"].data_key == "field_one"
+        assert schema_fields["field_2"].data_key == "field_2"
+
 
 class TestParentAndName:
     class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -101,6 +101,15 @@ class TestField:
         assert schema_fields["field_1"].data_key == "field_one"
         assert schema_fields["field_2"].data_key == "field_2"
 
+    def test_attribute_defaults_to_field_name(self):
+        class MySchema(Schema):
+            field_1 = fields.String(attribute="field_one")
+            field_2 = fields.String()
+
+        schema_fields = MySchema().fields
+        assert schema_fields["field_1"].attribute == "field_one"
+        assert schema_fields["field_2"].attribute == "field_2"
+
 
 class TestParentAndName:
     class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -32,7 +32,7 @@ class TestField:
         default = "œ∑´"
         field = fields.Field(dump_default=default, attribute=None)
         assert repr(field) == (
-            "<fields.Field(dump_default={0!r}, attribute=None, "
+            "<fields.Field(dump_default={0!r}, attribute=None, data_key=None, "
             "validate=None, required=False, "
             "load_only=False, dump_only=False, "
             "load_default={missing}, allow_none=False, "

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -553,11 +553,10 @@ def test_function_field(serialized_user, user):
 
 
 def test_fields_must_be_declared_as_instances(user):
-    class BadUserSchema(Schema):
-        name = fields.String
-
     with pytest.raises(TypeError, match="must be declared as a Field instance"):
-        BadUserSchema().dump(user)
+
+        class BadUserSchema(Schema):
+            name = fields.String
 
 
 # regression test


### PR DESCRIPTION
Closes #1864.

Trying to address #1864, I get typing issues, as foreseen in https://github.com/marshmallow-code/marshmallow/issues/1864#issuecomment-909225360. I wouldn't mind a bit of help, here.

This change spares users the hassle of checking if `data_key` is `None`, as can be seen in the changes in schema.py. This would be used in apispec, for instance.

Notes:

- In Pluck, we don't check for `None` but only for truthyness, which may be wrong for empty strings. I didn't look into it any further but this PR would fix it.
- I also intend to add `data_key` to the repr. The printed name will be the actual value, be it the parameter or the field name (default). I don't think it is an issue.
- I also intend to do the same with attribute, symmetrically.