### PR TITLE
Validate values passed for 'unknown'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 (unreleased)
 ************
 
+Features:
+
+- Raise `ValueError` if an invalid value is passed to the ``unknown`` argument (:issue:`1721`, :issue:`1732`).
+  Thanks :user:`sirosen` for the PR.
+
 Other changes:
 
 - Set lower bound for `packaging` requirement (:issue:`1957`).

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -390,7 +390,11 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         self.load_only = set(load_only) or set(self.opts.load_only)
         self.dump_only = set(dump_only) or set(self.opts.dump_only)
         self.partial = partial
-        self.unknown = validate_unknown_parameter_value(unknown or self.opts.unknown)
+        self.unknown = (
+            self.opts.unknown
+            if unknown is None
+            else validate_unknown_parameter_value(unknown)
+        )
         self.context = context or {}
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
@@ -834,7 +838,11 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         error_store = ErrorStore()
         errors = {}  # type: dict[str, list[str]]
         many = self.many if many is None else bool(many)
-        unknown = validate_unknown_parameter_value(unknown or self.unknown)
+        unknown = (
+            self.unknown
+            if unknown is None
+            else validate_unknown_parameter_value(unknown)
+        )
         if partial is None:
             partial = self.partial
         # Run preprocessors

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -34,6 +34,7 @@ from marshmallow.utils import (
     get_value,
     is_collection,
     is_instance_or_subclass,
+    validate_unknown_parameter_value,
 )
 from marshmallow.warnings import RemovedInMarshmallow4Warning
 
@@ -227,7 +228,7 @@ class SchemaOpts:
         self.include = getattr(meta, "include", {})
         self.load_only = getattr(meta, "load_only", ())
         self.dump_only = getattr(meta, "dump_only", ())
-        self.unknown = getattr(meta, "unknown", RAISE)
+        self.unknown = validate_unknown_parameter_value(getattr(meta, "unknown", RAISE))
         self.register = getattr(meta, "register", True)
 
 
@@ -389,7 +390,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         self.load_only = set(load_only) or set(self.opts.load_only)
         self.dump_only = set(dump_only) or set(self.opts.dump_only)
         self.partial = partial
-        self.unknown = unknown or self.opts.unknown
+        self.unknown = validate_unknown_parameter_value(unknown or self.opts.unknown)
         self.context = context or {}
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
@@ -833,7 +834,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         error_store = ErrorStore()
         errors = {}  # type: dict[str, list[str]]
         many = self.many if many is None else bool(many)
-        unknown = unknown or self.unknown
+        unknown = validate_unknown_parameter_value(unknown or self.unknown)
         if partial is None:
             partial = self.partial
         # Run preprocessors

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -20,6 +20,7 @@ from marshmallow.warnings import RemovedInMarshmallow4Warning
 EXCLUDE = "exclude"
 INCLUDE = "include"
 RAISE = "raise"
+_UNKNOWN_VALUES = {EXCLUDE, INCLUDE, RAISE}
 
 
 class _Missing:
@@ -336,7 +337,7 @@ def timedelta_to_microseconds(value: dt.timedelta) -> int:
 
 
 def validate_unknown_parameter_value(obj: typing.Any) -> str:
