### PR TITLE
Remove Meta.order_by from peewee example

### DIFF
--- a/examples/peewee_example.py
+++ b/examples/peewee_example.py
@@ -38,9 +38,6 @@ class Todo(BaseModel):
     user = pw.ForeignKeyField(User)
     posted_on = pw.DateTimeField()
 
-    class Meta:
-        order_by = ("-posted_on",)
-
 
 def create_tables():
     db.connect()


### PR DESCRIPTION
order_by was deprecated and removed from peewee

closes #1980