### PR TITLE
Type Hinting for Custom SchemaOpts-Class

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -318,7 +318,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
     OPTIONS_CLASS = SchemaOpts  # type: type
 
     # These get set by SchemaMeta
-    opts = None  # type: SchemaOpts
+    opts = None  # type: OPTIONS_CLASS
     _declared_fields = {}  # type: typing.Dict[str, ma_fields.Field]
     _hooks = {}  # type: typing.Dict[types.Tag, typing.List[str]]
 


### PR DESCRIPTION
Currently any additional attributes added to a custom class derived from `ma.schema.SchemaOpts` are not recognized due to this non-dynamic type hint. This change will make custom schema meta options recognizable by any IDE that relies on type hints.