### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.1
+  rev: v2.37.3
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
 - repo: https://github.com/python/black
-  rev: 22.3.0
+  rev: 22.8.0
   hooks:
   - id: black
     language_version: python3
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 5.0.4
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear==22.1.11]
+    additional_dependencies: [flake8-bugbear==22.9.11]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.960
+  rev: v0.971
   hooks:
   - id: mypy
     additional_dependencies: [types-simplejson, types-pytz, packaging]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,10 @@
 license_files = LICENSE
 
 [flake8]
-extend-ignore = E203, E266, E501, E731, B903
 max-line-length = 90
 max-complexity = 18
-select = B,C,E,F,W,T4,B9
+extend-select = B,C,T4
+extend-ignore = E203, E266, E501, E731, B903
 
 [tool:pytest]
 norecursedirs = .git .ropeproject .tox docs env venv tests/mypy_test_cases

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ license_files = LICENSE
 [flake8]
 max-line-length = 90
 max-complexity = 18
-extend-select = B,C,T4
 extend-ignore = E203, E266, E501, E731, B903
 
 [tool:pytest]

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -1063,7 +1063,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             raise error
         self.on_bind_field(field_name, field_obj)
 
-    @lru_cache(maxsize=8)
+    @lru_cache(maxsize=8)  # noqa (https://github.com/PyCQA/flake8-bugbear/issues/310)
     def _has_processors(self, tag) -> bool:
         return bool(self._hooks[(tag, True)] or self._hooks[(tag, False)])
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -658,14 +658,17 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     d_kwargs["partial"] = sub_partial
                 else:
                     d_kwargs["partial"] = partial
-                # lambda function does not bind loop variables
-                # but we don't mind since we call getter in this iteration
-                getter = lambda val: field_obj.deserialize(  # noqa: B023
-                    val,
-                    field_name,  # noqa: B023
-                    data,
-                    **d_kwargs,  # noqa: B023
-                )
+
+                def getter(
+                    val, field_obj=field_obj, field_name=field_name, d_kwargs=d_kwargs
+                ):
+                    return field_obj.deserialize(
+                        val,
+                        field_name,
+                        data,
+                        **d_kwargs,
+                    )
+
                 value = self._call_and_store(
                     getter_func=getter,
                     data=raw_value,

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -658,8 +658,13 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                     d_kwargs["partial"] = sub_partial
                 else:
                     d_kwargs["partial"] = partial
-                getter = lambda val: field_obj.deserialize(
-                    val, field_name, data, **d_kwargs
+                # lambda function does not bind loop variables
+                # but we don't mind since we call getter in this iteration
+                getter = lambda val: field_obj.deserialize(  # noqa: B023
+                    val,
+                    field_name,  # noqa: B023
+                    data,
+                    **d_kwargs,  # noqa: B023
                 )
                 value = self._call_and_store(
                     getter_func=getter,


### PR DESCRIPTION
Looks like pre-commit libs are a bit outdated (maybe showing we should be using pre-commit-ci ?).

I had to fix the config due to complicated issues I tried to explain in https://github.com/PyCQA/flake8/issues/1687.

Also, this updates flake8-bugbear which raises 2 new issues.

For one of them I think we can disable locally with a comment saying we know what we're doing.

The other error is about the use of `lru_cache`:

    src/marshmallow/schema.py:1063:6: B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks. The cache may retain instance references, preventing garbage collection.

I'm not sure it is that bad since we set a maxsize. pylint doesn't seem to care in this case (https://github.com/PyCQA/pylint/pull/6181). We could ignore locally. Or rework the method but is it worth it?

Edit: remove `extend-select` thanks to @asottile suggestion in https://github.com/PyCQA/flake8/issues/1687#issuecomment-1248290052.

Edit: perhaps define a function rather than disable the warning about the lambda