### PR TITLE
Fix type information for `__version_info__` to handle prereleases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: v0.910-1
   hooks:
   - id: mypy
-    additional_dependencies: [types-simplejson, types-pytz]
+    additional_dependencies: [types-simplejson, types-pytz, packaging]
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.12.0
   hooks:

--- a/src/marshmallow/__init__.py
+++ b/src/marshmallow/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import typing
 
 from marshmallow.schema import Schema, SchemaOpts
 
@@ -18,11 +17,11 @@ from packaging.version import Version
 
 __version__ = "3.14.1"
 __parsed_version__ = Version(__version__)
-__version_info__: tuple[int, int, int] | tuple[int, int, int, str, int] = typing.cast(
-    tuple[int, int, int], __parsed_version__.release
-)
+__version_info__: tuple[int, int, int] | tuple[
+    int, int, int, str, int
+] = __parsed_version__.release  # type: ignore[assignment]
 if __parsed_version__.pre:
-    __version_info__ += __parsed_version__.pre  # type: ignore
+    __version_info__ += __parsed_version__.pre  # type: ignore[assignment]
 __all__ = [
     "EXCLUDE",
     "INCLUDE",

--- a/src/marshmallow/__init__.py
+++ b/src/marshmallow/__init__.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+import typing
+
 from marshmallow.schema import Schema, SchemaOpts
 
 from . import fields
@@ -15,9 +18,11 @@ from packaging.version import Version
 
 __version__ = "3.14.1"
 __parsed_version__ = Version(__version__)
-__version_info__ = __parsed_version__.release
+__version_info__: tuple[int, int, int] | tuple[int, int, int, str, int] = typing.cast(
+    tuple[int, int, int], __parsed_version__.release
+)
 if __parsed_version__.pre:
-    __version_info__ += __parsed_version__.pre
+    __version_info__ += __parsed_version__.pre  # type: ignore
 __all__ = [
     "EXCLUDE",
     "INCLUDE",


### PR DESCRIPTION
~Running `__version_info__ += __parsed_version__.pre` in `__init__.py` is incorrect (adding tuples). This bug will only be tripped on a prerelease version, so it hasn't had any impact to-date.~
For background, see also: https://github.com/marshmallow-code/webargs/issues/667
EDIT: The issue is not a bug at runtime, but a type annotation is needed for `__version_info__`. Right now, it combines strings and ints but has a type of `tuple[int, ...]`

`__version_info__` was being computed by adding together tuples. `mypy` has started flagging this (I think due to improved `packaging` type information).

To protect against flaws in the correction, and to present accurate type information, the `__version_info__` tuple is built by a utility function.