### PR TITLE
docs: fix simple typo, stict -> strict

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1801,7 +1801,7 @@ class IPv6(IP):
 class IPInterface(Field):
     """A IPInterface field.
 
-    IP interface is the non-stict form of the IPNetwork type where arbitrary host
+    IP interface is the non-strict form of the IPNetwork type where arbitrary host
     addresses are always accepted.
 
     IPAddress and mask e.g. '192.168.0.2/24' or '192.168.0.2/255.255.255.0'


### PR DESCRIPTION
There is a small typo in src/marshmallow/fields.py.

Should read `strict` rather than `stict`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md