### PR TITLE
add get_schema_requirements to util

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping
 from email.utils import format_datetime, parsedate_to_datetime
 from pprint import pprint as py_pprint
 
+from marshmallow import Schema
 from marshmallow.base import FieldABC
 from marshmallow.exceptions import FieldInstanceResolutionError
 from marshmallow.warnings import RemovedInMarshmallow4Warning
@@ -333,3 +334,28 @@ def timedelta_to_microseconds(value: dt.timedelta) -> int:
     https://github.com/python/cpython/blob/bb3e0c240bc60fe08d332ff5955d54197f79751c/Lib/datetime.py#L665-L667  # noqa: B950
     """
     return (value.days * (24 * 3600) + value.seconds) * 1000000 + value.microseconds
+
+
+def get_schema_requirements(schema_class: Schema | dict) -> dict:
+    """Given a Schema iterate over the _declared_fields and return dictionaries of the field dictionary
+    """
+    fields = {}
+    for top_key, top_value in getattr(schema_class, "_declared_fields", schema_class).items():
+        field = {}
+        for fkey, fvalue in top_value.__dict__.items():
+            field['class_name'] = top_value.__class__.__name__
+            if fkey in ['dump_default', 'load_default']:
+                field[fkey] = str(fvalue)
+                continue
+            if fkey in ['validate', 'validators']:
+                if isinstance(fvalue, list):
+                    field[fkey] = [x.__dict__ for x in fvalue]
+                else:
+                    field[fkey] = fvalue
+                continue
+            if fkey in ['inner']:
+                field[fkey] = get_schema_requirements({'inner': fvalue}).pop('inner')
+                continue
+            field[fkey] = fvalue
+        fields[top_key] = field
+    return fields


### PR DESCRIPTION
I didn't see in the documentation how to do this.


this doesn't cover all the edge cases, but does cover a use case.

Wanted to serialize all of the field meta data for some frontend code, so the frontend knows about the field layout.

Usage example:


```
n [7]: pprint(get_schema_requirements(DecimalSchema))

{'between': {'_creation_index': 33,
             'allow_none': False,
             'attribute': None,
             'class_name': 'List',
             'data_key': None,
             'dump_default': '<marshmallow.missing>',
             'dump_only': False,
             'error_messages': {'invalid': 'Not a valid list.',
                                'null': 'Field may not be null.',
                                'required': 'Missing data for required field.',
                                'validator_failed': 'Invalid value.'},
             'inner': {'_creation_index': 32,
                       'allow_nan': False,
                       'allow_none': False,
                       'as_string': False,
                       'attribute': None,
                       'class_name': 'StrictDecimal',
                       'data_key': None,
                       'dump_default': '<marshmallow.missing>',
                       'dump_only': False,
                       'error_messages': {'invalid': 'Not a valid number.',
                                          'null': 'Field may not be null.',
                                          'required': 'Missing data for '
                                                      'required field.',
                                          'special': 'Special numeric values '
                                                     '(nan or infinity) are '
                                                     'not permitted.',
                                          'too_large': 'Number too large.',
                                          'validator_failed': 'Invalid value.'},
                       'load_default': '<marshmallow.missing>',
                       'load_only': False,
                       'metadata': {'decimal_places': 2, 'max_digits': 11},
                       'places': None,
                       'required': False,
                       'rounding': None,
                       'validate': None,
                       'validators': []},
             'load_default': '<marshmallow.missing>',
             'load_only': True,
             'metadata': {},
             'required': False,
             'validate': [{'equal': None, 'error': None, 'max': 2, 'min': 2}],
             'validators': [{'equal': None,
                             'error': None,
                             'max': 2,
                             'min': 2}]},
 'between_first': {'_creation_index': 30,
                   'allow_nan': False,
                   'allow_none': False,
                   'as_string': False,
                   'attribute': None,
                   'class_name': 'StrictDecimal',
                   'data_key': None,
                   'dump_default': '<marshmallow.missing>',
                   'dump_only': True,
                   'error_messages': {'invalid': 'Not a valid number.',
                                      'null': 'Field may not be null.',
                                      'required': 'Missing data for required '
                                                  'field.',
                                      'special': 'Special numeric values (nan '
                                                 'or infinity) are not '
                                                 'permitted.',
                                      'too_large': 'Number too large.',
                                      'validator_failed': 'Invalid value.'},
                   'load_default': '<marshmallow.missing>',
                   'load_only': False,
                   'metadata': {'decimal_places': 2, 'max_digits': 11},
                   'places': None,
                   'required': False,
                   'rounding': None,
                   'validate': None,
                   'validators': []},
 'between_second': {'_creation_index': 31,
                    'allow_nan': False,
                    'allow_none': False,
                    'as_string': False,
                    'attribute': None,
                    'class_name': 'StrictDecimal',
                    'data_key': None,
                    'dump_default': '<marshmallow.missing>',
                    'dump_only': True,
                    'error_messages': {'invalid': 'Not a valid number.',
                                       'null': 'Field may not be null.',
                                       'required': 'Missing data for required '
                                                   'field.',
                                       'special': 'Special numeric values (nan '
                                                  'or infinity) are not '
                                                  'permitted.',
                                       'too_large': 'Number too large.',
                                       'validator_failed': 'Invalid value.'},
                    'load_default': '<marshmallow.missing>',
                    'load_only': False,
                    'metadata': {'decimal_places': 2, 'max_digits': 11},
                    'places': None,
                    'required': False,
                    'rounding': None,
                    'validate': None,
                    'validators': []},
```