### PR TITLE
Merge EnumSymbol and EnumValue into Enum field

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -55,8 +55,8 @@ ALL_FIELDS = [
     fields.IPv4Interface,
     fields.IPv6Interface,
     functools.partial(fields.Enum, GenderEnum),
-    functools.partial(fields.Enum, HairColorEnum, fields.String),
-    functools.partial(fields.Enum, GenderEnum, fields.Integer),
+    functools.partial(fields.Enum, HairColorEnum, by_value=fields.String),
+    functools.partial(fields.Enum, GenderEnum, by_value=fields.Integer),
 ]
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -54,9 +54,9 @@ ALL_FIELDS = [
     fields.IPInterface,
     fields.IPv4Interface,
     fields.IPv6Interface,
-    functools.partial(fields.EnumSymbol, GenderEnum),
-    functools.partial(fields.EnumValue, fields.String, HairColorEnum),
-    functools.partial(fields.EnumValue, fields.Integer, GenderEnum),
+    functools.partial(fields.Enum, GenderEnum),
+    functools.partial(fields.Enum, HairColorEnum, fields.String),
+    functools.partial(fields.Enum, GenderEnum, fields.Integer),
 ]
 
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1097,60 +1097,82 @@ class TestFieldDeserialization:
 
         assert excinfo.value.args[0] == "Not a valid IPv6 interface."
 
-    def test_enum_by_symbol_field_deserialization(self):
+    def test_enum_field_by_symbol_deserialization(self):
         field = fields.Enum(GenderEnum)
         assert field.deserialize("male") == GenderEnum.male
 
-    def test_enum_by_symbol_field_invalid_value(self):
+    def test_enum_field_by_symbol_invalid_value(self):
         field = fields.Enum(GenderEnum)
         with pytest.raises(
             ValidationError, match="Must be one of: male, female, non_binary."
         ):
             field.deserialize("dummy")
 
-    def test_enum_by_symbol_field_not_string(self):
+    def test_enum_field_by_symbol_not_string(self):
         field = fields.Enum(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
-    def test_enum_by_value_field_deserialization(self):
-        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
+    def test_enum_field_by_value_true_deserialization(self):
+        field = fields.Enum(HairColorEnum, by_value=True)
         assert field.deserialize("black hair") == HairColorEnum.black
-        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True)
         assert field.deserialize(1) == GenderEnum.male
-        field = fields.Enum(
-            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
-        )
+
+    def test_enum_field_by_value_field_deserialization(self):
+        field = fields.Enum(HairColorEnum, by_value=fields.String)
+        assert field.deserialize("black hair") == HairColorEnum.black
+        field = fields.Enum(GenderEnum, by_value=fields.Integer)
+        assert field.deserialize(1) == GenderEnum.male
+        field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
         assert field.deserialize("29/02/2004") == DateEnum.date_1
 
-    def test_enum_by_value_field_invalid_value(self):
-        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
+    def test_enum_field_by_value_true_invalid_value(self):
+        field = fields.Enum(HairColorEnum, by_value=True)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
         ):
             field.deserialize("dummy")
-        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
-        field = fields.Enum(
-            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
-        )
+
+    def test_enum_field_by_value_field_invalid_value(self):
+        field = fields.Enum(HairColorEnum, by_value=fields.String)
+        with pytest.raises(
+            ValidationError,
+            match="Must be one of: black hair, brown hair, blond hair, red hair.",
+        ):
+            field.deserialize("dummy")
+        field = fields.Enum(GenderEnum, by_value=fields.Integer)
+        with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
+            field.deserialize(12)
+        field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
         with pytest.raises(
             ValidationError, match="Must be one of: 29/02/2004, 29/02/2008, 29/02/2012."
         ):
             field.deserialize("28/02/2004")
 
