### PR TITLE
Fix serialization of List items if they are serialized by fields.Method.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -169,3 +169,4 @@ Contributors (chronological)
 - Kevin Kirsche `@kkirsche <https://github.com/kkirsche>`_
 - Isira Seneviratne `@Isira-Seneviratne <https://github.com/Isira-Seneviratne>`_
 - Karthikeyan Singaravelan `@tirkarthi  <https://github.com/tirkarthi>`_
+- Benedek Horváth `@benedekh <https://github.com/benedekh>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -763,7 +763,8 @@ class List(Field):
     def _bind_to_schema(self, field_name, schema):
         super()._bind_to_schema(field_name, schema)
         self.inner = copy.deepcopy(self.inner)
-        self.inner._bind_to_schema(field_name, self)
+        self.inner.parent = self
+        self.inner._bind_to_schema(field_name, schema)
         if isinstance(self.inner, Nested):
             self.inner.only = self.only
             self.inner.exclude = self.exclude

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -665,3 +665,16 @@ class TestDictNested:
                     "daughter": {"value": {"age": ["Missing data for required field."]}}
                 }
             }
+
+
+class TestMethodSerializationOfListItems:
+    def test_method_serialization_of_list_items(self):
+        class ExampleSchema(Schema):
+            dummy_list = fields.List(fields.Method(serialize="serialize_me"))
+
+            def serialize_me(self, obj):
+                return [str(value) for value in obj["dummy_list"]]
+
+        obj = {"dummy_list": ["hello", "world"]}
+        dumped = ExampleSchema().dump(obj)
+        assert dumped == {"dummy_list": [["hello", "world"], ["hello", "world"]]}


### PR DESCRIPTION
Fixes #1993. 

This PR fixes a bug that is present in marshmallow 3.15.0 and 3.16.0 at least. The problem is, list items cannot be serialized by fields.Method due to wrong schema being attached to fields.Method. This PR fixes the bug and provides a minimalistic unit test to demonstrate the bug and to test the fix.