### PR TITLE
Rework Integer._validated

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -998,11 +998,7 @@ class Integer(Number):
 
     # override Number
     def _validated(self, value):
-        if self.strict:
-            if isinstance(value, numbers.Number) and isinstance(
-                value, numbers.Integral
-            ):
-                return super()._validated(value)
+        if self.strict and not isinstance(value, numbers.Integral):
             raise self.make_error("invalid", input=value)
         return super()._validated(value)
 


### PR DESCRIPTION
Just passed by and figured I had to read it several times and the logic could be simplified.

Also, checking both Number an Integral seems redundant:

```
>>> issubclass(numbers.Integral, numbers.Number)
True
```