-    def test_enum_by_value_field_wrong_type(self):
-        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
+    def test_enum_field_by_value_true_wrong_type(self):
+        field = fields.Enum(HairColorEnum, by_value=True)
+        with pytest.raises(
+            ValidationError,
+            match="Must be one of: black hair, brown hair, blond hair, red hair.",
+        ):
+            field.deserialize("dummy")
+        field = fields.Enum(GenderEnum, by_value=True)
+        with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
+            field.deserialize(12)
+
+    def test_enum_field_by_value_field_wrong_type(self):
+        field = fields.Enum(HairColorEnum, by_value=fields.String)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
-        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=fields.Integer)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
-        field = fields.Enum(
-            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
-        )
+        field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
         with pytest.raises(ValidationError, match="Not a valid date."):
             field.deserialize("30/02/2004")
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1097,54 +1097,54 @@ class TestFieldDeserialization:
 
         assert excinfo.value.args[0] == "Not a valid IPv6 interface."
 
-    def test_enumsymbol_field_deserialization(self):
-        field = fields.EnumSymbol(GenderEnum)
+    def test_enum_by_symbol_field_deserialization(self):
+        field = fields.Enum(GenderEnum)
         assert field.deserialize("male") == GenderEnum.male
 
-    def test_enumsymbol_field_invalid_value(self):
-        field = fields.EnumSymbol(GenderEnum)
+    def test_enum_by_symbol_field_invalid_value(self):
+        field = fields.Enum(GenderEnum)
         with pytest.raises(
             ValidationError, match="Must be one of: male, female, non_binary."
         ):
             field.deserialize("dummy")
 
-    def test_enumsymbol_field_not_string(self):
-        field = fields.EnumSymbol(GenderEnum)
+    def test_enum_by_symbol_field_not_string(self):
+        field = fields.Enum(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
 
-    def test_enumvalue_field_deserialization(self):
-        field = fields.EnumValue(fields.String, HairColorEnum)
+    def test_enum_by_value_field_deserialization(self):
+        field = fields.Enum(HairColorEnum, fields.String)
         assert field.deserialize("black hair") == HairColorEnum.black
-        field = fields.EnumValue(fields.Integer, GenderEnum)
+        field = fields.Enum(GenderEnum, fields.Integer)
         assert field.deserialize(1) == GenderEnum.male
-        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
         assert field.deserialize("29/02/2004") == DateEnum.date_1
 
-    def test_enumvalue_field_invalid_value(self):
-        field = fields.EnumValue(fields.String, HairColorEnum)
+    def test_enum_by_value_field_invalid_value(self):
+        field = fields.Enum(HairColorEnum, fields.String)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
         ):
             field.deserialize("dummy")
-        field = fields.EnumValue(fields.Integer, GenderEnum)
+        field = fields.Enum(GenderEnum, fields.Integer)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
-        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
         with pytest.raises(
             ValidationError, match="Must be one of: 29/02/2004, 29/02/2008, 29/02/2012."
         ):
             field.deserialize("28/02/2004")
 
-    def test_enumvalue_field_wrong_type(self):
-        field = fields.EnumValue(fields.String, HairColorEnum)
+    def test_enum_by_value_field_wrong_type(self):
+        field = fields.Enum(HairColorEnum, fields.String)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
-        field = fields.EnumValue(fields.Integer, GenderEnum)
+        field = fields.Enum(GenderEnum, fields.Integer)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
-        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
         with pytest.raises(ValidationError, match="Not a valid date."):
             field.deserialize("30/02/2004")
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1114,37 +1114,43 @@ class TestFieldDeserialization:
             field.deserialize(12)
 
     def test_enum_by_value_field_deserialization(self):
-        field = fields.Enum(HairColorEnum, fields.String)
+        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
         assert field.deserialize("black hair") == HairColorEnum.black
