### PR TITLE
Run pre-commit autoupdate to update `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v2.31.1
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/python/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
     language_version: python3
@@ -15,7 +15,7 @@ repos:
   - id: flake8
     additional_dependencies: [flake8-bugbear==22.1.11]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v0.942
   hooks:
   - id: mypy
     additional_dependencies: [types-simplejson, types-pytz, packaging]


### PR DESCRIPTION
@sloria, @lafrech, can we fast-track this, assuming CI shows no issues? At `black==22.1.0`, a fresh install (as in CI) gets `click==8.1.0` and fails. There are issues on `black` and on `click` which explain how this happened, but the fix is just to bump `black`.

---

Update to latest tool versions, in particular `black==22.3.0` to fix a bug which caused it to be incompatible with the latest `click` version and crashfail.