### PR TITLE
Add py.typed to MANIFEST.in to include in source distributions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -165,3 +165,4 @@ Contributors (chronological)
 - Jochen Kupperschmidt  `@homeworkprod <https://github.com/homeworkprod>`_
 - `@yourun-proger <https://github.com/yourun-proger>`_
 - Ryan Morehart '@traherom <https://github.com/traherom>`_
+- Ben Windsor  '@bwindsor <https://github.com/bwindsor>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.14.1 (unreleased)
+*******************
+
+Bug fixes:
+
+- Fix publishing type hints per `PEP-561 <https://www.python.org/dev/peps/pep-0561/>`_.
+  Thanks :user:`bwindsor` for the catch and patch.
+
 3.14.0 (2021-10-17)
 *******************
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include *.rst NOTICE
+include src/marshmallow/py.typed
 recursive-include tests *
 recursive-include examples *
 recursive-include docs *


### PR DESCRIPTION
Including `py.typed` via `MANIFEST.in` will ensure that it is included in source distributions, and therefore remain compatible with Mypy for anybody who installs marshmallow via source distribution. A full explanation of the issue can be found in #1904.

Fixes #1904 