### PR TITLE
Add messages_dict property to ValidationError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies: [types-simplejson, types-pytz, packaging]
+    # these files are checked under `tox -e mypy-test`
+    exclude: ^tests/mypy_test_cases/.*$
 - repo: https://github.com/asottile/blacken-docs
   rev: v1.12.1
   hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ resources:
 jobs:
 - template: job--python-tox.yml@sloria
   parameters:
-    toxenvs: [lint, py37, py310]
+    toxenvs: [lint, mypy-test, py37, py310]
     os: linux
 - template: job--pypi-release.yml@sloria
   parameters:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 
 [tool:pytest]
-norecursedirs = .git .ropeproject .tox docs env venv
+norecursedirs = .git .ropeproject .tox docs env venv tests/mypy_test_cases
 addopts = -v --tb=short
 
 [mypy]

--- a/src/marshmallow/exceptions.py
+++ b/src/marshmallow/exceptions.py
@@ -47,6 +47,15 @@ class ValidationError(MarshmallowError):
             return self.messages
         return {self.field_name: self.messages}
 
+    @property
+    def messages_dict(self) -> dict[str, typing.Any]:
+        if not isinstance(self.messages, dict):
+            raise TypeError(
+                "cannot access 'messages_dict' when 'messages' is of type "
+                + type(self.messages).__name__
+            )
+        return self.messages
+
 
 class RegistryError(NameError):
     """Raised when an invalid operation is performed on the serializer

--- a/tests/mypy_test_cases/test_validation_error.py
+++ b/tests/mypy_test_cases/test_validation_error.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import marshmallow as ma
+
+# OK types for 'message'
+ma.ValidationError("foo")
+ma.ValidationError(["foo"])
+ma.ValidationError({"foo": "bar"})
+
+# non-OK types for 'message'
+ma.ValidationError(0)  # type: ignore[arg-type]
+
+# 'messages' is a dict|list
+err = ma.ValidationError("foo")
+a: dict | list = err.messages
+# union type can't assign to non-union type
+b: str = err.messages  # type: ignore[assignment]
+c: dict = err.messages  # type: ignore[assignment]
+# 'messages_dict' is a dict, so that it can assign to a dict
+d: dict = err.messages_dict

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from marshmallow.exceptions import ValidationError
 
 
@@ -25,3 +27,16 @@ class TestValidationError:
 
         err2 = ValidationError("invalid email", "email")
         assert str(err2) == "invalid email"
+
+    def test_stores_dictionaries_in_messages_dict(self):
+        messages = {"user": {"email": ["email is invalid"]}}
+        err = ValidationError(messages)
+        assert err.messages_dict == messages
+
+    def test_messages_dict_type_error_on_badval(self):
+        err = ValidationError("foo")
+        with pytest.raises(TypeError) as excinfo:
+            err.messages_dict
+        assert "cannot access 'messages_dict' when 'messages' is of type list" in str(
+            excinfo.value
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py37,py38,py39,py310,docs
+envlist = lint,mypy-test,py37,py38,py39,py310,docs
 
 [testenv]
 extras = tests
@@ -9,6 +9,10 @@ commands = pytest {posargs}
 deps = pre-commit~=2.4
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy-test]
+deps = mypy
+commands = mypy --show-error-codes --warn-unused-ignores tests/mypy_test_cases/
 
 [testenv:docs]
 extras = docs


### PR DESCRIPTION
'messages_dict' is an alias for 'messages' which checks if the value is a dict and raises a TypeError if it is not.

This "type asserting property" leads to easier usage with type checkers. In many cases, the 'messages' attribute is known to be a dict, but is annotated as a union type, leading to false negatives from type checkers. Using 'messages_dict', one can write

```python
x: dict = err.messages_dict
```

rather than

```python
x: dict = typing.cast(dict, err.messages)
```

To validate this behavior at type checking time and runtime, two tests are added:

1. A pytest test which checks that the desired TypeError is raised if the value is not a dict

2. A new file to act as a "mypy test case", using `mypy --warn-unused-ignores` to check that things are annotated correctly

(1) is like existing tests, but (2) requires a little bit of new infrastrucutre. A new dir for the tests, which is listed in pytest norecursedirs, and a new tox env (listed in CI as well) which runs `mypy` with the desirable flags.

resolves #1442

---

Some minor notes:
- This behavior was one of a couple of possible solutions for #1442, where it got a 👍 from the OP. It has some faults, but I think it's the simplest solution.
- The testing strategy used for annotations is recommended [in the standalone `typing` docs](https://typing.readthedocs.io/en/latest/source/quality.html#testing-using-mypy-warn-unused-ignores). As far as I know, it's the simplest way of adding testing for type annotations, especially as it doesn't require learning any new tools.