### PR TITLE
Set lower bound for `packaging` requirement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+(unreleased)
+************
+
+Other changes:
+
+- Set lower bound for `packaging` requirement (:issue:`1957`).
+  Thanks :user:`MatthewNicolTR` for reporting and thanks :user:`sirosen` for the PR.
+
 3.15.0 (2022-03-12)
 *******************
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     package_dir={"": "src"},
     package_data={"marshmallow": ["py.typed"]},
     include_package_data=True,
-    install_requires=["packaging"],
+    install_requires=["packaging>=17.0"],
     extras_require=EXTRAS_REQUIRE,
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
Set this at 17.0 as the first version which added the `release` property to `Version` objects.

closes #1957

---

Looking at open issues for "easy wins". This is a one-line change to package data and seems pretty safe.