-    if obj not in (INCLUDE, EXCLUDE, RAISE):
+    if obj not in _UNKNOWN_VALUES:
         raise ValueError(
             f"Object {obj!r} is not a valid value for the 'unknown' parameter"
         )

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -333,3 +333,11 @@ def timedelta_to_microseconds(value: dt.timedelta) -> int:
     https://github.com/python/cpython/blob/bb3e0c240bc60fe08d332ff5955d54197f79751c/Lib/datetime.py#L665-L667  # noqa: B950
     """
     return (value.days * (24 * 3600) + value.seconds) * 1000000 + value.microseconds
+
+
+def validate_unknown_parameter_value(obj: typing.Any) -> str:
+    if obj not in (INCLUDE, EXCLUDE, RAISE):
+        raise ValueError(
+            f"Object {obj!r} is not a valid value for the 'unknown' parameter"
+        )
+    return obj

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,49 +1,46 @@
 import datetime as dt
 import decimal
-import random
 import math
-from collections import namedtuple, OrderedDict
-
-import simplejson as json
+import random
+from collections import OrderedDict, namedtuple
 
 import pytest
-
+import simplejson as json
 from marshmallow import (
+    EXCLUDE,
+    INCLUDE,
+    RAISE,
     Schema,
+    class_registry,
     fields,
     utils,
     validates,
     validates_schema,
-    EXCLUDE,
-    INCLUDE,
-    RAISE,
-    class_registry,
 )
 from marshmallow.exceptions import (
-    ValidationError,
-    StringNotCollectionError,
     RegistryError,
+    StringNotCollectionError,
+    ValidationError,
 )
 
 from tests.base import (
-    UserSchema,
-    UserMetaSchema,
-    UserRelativeUrlSchema,
-    ExtendedUserSchema,
-    UserIntSchema,
-    UserFloatStringSchema,
-    BlogSchema,
-    BlogUserMetaSchema,
+    Blog,
     BlogOnlySchema,
-    UserExcludeSchema,
-    UserAdditionalSchema,
+    BlogSchema,
     BlogSchemaExclude,
     BlogSchemaMeta,
+    BlogUserMetaSchema,
+    ExtendedUserSchema,
     User,
+    UserAdditionalSchema,
+    UserExcludeSchema,
+    UserFloatStringSchema,
+    UserIntSchema,
+    UserMetaSchema,
+    UserRelativeUrlSchema,
+    UserSchema,
     mockjson,
-    Blog,
 )
-
 
 random.seed(1)
 
@@ -2919,7 +2916,10 @@ def test_unknown_parameter_value_is_validated(usage_location):
     class MySchema(Schema):
         foo = fields.String()
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+        ValueError,
+        match="Object 'badval' is not a valid value for the 'unknown' parameter",
+    ):
         # Meta.unknown setting gets caught at class creation time, since that's when
         # metaclass __new__ runs
         if usage_location == "meta":
@@ -2933,8 +2933,3 @@ def test_unknown_parameter_value_is_validated(usage_location):
             MySchema(unknown="badval")
         else:
             MySchema().load({"foo": "bar"}, unknown="badval")
-
-    assert (
-        str(excinfo.value)
-        == "Object 'badval' is not a valid value for the 'unknown' parameter"
-    )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2912,3 +2912,29 @@ def test_class_registry_returns_schema_type():
 
     SchemaClass = class_registry.get_class(DefinitelyUniqueSchema.__name__)
     assert SchemaClass is DefinitelyUniqueSchema
+
+
+@pytest.mark.parametrize("usage_location", ["meta", "init", "load"])
+def test_unknown_parameter_value_is_validated(usage_location):
+    class MySchema(Schema):
+        foo = fields.String()
+
+    with pytest.raises(ValueError) as excinfo:
+        # Meta.unknown setting gets caught at class creation time, since that's when
+        # metaclass __new__ runs
+        if usage_location == "meta":
+
+            class SubSchema(MySchema):
+                class Meta:
+                    unknown = "badval"
+
+        # usages in init and load are caught at call time, as expected
+        elif usage_location == "init":
+            MySchema(unknown="badval")
+        else:
+            MySchema().load({"foo": "bar"}, unknown="badval")
+
+    assert (
+        str(excinfo.value)
+        == "Object 'badval' is not a valid value for the 'unknown' parameter"
+    )


### PR DESCRIPTION
There are three places that a user can pass a value for 'unknown':
- `Meta` in a Schema class definition
- `Schema.__init__`
- `Schema.load`

For each of these, call an internal check to confirm that the value is valid. In cases where `unknown or self.unknown` is used to support `None`, do the validation after the `or`.

A new test case covers these three locations and confirms that passing an unknown (hah!) value causes a ValueError.

closes #1721, #1732