### PR TITLE
Fix Field._serialize typing

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -387,7 +387,9 @@ class Field(FieldABC):
             self.parent.root if isinstance(self.parent, FieldABC) else self.parent
         )
 
-    def _serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
+    def _serialize(
+        self, value: typing.Any, attr: str | None, obj: typing.Any, **kwargs
+    ):
         """Serializes ``value`` to a basic Python datatype. Noop by default.
         Concrete :class:`Field` classes should implement this method.
 


### PR DESCRIPTION
We sometimes pass `None` (in `Mapping`).

Also `_deserialize` does the same.

Got caught by this while working on `Enum` field.