### PR TITLE
Add return type to `fields.Email.__init__` so that it's not untyped

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1731,7 +1731,7 @@ class Email(String):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid email address."}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # Insert validation into self.validators so that multiple errors can be stored.
         validator = validate.Email(error=self.error_messages["invalid"])


### PR DESCRIPTION
This merge request adds a type hint to `fields.Email`'s `__init__ method to avoid no untyped call errors in mypy for library consumers.