### PR TITLE
Allow `fields.Nested` to consume a dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 3.15.0 (unreleased)
 *******************
 
+Features:
+
+- Allow passing a `dict` to `fields.Nested` (:pr:`1935`).
+  Thanks :user:`sirosen` for the PR.
+
 Other changes:
 
 - Address distutils deprecation warning in Python 3.10 (:pr:`1903`).

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -508,7 +508,8 @@ class Nested(Field):
         # No
         author = fields.Nested(UserSchema(), only=('id', 'name'))
 
-    :param nested: `Schema` instance, class, class name (string), or callable that returns a `Schema` instance.
+    :param nested: `Schema` instance, class, class name (string), dictionary, or callable that
+        returns a `Schema` or dictionary. Dictionaries are converted with `Schema.from_dict`.
     :param exclude: A list or tuple of fields to exclude.
     :param only: A list or tuple of fields to marshal. If `None`, all fields are marshalled.
         This parameter takes precedence over ``exclude``.
@@ -523,7 +524,11 @@ class Nested(Field):
 
     def __init__(
         self,
-        nested: SchemaABC | type | str | typing.Callable[[], SchemaABC],
+        nested: SchemaABC
+        | type
+        | str
+        | dict[str, Field | type]
+        | typing.Callable[[], SchemaABC | dict[str, Field | type]],
         *,
         dump_default: typing.Any = missing_,
         default: typing.Any = missing_,
@@ -568,6 +573,8 @@ class Nested(Field):
                 nested = self.nested()
             else:
                 nested = self.nested
+            if isinstance(nested, dict):
+                nested = self._nested_from_dict(nested)
 
             if isinstance(nested, SchemaABC):
                 self._schema = copy.copy(nested)
@@ -613,6 +620,13 @@ class Nested(Field):
             for field in getattr(self.root, option_name, set())
             if field.startswith(nested_field)
         ]
+
+    # this helper defers the import of `marshmallow.schema` to avoid circular imports
+    # however, it otherwise aliases Schema.from_dict
+    def _nested_from_dict(self, fields: dict[str, Field | type]) -> type:
+        from marshmallow.schema import Schema
+
+        return Schema.from_dict(fields)
 
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         # Load up the schema first. This allows a RegistryError to be raised

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -574,7 +574,10 @@ class Nested(Field):
             else:
                 nested = self.nested
             if isinstance(nested, dict):
-                nested = self._nested_from_dict(nested)
+                # defer the import of `marshmallow.schema` to avoid circular imports
+                from marshmallow.schema import Schema
+
+                nested = Schema.from_dict(nested)
 
             if isinstance(nested, SchemaABC):
                 self._schema = copy.copy(nested)
@@ -620,13 +623,6 @@ class Nested(Field):
             for field in getattr(self.root, option_name, set())
             if field.startswith(nested_field)
         ]
-
-    # this helper defers the import of `marshmallow.schema` to avoid circular imports
-    # however, it otherwise aliases Schema.from_dict
-    def _nested_from_dict(self, fields: dict[str, Field | type]) -> type:
-        from marshmallow.schema import Schema
-
-        return Schema.from_dict(fields)
 
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         # Load up the schema first. This allows a RegistryError to be raised

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -336,6 +336,25 @@ class TestNestedField:
         with pytest.raises(StringNotCollectionError):
             fields.Nested(Schema, **{param: "foo"})
 
+    @pytest.mark.parametrize(
+        "nested_value",
+        [
+            {"hello": fields.String()},
+            lambda: {"hello": fields.String()},
+        ],
+    )
+    def test_nested_instantiation_from_dict(self, nested_value):
+        class MySchema(Schema):
+            nested = fields.Nested(nested_value)
+
+        schema = MySchema()
+
+        ret = schema.load({"nested": {"hello": "world"}})
+        assert ret == {"nested": {"hello": "world"}}
+
+        with pytest.raises(ValidationError):
+            schema.load({"nested": {"x": 1}})
+
     @pytest.mark.parametrize("schema_unknown", (EXCLUDE, INCLUDE, RAISE))
     @pytest.mark.parametrize("field_unknown", (None, EXCLUDE, INCLUDE, RAISE))
     def test_nested_unknown_override(self, schema_unknown, field_unknown):


### PR DESCRIPTION
To make it easier to leverage `Schema.from_dict`, allow `Nested` to consume a dict mapping names to fields. This is internally passed to `Schema.from_dict`.
That is, what previously would be written

    Nested(Schema.from_dict({"foo": String()}))

can now be written

    Nested({"foo": String()})

This relates to the original use-case for `Schema.from_dict`: easier lightweight schema generation.

---

Currently `webargs` redefines `Nested` to add this behavior, but it leads to a messy situation which I'm trying to sort out.
(References: https://github.com/marshmallow-code/webargs/issues/677 , https://github.com/marshmallow-code/webargs/pull/681 , https://github.com/marshmallow-code/webargs/issues/671 )

Presumably if this feature is useful in `webargs` -- and it looks like support for `webargs`-like use-cases was [the original motivation for `from_dict`](https://github.com/marshmallow-code/marshmallow/issues/1312) -- it would be useful to the broader `marshmallow` userbase.

The only thing which feels messy here is that the `fields` and `schema` modules are carefully avoiding direct dependencies via `base`. That won't work for `from_dict`, so I've wrapped that in a helper which does the import of `Schema` when it is called.