-        field = fields.Enum(GenderEnum, fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
         assert field.deserialize(1) == GenderEnum.male
-        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
+        field = fields.Enum(
+            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
+        )
         assert field.deserialize("29/02/2004") == DateEnum.date_1
 
     def test_enum_by_value_field_invalid_value(self):
-        field = fields.Enum(HairColorEnum, fields.String)
+        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
         with pytest.raises(
             ValidationError,
             match="Must be one of: black hair, brown hair, blond hair, red hair.",
         ):
             field.deserialize("dummy")
-        field = fields.Enum(GenderEnum, fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
         with pytest.raises(ValidationError, match="Must be one of: 1, 2, 3."):
             field.deserialize(12)
-        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
+        field = fields.Enum(
+            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
+        )
         with pytest.raises(
             ValidationError, match="Must be one of: 29/02/2004, 29/02/2008, 29/02/2012."
         ):
             field.deserialize("28/02/2004")
 
     def test_enum_by_value_field_wrong_type(self):
-        field = fields.Enum(HairColorEnum, fields.String)
+        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
         with pytest.raises(ValidationError, match="Not a valid string."):
             field.deserialize(12)
-        field = fields.Enum(GenderEnum, fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
         with pytest.raises(ValidationError, match="Not a valid integer."):
             field.deserialize("dummy")
-        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
+        field = fields.Enum(
+            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
+        )
         with pytest.raises(ValidationError, match="Not a valid date."):
             field.deserialize("30/02/2004")
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -255,22 +255,29 @@ class TestFieldSerialization:
             == ipv6interface_exploded_string
         )
 
-    def test_enum_by_symbol_field_serialization(self, user):
+    def test_enum_field_by_symbol_serialization(self, user):
         user.sex = GenderEnum.male
         field = fields.Enum(GenderEnum)
         assert field.serialize("sex", user) == "male"
 
-    def test_enum_by_value_field_serialization(self, user):
+    def test_enum_field_by_value_true_serialization(self, user):
         user.hair_color = HairColorEnum.black
-        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
+        field = fields.Enum(HairColorEnum, by_value=True)
         assert field.serialize("hair_color", user) == "black hair"
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True)
         assert field.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
-        field = fields.Enum(
-            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
-        )
+
+    def test_enum_field_by_value_field_serialization(self, user):
+        user.hair_color = HairColorEnum.black
+        field = fields.Enum(HairColorEnum, by_value=fields.String)
+        assert field.serialize("hair_color", user) == "black hair"
+        user.sex = GenderEnum.male
+        field = fields.Enum(GenderEnum, by_value=fields.Integer)
+        assert field.serialize("sex", user) == 1
+        user.some_date = DateEnum.date_1
+        field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
         assert field.serialize("some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -262,13 +262,15 @@ class TestFieldSerialization:
 
     def test_enum_by_value_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
-        field = fields.Enum(HairColorEnum, fields.String)
+        field = fields.Enum(HairColorEnum, by_value=True, field=fields.String)
         assert field.serialize("hair_color", user) == "black hair"
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum, fields.Integer)
+        field = fields.Enum(GenderEnum, by_value=True, field=fields.Integer)
         assert field.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
-        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
+        field = fields.Enum(
+            DateEnum, by_value=True, field=fields.Date(format="%d/%m/%Y")
+        )
         assert field.serialize("some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -255,20 +255,20 @@ class TestFieldSerialization:
             == ipv6interface_exploded_string
         )
 
-    def test_enumsymbol_field_serialization(self, user):
+    def test_enum_by_symbol_field_serialization(self, user):
         user.sex = GenderEnum.male
-        field = fields.EnumSymbol(GenderEnum)
+        field = fields.Enum(GenderEnum)
         assert field.serialize("sex", user) == "male"
 
-    def test_enumvalue_field_serialization(self, user):
+    def test_enum_by_value_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
-        field = fields.EnumValue(fields.String, HairColorEnum)
+        field = fields.Enum(HairColorEnum, fields.String)
         assert field.serialize("hair_color", user) == "black hair"
         user.sex = GenderEnum.male
-        field = fields.EnumValue(fields.Integer, GenderEnum)
+        field = fields.Enum(GenderEnum, fields.Integer)
         assert field.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
-        field = fields.EnumValue(fields.Date(format="%d/%m/%Y"), DateEnum)
+        field = fields.Enum(DateEnum, fields.Date(format="%d/%m/%Y"))
         assert field.serialize("some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):


### PR DESCRIPTION
On second thought, this fits more with our fields naming rationale. Generally, the field name represents the type in object world and the serialization type is defined at init (with an argument such as format, etc.).

I'd like to merge this before publishing 3.18. If this needs more thought and we want to ship a bugfix before, we can revert the merge of #2017.