### PR TITLE
Add Enum field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1905,8 +1905,6 @@ class EnumValue(Field):
 
     def __init__(self, cls_or_instance: Field | type, enum: type[Enum], **kwargs):
         super().__init__(**kwargs)
-        self.enum = enum
-        self.choices = ", ".join([str(m.value) for m in enum])
         try:
             self.field = resolve_field_instance(cls_or_instance)
         except FieldInstanceResolutionError as error:
@@ -1914,6 +1912,10 @@ class EnumValue(Field):
                 "The enum field must be a subclass or instance of "
                 "marshmallow.base.FieldABC."
             ) from error
+        self.enum = enum
+        self.choices = ", ".join(
+            [str(self.field._serialize(m.value, None, None)) for m in enum]
+        )
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1864,15 +1864,10 @@ class EnumSymbol(String):
         "unknown": "Must be one of: {choices}.",
     }
 
-    def __init__(
-        self,
-        enum,
-        *args,
-        **kwargs,
-    ):
+    def __init__(self, enum: type[Enum], **kwargs):
         self.enum = enum
         self.choices = ", ".join(enum.__members__)
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def _serialize(self, value, attr, obj, **kwargs):
         if value is None:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -59,9 +59,9 @@ __all__ = [
     "IPInterface",
     "IPv4Interface",
     "IPv6Interface",
-    "Enum",
-    "StringEnum",
-    "IntegerEnum",
+    "EnumSymbol",
+    "StringEnumValue",
+    "IntegerEnumValue",
     "Method",
     "Function",
     "Str",
@@ -1858,7 +1858,7 @@ class IPv6Interface(IPInterface):
     DESERIALIZATION_CLASS = ipaddress.IPv6Interface
 
 
-class Enum(String):
+class EnumSymbol(String):
 
     default_error_messages = {
         "unknown": "Must be one of: {choices}.",
@@ -1887,7 +1887,7 @@ class Enum(String):
             raise self.make_error("unknown", choices=self.choices) from exc
 
 
-class TypedEnum:
+class EnumValue:
     """Base class for typed Enum fields"""
 
     default_error_messages = {
@@ -1917,11 +1917,11 @@ class TypedEnum:
             raise self.make_error("unknown", choices=self.choices) from exc
 
 
-class StringEnum(TypedEnum, String):
+class StringEnumValue(EnumValue, String):
     """String Enum"""
 
 
-class IntegerEnum(TypedEnum, Integer):
+class IntegerEnumValue(EnumValue, Integer):
     """Integer Enum"""
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1859,6 +1859,12 @@ class IPv6Interface(IPInterface):
 
 
 class EnumSymbol(String):
+    """An Enum field (de)serializing enum members by symbol (name) as string.
+
+    :param enum Enum: Enum class
+
+    .. versionadded:: 3.18.0
+    """
 
     default_error_messages = {
         "unknown": "Must be one of: {choices}.",
@@ -1883,7 +1889,15 @@ class EnumSymbol(String):
 
 
 class EnumValue(Field):
-    """Base class for typed Enum fields"""
+    """An Enum field (de)serializing enum members by value.
+
+    A Field must be provided to (de)serialize the value.
+
+    :param cls_or_instance: Field class or instance.
+    :param enum Enum: Enum class
+
+    .. versionadded:: 3.18.0
+    """
 
     default_error_messages = {
         "unknown": "Must be one of: {choices}.",

--- a/tests/base.py
+++ b/tests/base.py
@@ -48,9 +48,9 @@ ALL_FIELDS = [
     fields.IPInterface,
     fields.IPv4Interface,
     fields.IPv6Interface,
-    functools.partial(fields.Enum, GenderEnum),
-    functools.partial(fields.StringEnum, HairColorEnum),
-    functools.partial(fields.IntegerEnum, GenderEnum),
+    functools.partial(fields.EnumSymbol, GenderEnum),
+    functools.partial(fields.StringEnumValue, HairColorEnum),
+    functools.partial(fields.IntegerEnumValue, GenderEnum),
 ]
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,7 @@
 """Test utilities and fixtures."""
 import datetime as dt
 import uuid
-from enum import IntEnum
+from enum import Enum, IntEnum
 
 import simplejson
 
@@ -17,6 +17,13 @@ class GenderEnum(IntEnum):
     male = 1
     female = 2
     non_binary = 3
+
+
+class HairColorEnum(Enum):
+    black = "black hair"
+    brown = "brown hair"
+    blond = "blond hair"
+    red = "red hair"
 
 
 ALL_FIELDS = [
@@ -41,6 +48,8 @@ ALL_FIELDS = [
     fields.IPv4Interface,
     fields.IPv6Interface,
     lambda **x: fields.Enum(GenderEnum, **x),
+    lambda **x: fields.StringEnum(HairColorEnum, **x),
+    lambda **x: fields.IntegerEnum(GenderEnum, **x),
 ]
 
 
@@ -79,6 +88,7 @@ class User:
         birthtime=None,
         balance=100,
         sex=GenderEnum.male,
+        hair_color=HairColorEnum.black,
         employer=None,
         various_data=None,
     ):
@@ -95,7 +105,7 @@ class User:
         self.email = email
         self.balance = balance
         self.registered = registered
-        self.hair_colors = ["black", "brown", "blond", "redhead"]
+        self.hair_colors = list(HairColorEnum.__members__)
         self.sex_choices = list(GenderEnum.__members__)
         self.finger_count = 10
         self.uid = uuid.uuid1()
@@ -104,6 +114,7 @@ class User:
         self.birthtime = birthtime or dt.time(0, 1, 2, 3333)
         self.activation_date = dt.date(2013, 12, 11)
         self.sex = sex
+        self.hair_color = hair_color
         self.employer = employer
         self.relatives = []
         self.various_data = various_data or {

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,7 @@
 """Test utilities and fixtures."""
 import datetime as dt
 import uuid
+from enum import IntEnum
 
 import simplejson
 
@@ -10,6 +11,12 @@ from marshmallow import Schema, fields, post_load, validate, missing
 from marshmallow.exceptions import ValidationError
 
 central = pytz.timezone("US/Central")
+
+
+class GenderEnum(IntEnum):
+    male = 1
+    female = 2
+    non_binary = 3
 
 
 ALL_FIELDS = [
@@ -33,7 +40,9 @@ ALL_FIELDS = [
     fields.IPInterface,
     fields.IPv4Interface,
     fields.IPv6Interface,
+    lambda **x: fields.Enum(GenderEnum, **x),
 ]
+
 
 ##### Custom asserts #####
 
@@ -69,7 +78,7 @@ class User:
         birthdate=None,
         birthtime=None,
         balance=100,
-        sex="male",
+        sex=GenderEnum.male,
         employer=None,
         various_data=None,
     ):
@@ -87,7 +96,7 @@ class User:
         self.balance = balance
         self.registered = registered
         self.hair_colors = ["black", "brown", "blond", "redhead"]
-        self.sex_choices = ("male", "female")
+        self.sex_choices = list(GenderEnum.__members__)
         self.finger_count = 10
         self.uid = uuid.uuid1()
         self.time_registered = time_registered or dt.time(1, 23, 45, 6789)
@@ -180,7 +189,7 @@ class UserSchema(Schema):
     birthtime = fields.Time()
     activation_date = fields.Date()
     since_created = fields.TimeDelta()
-    sex = fields.Str(validate=validate.OneOf(["male", "female"]))
+    sex = fields.Str(validate=validate.OneOf(list(GenderEnum.__members__)))
     various_data = fields.Dict()
 
     class Meta:

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,5 @@
 """Test utilities and fixtures."""
+import functools
 import datetime as dt
 import uuid
 from enum import Enum, IntEnum
@@ -47,9 +48,9 @@ ALL_FIELDS = [
     fields.IPInterface,
     fields.IPv4Interface,
     fields.IPv6Interface,
-    lambda **x: fields.Enum(GenderEnum, **x),
-    lambda **x: fields.StringEnum(HairColorEnum, **x),
-    lambda **x: fields.IntegerEnum(GenderEnum, **x),
+    functools.partial(fields.Enum, GenderEnum),
+    functools.partial(fields.StringEnum, HairColorEnum),
+    functools.partial(fields.IntegerEnum, GenderEnum),
 ]
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -49,8 +49,8 @@ ALL_FIELDS = [
     fields.IPv4Interface,
     fields.IPv6Interface,
     functools.partial(fields.EnumSymbol, GenderEnum),
-    functools.partial(fields.StringEnumValue, HairColorEnum),
-    functools.partial(fields.IntegerEnumValue, GenderEnum),
+    functools.partial(fields.EnumValue, fields.String, HairColorEnum),
+    functools.partial(fields.EnumValue, fields.Integer, GenderEnum),
 ]
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,6 +27,12 @@ class HairColorEnum(Enum):
     red = "red hair"
 
 
+class DateEnum(Enum):
+    date_1 = dt.date(2004, 2, 29)
+    date_2 = dt.date(2008, 2, 29)
+    date_3 = dt.date(2012, 2, 29)
+
+
 ALL_FIELDS = [
     fields.String,
     fields.Integer,

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -17,6 +17,7 @@ from tests.base import (
     ALL_FIELDS,
     GenderEnum,
     HairColorEnum,
+    DateEnum,
 )
 
 
@@ -1096,52 +1097,56 @@ class TestFieldDeserialization:
 
         assert excinfo.value.args[0] == "Not a valid IPv6 interface."
 
-    def test_enum_field_deserialization(self):
+    def test_enumsymbol_field_deserialization(self):
         field = fields.EnumSymbol(GenderEnum)
         assert field.deserialize("male") == GenderEnum.male
 
-    def test_enum_field_invalid_value(self):
+    def test_enumsymbol_field_invalid_value(self):
         field = fields.EnumSymbol(GenderEnum)
         with pytest.raises(
             ValidationError, match="Must be one of: male, female, non_binary."
         ):
             field.deserialize("dummy")
 
-    def test_enum_field_not_string(self):
+    def test_enumsymbol_field_not_string(self):
         field = fields.EnumSymbol(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
-    def test_stringenum_field_deserialization(self):
+    def test_enumvalue_field_deserialization(self):
         field = fields.EnumValue(fields.String, HairColorEnum)
         assert field.deserialize("black hair") == HairColorEnum.black
+        field = fields.EnumValue(fields.Integer, GenderEnum)
+        assert field.deserialize(1) == GenderEnum.male
+        field = fields.EnumValue(fields.Date, DateEnum)
+        assert field.deserialize("2004-02-29") == DateEnum.date_1
 
-    def test_stringenum_field_invalid_value(self):
+    def test_enumvalue_field_invalid_value(self):
         field = fields.EnumValue(fields.String, HairColorEnum)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
         ):
             field.deserialize("dummy")
-
-    def test_stringenum_field_not_string(self):
-        field = fields.EnumValue(fields.String, HairColorEnum)
-        with pytest.raises(ValidationError, match="Not a valid string."):
-            field.deserialize(12)
-
-    def test_integerenum_field_deserialization(self):
-        field = fields.EnumValue(fields.Integer, GenderEnum)
-        assert field.deserialize(1) == GenderEnum.male
-
-    def test_integerenum_field_invalid_value(self):
         field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
+        field = fields.EnumValue(fields.Date, DateEnum)
+        with pytest.raises(
+            ValidationError, match="Must be one of: 2004-02-29, 2008-02-29, 2012-02-29."
+        ):
+            field.deserialize("2004-02-28")
 
-    def test_integerenum_field_not_integer(self):
+    def test_enumvalue_field_wrong_type(self):
+        field = fields.EnumValue(fields.String, HairColorEnum)
+        with pytest.raises(ValidationError, match="Not a valid string."):
+            field.deserialize(12)
         field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
+        field = fields.EnumValue(fields.Date, DateEnum)
+        with pytest.raises(ValidationError, match="Not a valid date."):
+            field.deserialize("2004-02-30")
 
     def test_deserialization_function_must_be_callable(self):
         with pytest.raises(TypeError):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -16,6 +16,7 @@ from tests.base import (
     central,
     ALL_FIELDS,
     GenderEnum,
+    HairColorEnum,
 )
 
 
@@ -1095,27 +1096,52 @@ class TestFieldDeserialization:
 
         assert excinfo.value.args[0] == "Not a valid IPv6 interface."
 
-    @pytest.mark.parametrize("by_value,value", ((True, 1), (False, "male")))
-    def test_enum_field_deserialization(self, by_value, value):
-        field = fields.Enum(GenderEnum, by_value=by_value)
-        assert field.deserialize(value) == GenderEnum.male
+    def test_enum_field_deserialization(self):
+        field = fields.Enum(GenderEnum)
+        assert field.deserialize("male") == GenderEnum.male
 
-    @pytest.mark.parametrize(
-        "by_value,exc_str",
-        (
-            (True, "Must be one of: 1, 2, 3"),
-            (False, "Must be one of: male, female, non_binary"),
-        ),
-    )
-    def test_enum_field_invalid_value(self, by_value, exc_str):
-        field = fields.Enum(GenderEnum, by_value=by_value)
-        with pytest.raises(ValidationError, match=exc_str):
+    def test_enum_field_invalid_value(self):
+        field = fields.Enum(GenderEnum)
+        with pytest.raises(
+            ValidationError, match="Must be one of: male, female, non_binary."
+        ):
             field.deserialize("dummy")
 
-    def test_enum_field_by_name_not_string(self):
+    def test_enum_field_not_string(self):
         field = fields.Enum(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
+
+    def test_stringenum_field_deserialization(self):
+        field = fields.StringEnum(HairColorEnum)
+        assert field.deserialize("black hair") == HairColorEnum.black
+
+    def test_stringenum_field_invalid_value(self):
+        field = fields.StringEnum(HairColorEnum)
+        with pytest.raises(
+            ValidationError,
+            match="Must be one of: black hair, brown hair, blond hair, red hair.",
+        ):
+            field.deserialize("dummy")
+
+    def test_stringenum_field_not_string(self):
+        field = fields.StringEnum(HairColorEnum)
+        with pytest.raises(ValidationError, match="Not a valid string."):
+            field.deserialize(12)
+
+    def test_integerenum_field_deserialization(self):
+        field = fields.IntegerEnum(GenderEnum)
+        assert field.deserialize(1) == GenderEnum.male
+
+    def test_integerenum_field_invalid_value(self):
+        field = fields.IntegerEnum(GenderEnum)
+        with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
+            field.deserialize(12)
+
+    def test_integerenum_field_not_integer(self):
+        field = fields.IntegerEnum(GenderEnum)
+        with pytest.raises(ValidationError, match="Not a valid integer."):
+            field.deserialize("dummy")
 
     def test_deserialization_function_must_be_callable(self):
         with pytest.raises(TypeError):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1118,8 +1118,8 @@ class TestFieldDeserialization:
         assert field.deserialize("black hair") == HairColorEnum.black
         field = fields.EnumValue(fields.Integer, GenderEnum)
         assert field.deserialize(1) == GenderEnum.male
-        field = fields.EnumValue(fields.Date, DateEnum)
-        assert field.deserialize("2004-02-29") == DateEnum.date_1
+        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        assert field.deserialize("29/02/2004") == DateEnum.date_1
 
     def test_enumvalue_field_invalid_value(self):
         field = fields.EnumValue(fields.String, HairColorEnum)
@@ -1131,11 +1131,11 @@ class TestFieldDeserialization:
         field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
-        field = fields.EnumValue(fields.Date, DateEnum)
+        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
         with pytest.raises(
-            ValidationError, match="Must be one of: 2004-02-29, 2008-02-29, 2012-02-29."
+            ValidationError, match="Must be one of: 29/02/2004, 29/02/2008, 29/02/2012."
         ):
-            field.deserialize("2004-02-28")
+            field.deserialize("28/02/2004")
 
     def test_enumvalue_field_wrong_type(self):
         field = fields.EnumValue(fields.String, HairColorEnum)
@@ -1144,9 +1144,9 @@ class TestFieldDeserialization:
         field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
-        field = fields.EnumValue(fields.Date, DateEnum)
+        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
         with pytest.raises(ValidationError, match="Not a valid date."):
-            field.deserialize("2004-02-30")
+            field.deserialize("30/02/2004")
 
     def test_deserialization_function_must_be_callable(self):
         with pytest.raises(TypeError):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1097,27 +1097,27 @@ class TestFieldDeserialization:
         assert excinfo.value.args[0] == "Not a valid IPv6 interface."
 
     def test_enum_field_deserialization(self):
-        field = fields.Enum(GenderEnum)
+        field = fields.EnumSymbol(GenderEnum)
         assert field.deserialize("male") == GenderEnum.male
 
     def test_enum_field_invalid_value(self):
-        field = fields.Enum(GenderEnum)
+        field = fields.EnumSymbol(GenderEnum)
         with pytest.raises(
             ValidationError, match="Must be one of: male, female, non_binary."
         ):
             field.deserialize("dummy")
 
     def test_enum_field_not_string(self):
-        field = fields.Enum(GenderEnum)
+        field = fields.EnumSymbol(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
     def test_stringenum_field_deserialization(self):
-        field = fields.StringEnum(HairColorEnum)
+        field = fields.StringEnumValue(HairColorEnum)
         assert field.deserialize("black hair") == HairColorEnum.black
 
     def test_stringenum_field_invalid_value(self):
-        field = fields.StringEnum(HairColorEnum)
+        field = fields.StringEnumValue(HairColorEnum)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
@@ -1125,21 +1125,21 @@ class TestFieldDeserialization:
             field.deserialize("dummy")
 
     def test_stringenum_field_not_string(self):
-        field = fields.StringEnum(HairColorEnum)
+        field = fields.StringEnumValue(HairColorEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
     def test_integerenum_field_deserialization(self):
-        field = fields.IntegerEnum(GenderEnum)
+        field = fields.IntegerEnumValue(GenderEnum)
         assert field.deserialize(1) == GenderEnum.male
 
     def test_integerenum_field_invalid_value(self):
-        field = fields.IntegerEnum(GenderEnum)
+        field = fields.IntegerEnumValue(GenderEnum)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
 
     def test_integerenum_field_not_integer(self):
-        field = fields.IntegerEnum(GenderEnum)
+        field = fields.IntegerEnumValue(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1113,11 +1113,11 @@ class TestFieldDeserialization:
             field.deserialize(12)
 
     def test_stringenum_field_deserialization(self):
-        field = fields.StringEnumValue(HairColorEnum)
+        field = fields.EnumValue(fields.String, HairColorEnum)
         assert field.deserialize("black hair") == HairColorEnum.black
 
     def test_stringenum_field_invalid_value(self):
-        field = fields.StringEnumValue(HairColorEnum)
+        field = fields.EnumValue(fields.String, HairColorEnum)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
@@ -1125,21 +1125,21 @@ class TestFieldDeserialization:
             field.deserialize("dummy")
 
     def test_stringenum_field_not_string(self):
-        field = fields.StringEnumValue(HairColorEnum)
+        field = fields.EnumValue(fields.String, HairColorEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
     def test_integerenum_field_deserialization(self):
-        field = fields.IntegerEnumValue(GenderEnum)
+        field = fields.EnumValue(fields.Integer, GenderEnum)
         assert field.deserialize(1) == GenderEnum.male
 
     def test_integerenum_field_invalid_value(self):
-        field = fields.IntegerEnumValue(GenderEnum)
+        field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
 
     def test_integerenum_field_not_integer(self):
-        field = fields.IntegerEnumValue(GenderEnum)
+        field = fields.EnumValue(fields.Integer, GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -257,17 +257,17 @@ class TestFieldSerialization:
 
     def test_enum_field_serialization(self, user):
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum)
+        field = fields.EnumSymbol(GenderEnum)
         assert field.serialize("sex", user) == "male"
 
     def test_stringenum_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
-        field = fields.StringEnum(HairColorEnum)
+        field = fields.StringEnumValue(HairColorEnum)
         assert field.serialize("hair_color", user) == "black hair"
 
     def test_integerenum_field_serialization(self, user):
         user.sex = GenderEnum.male
-        field = fields.IntegerEnum(GenderEnum)
+        field = fields.IntegerEnumValue(GenderEnum)
         assert field.serialize("sex", user) == 1
 
     def test_decimal_field(self, user):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -262,12 +262,12 @@ class TestFieldSerialization:
 
     def test_stringenum_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
-        field = fields.StringEnumValue(HairColorEnum)
+        field = fields.EnumValue(fields.String, HairColorEnum)
         assert field.serialize("hair_color", user) == "black hair"
 
     def test_integerenum_field_serialization(self, user):
         user.sex = GenderEnum.male
-        field = fields.IntegerEnumValue(GenderEnum)
+        field = fields.EnumValue(fields.Integer, GenderEnum)
         assert field.serialize("sex", user) == 1
 
     def test_decimal_field(self, user):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,7 +11,7 @@ import pytest
 
 from marshmallow import Schema, fields, missing as missing_
 
-from tests.base import User, ALL_FIELDS, central, GenderEnum
+from tests.base import User, ALL_FIELDS, central, GenderEnum, HairColorEnum
 
 
 class DateTimeList:
@@ -255,11 +255,20 @@ class TestFieldSerialization:
             == ipv6interface_exploded_string
         )
 
-    @pytest.mark.parametrize("by_value,value", ((True, 1), (False, "male")))
-    def test_enum_field_serialization(self, user, by_value, value):
+    def test_enum_field_serialization(self, user):
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum, by_value=by_value)
-        assert field.serialize("sex", user) == value
+        field = fields.Enum(GenderEnum)
+        assert field.serialize("sex", user) == "male"
+
+    def test_stringenum_field_serialization(self, user):
+        user.hair_color = HairColorEnum.black
+        field = fields.StringEnum(HairColorEnum)
+        assert field.serialize("hair_color", user) == "black hair"
+
+    def test_integerenum_field_serialization(self, user):
+        user.sex = GenderEnum.male
+        field = fields.IntegerEnum(GenderEnum)
+        assert field.serialize("sex", user) == 1
 
     def test_decimal_field(self, user):
         user.m1 = 12

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,7 +11,7 @@ import pytest
 
 from marshmallow import Schema, fields, missing as missing_
 
-from tests.base import User, ALL_FIELDS, central
+from tests.base import User, ALL_FIELDS, central, GenderEnum
 
 
 class DateTimeList:
@@ -254,6 +254,12 @@ class TestFieldSerialization:
             field_exploded.serialize("ipv6interface", user)
             == ipv6interface_exploded_string
         )
+
+    @pytest.mark.parametrize("by_value,value", ((True, 1), (False, "male")))
+    def test_enum_field_serialization(self, user, by_value, value):
+        user.sex = GenderEnum.male
+        field = fields.Enum(GenderEnum, by_value=by_value)
+        assert field.serialize("sex", user) == value
 
     def test_decimal_field(self, user):
         user.m1 = 12

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -268,8 +268,8 @@ class TestFieldSerialization:
         field = fields.EnumValue(fields.Integer, GenderEnum)
         assert field.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
-        field = fields.EnumValue(fields.Date, DateEnum)
-        assert field.serialize("some_date", user) == "2004-02-29"
+        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        assert field.serialize("some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):
         user.m1 = 12

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -11,7 +11,7 @@ import pytest
 
 from marshmallow import Schema, fields, missing as missing_
 
-from tests.base import User, ALL_FIELDS, central, GenderEnum, HairColorEnum
+from tests.base import User, ALL_FIELDS, central, GenderEnum, HairColorEnum, DateEnum
 
 
 class DateTimeList:
@@ -255,20 +255,21 @@ class TestFieldSerialization:
             == ipv6interface_exploded_string
         )
 
-    def test_enum_field_serialization(self, user):
+    def test_enumsymbol_field_serialization(self, user):
         user.sex = GenderEnum.male
         field = fields.EnumSymbol(GenderEnum)
         assert field.serialize("sex", user) == "male"
 
-    def test_stringenum_field_serialization(self, user):
+    def test_enumvalue_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
         field = fields.EnumValue(fields.String, HairColorEnum)
         assert field.serialize("hair_color", user) == "black hair"
-
-    def test_integerenum_field_serialization(self, user):
         user.sex = GenderEnum.male
         field = fields.EnumValue(fields.Integer, GenderEnum)
         assert field.serialize("sex", user) == 1
+        user.some_date = DateEnum.date_1
+        field = fields.EnumValue(fields.Date, DateEnum)
+        assert field.serialize("some_date", user) == "2004-02-29"
 
     def test_decimal_field(self, user):
         user.m1 = 12


### PR DESCRIPTION
Replaces @orenc17's #1885.

This is a long standing feature request. See for instance discussions in #267.

The status quo is that people can use @justanr's [marshmallow_enum](https://github.com/justanr/marshmallow_enum).

Currently, this lib doesn't seem actively maintained. I don't blame the author. A few things are outdated, deprecated stuff. The changes since MA3 have been user contributed and some are still missing.

I'm thinking if we recommend this lib as the reference choice, why not integrate it in code? This is what I've been trying to do.

I started by importing the code and updating it for PY3/MA3.

I also removed the dump/load asymmetry (dump by value, load by name) that I found awkward and revamped the error message generation.

I was still not happy with the `by_value`/`by_name` mechanism. I serialize by name, so I could live with only this, but I understand the need for serializing by value (to get an int or a nicer string). However, I like the type to be well-defined so that we can inherit deserialization from basic fields, and to help documenting the type (e.g. in apispec).

My proposal is therefore an `Enum` field serializing by name, and typed enum fields `StringEnum` and `IntegerEnum`, to serialize by value with a given type. Users would be free to create new types but I believe those cover most cases.

Transition from `marshmallow_enum` should be relatively smooth for users who don't use the dump/load asymmetry and who don't rely on exact error messages.

This still lacks a bit of doc but I'd rather get feedback before polishing.

Note we can't use `OneOf` validator because validation occurs after deserialization and wrong values are caught at deserialization already.
