### PR TITLE
Fix Memory Leak

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -247,6 +247,10 @@ class Field(FieldABC):
     def __deepcopy__(self, memo):
         return copy.copy(self)
 
+    def __del__(self):
+        self.parent = None
+        self.root = None
+
     def get_value(self, obj, attr, accessor=None, default=missing_):
         """Return the value for a given key from an object.
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -404,6 +404,11 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         messages.update(self.error_messages or {})
         self.error_messages = messages
 
+    def __del__(self):
+        self.fields = None
+        self.load_fields = None
+        self.dump_fields = None
+
     def __repr__(self) -> str:
         return "<{ClassName}(many={self.many})>".format(
             ClassName=self.__class__.__name__, self=self


### PR DESCRIPTION
Fixes #1943 

The garbage collector is not cleaning up circular references between schemas and fields, so the `__del__()` methods must explicitly clear these references.