### PR TITLE
Support serialization as float in TimeDelta field

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -169,3 +169,4 @@ Contributors (chronological)
 - Kevin Kirsche `@kkirsche <https://github.com/kkirsche>`_
 - Isira Seneviratne `@Isira-Seneviratne <https://github.com/Isira-Seneviratne>`_
 - Karthikeyan Singaravelan `@tirkarthi  <https://github.com/tirkarthi>`_
+- Marco Satti `@marcosatti  <https://github.com/marcosatti>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1440,7 +1440,7 @@ class TimeDelta(Field):
     :param precision: Influences how the integer or float is interpreted during
         (de)serialization. Must be 'days', 'seconds', 'microseconds',
         'milliseconds', 'minutes', 'hours' or 'weeks'.
-    :param serde_type: Whether to (de)serialize to a `int` or `float`.
+    :param serialization_type: Whether to (de)serialize to a `int` or `float`.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
 
     Integer Caveats
@@ -1453,16 +1453,15 @@ class TimeDelta(Field):
     Use of `float` when (de)serializing may result in data precision loss due
     to the way machines handle floating point values.
 
-    Microseconds is the smallest unit able to be represented wholly.
-    Smaller units than microseconds cannot be properly deserialized and will result
-    in the truncation of any fractional data. This is only possible when using `float`.
-    For example, 1.12345 interpreted as microseconds will result in `timedelta(microseconds=1)`.
+    Regardless of the precision chosen, the fractional part when using `float`
+    will always be truncated to microseconds.
+    For example, `1.12345` interpreted as microseconds will result in `timedelta(microseconds=1)`.
 
     .. versionchanged:: 2.0.0
         Always serializes to an integer value to avoid rounding errors.
         Add `precision` parameter.
     .. versionchanged:: 3.17.0
-        Allow (de)serialization to `float` through use of a new `serde_type` parameter.
+        Allow (de)serialization to `float` through use of a new `serialization_type` parameter.
         `int` is the default to retain previous behaviour.
     """
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -692,11 +692,66 @@ class TestFieldDeserialization:
         assert result.seconds == 123
         assert result.microseconds == 456000
 
+        total_microseconds_value = 322.0
+        field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS, float)
+        result = field.deserialize(total_microseconds_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(microseconds=1).total_seconds()
+        assert math.isclose(
+            result.total_seconds() / unit_value, total_microseconds_value
+        )
+
+        total_microseconds_value = 322.12345
+        field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS, float)
+        result = field.deserialize(total_microseconds_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(microseconds=1).total_seconds()
+        assert math.isclose(
+            result.total_seconds() / unit_value, math.floor(total_microseconds_value)
+        )
+
+        total_milliseconds_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS, float)
+        result = field.deserialize(total_milliseconds_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(milliseconds=1).total_seconds()
+        assert math.isclose(
+            result.total_seconds() / unit_value, total_milliseconds_value
+        )
+
         total_seconds_value = 322.223
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        field = fields.TimeDelta(fields.TimeDelta.SECONDS, float)
         result = field.deserialize(total_seconds_value)
         assert isinstance(result, dt.timedelta)
-        assert result.total_seconds() == total_seconds_value
+        assert math.isclose(result.total_seconds(), total_seconds_value)
+
+        total_minutes_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.MINUTES, float)
+        result = field.deserialize(total_minutes_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(minutes=1).total_seconds()
+        assert math.isclose(result.total_seconds() / unit_value, total_minutes_value)
+
+        total_hours_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.HOURS, float)
+        result = field.deserialize(total_hours_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(hours=1).total_seconds()
+        assert math.isclose(result.total_seconds() / unit_value, total_hours_value)
+
+        total_days_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.DAYS, float)
+        result = field.deserialize(total_days_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(days=1).total_seconds()
+        assert math.isclose(result.total_seconds() / unit_value, total_days_value)
+
+        total_weeks_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.WEEKS, float)
+        result = field.deserialize(total_weeks_value)
+        assert isinstance(result, dt.timedelta)
+        unit_value = dt.timedelta(weeks=1).total_seconds()
+        assert math.isclose(result.total_seconds() / unit_value, total_weeks_value)
 
     @pytest.mark.parametrize("in_value", ["", "badvalue", [], 9999999999])
     def test_invalid_timedelta_field_deserialization(self, in_value):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -692,6 +692,12 @@ class TestFieldDeserialization:
         assert result.seconds == 123
         assert result.microseconds == 456000
 
+        total_seconds_value = 322.223
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        result = field.deserialize(total_seconds_value)
+        assert isinstance(result, dt.timedelta)
+        assert result.total_seconds() == total_seconds_value
+
     @pytest.mark.parametrize("in_value", ["", "badvalue", [], 9999999999])
     def test_invalid_timedelta_field_deserialization(self, in_value):
         field = fields.TimeDelta(fields.TimeDelta.DAYS)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -771,6 +771,9 @@ class TestFieldSerialization:
             field.serialize("d10", user), user.d10.total_seconds() / unit_value
         )
 
+        with pytest.raises(ValueError):
+            fields.TimeDelta(fields.TimeDelta.SECONDS, str)
+
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.utcnow(), dt.datetime.now()])
         field = fields.List(fields.DateTime)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,6 +5,7 @@ import itertools
 import decimal
 import uuid
 import ipaddress
+import math
 
 import pytest
 
@@ -658,8 +659,6 @@ class TestFieldSerialization:
         assert field.serialize("d1", user) == 86401000001
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
         assert field.serialize("d1", user) == 24
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d1", user) == user.d1.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d2", user) == 1
@@ -667,8 +666,6 @@ class TestFieldSerialization:
         assert field.serialize("d2", user) == 86401
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d2", user) == 86401000001
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d2", user) == user.d2.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d3", user) == 1
@@ -676,8 +673,6 @@ class TestFieldSerialization:
         assert field.serialize("d3", user) == 86401
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d3", user) == 86401000001
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d3", user) == user.d3.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d4", user) == 0
@@ -685,8 +680,6 @@ class TestFieldSerialization:
         assert field.serialize("d4", user) == 0
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d4", user) == 0
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d4", user) == user.d4.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d5", user) == -1
@@ -694,8 +687,6 @@ class TestFieldSerialization:
         assert field.serialize("d5", user) == -86400
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d5", user) == -86400000000
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d5", user) == user.d5.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
         assert field.serialize("d6", user) == 1
@@ -718,8 +709,6 @@ class TestFieldSerialization:
         assert field.serialize("d6", user) == d6_seconds * 1000 + 1
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d6", user) == d6_seconds * 10**6 + 1000 + 1
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        assert field.serialize("d6", user) == user.d6.total_seconds()
 
         user.d7 = None
         assert field.serialize("d7", user) is None
@@ -742,9 +731,45 @@ class TestFieldSerialization:
             milliseconds=10,
             microseconds=742,
         )
-        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
-        # Test for reasonable approximate equality. No guarantees are made about accuracy.
-        assert abs(field.serialize("d10", user) - 1130751.010742) < 0.1
+
+        field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS, float)
+        unit_value = dt.timedelta(microseconds=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
+
+        field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS, float)
+        unit_value = dt.timedelta(milliseconds=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
+
+        field = fields.TimeDelta(fields.TimeDelta.SECONDS, float)
+        assert math.isclose(field.serialize("d10", user), user.d10.total_seconds())
+
+        field = fields.TimeDelta(fields.TimeDelta.MINUTES, float)
+        unit_value = dt.timedelta(minutes=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
+
+        field = fields.TimeDelta(fields.TimeDelta.HOURS, float)
+        unit_value = dt.timedelta(hours=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
+
+        field = fields.TimeDelta(fields.TimeDelta.DAYS, float)
+        unit_value = dt.timedelta(days=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
+
+        field = fields.TimeDelta(fields.TimeDelta.WEEKS, float)
+        unit_value = dt.timedelta(weeks=1).total_seconds()
+        assert math.isclose(
+            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+        )
 
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.utcnow(), dt.datetime.now()])

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -658,6 +658,8 @@ class TestFieldSerialization:
         assert field.serialize("d1", user) == 86401000001
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
         assert field.serialize("d1", user) == 24
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d1", user) == user.d1.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d2", user) == 1
@@ -665,6 +667,8 @@ class TestFieldSerialization:
         assert field.serialize("d2", user) == 86401
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d2", user) == 86401000001
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d2", user) == user.d2.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d3", user) == 1
@@ -672,6 +676,8 @@ class TestFieldSerialization:
         assert field.serialize("d3", user) == 86401
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d3", user) == 86401000001
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d3", user) == user.d3.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d4", user) == 0
@@ -679,6 +685,8 @@ class TestFieldSerialization:
         assert field.serialize("d4", user) == 0
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d4", user) == 0
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d4", user) == user.d4.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         assert field.serialize("d5", user) == -1
@@ -686,6 +694,8 @@ class TestFieldSerialization:
         assert field.serialize("d5", user) == -86400
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d5", user) == -86400000000
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d5", user) == user.d5.total_seconds()
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
         assert field.serialize("d6", user) == 1
@@ -708,6 +718,8 @@ class TestFieldSerialization:
         assert field.serialize("d6", user) == d6_seconds * 1000 + 1
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         assert field.serialize("d6", user) == d6_seconds * 10**6 + 1000 + 1
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        assert field.serialize("d6", user) == user.d6.total_seconds()
 
         user.d7 = None
         assert field.serialize("d7", user) is None
@@ -720,6 +732,19 @@ class TestFieldSerialization:
         user.d9 = dt.timedelta(milliseconds=1999)
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
         assert field.serialize("d9", user) == 1
+
+        user.d10 = dt.timedelta(
+            weeks=1,
+            days=6,
+            hours=2,
+            minutes=5,
+            seconds=51,
+            milliseconds=10,
+            microseconds=742,
+        )
+        field = fields.TimeDelta(fields.TimeDelta.TOTAL_SECONDS)
+        # Test for reasonable approximate equality. No guarantees are made about accuracy.
+        assert abs(field.serialize("d10", user) - 1130751.010742) < 0.1
 
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.utcnow(), dt.datetime.now()])


### PR DESCRIPTION
Add functionality to (de)serialize to float values as a representation of the total seconds. 

In our use case, we are trying to specify a period which is a combination of seconds, milliseconds and microseconds, which is easier to represent as a single floating point value rather than specifying the smallest unit (microseconds). We have currently been serializing to a `fields.Float()` using `.total_seconds()` and the equivalent to deserialize.

The feature does not promise absolute precision, which is stated in the docs (same restrictions as floating point values).

This does not change the current way `TimeDelta` is used.
