### PR TITLE
RFC alternative key in serialized data

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -138,6 +138,7 @@ class Field(FieldABC):
     #  for those fields
     _CHECK_ATTRIBUTE = True
     _creation_index = 0  # Used for sorting
+    _deserialized_key: str | None = None
 
     #: Default error messages for various kinds of errors. The keys in this dictionary
     #: are passed to `Field.make_error`. The values are error messages passed to
@@ -156,6 +157,7 @@ class Field(FieldABC):
         dump_default: typing.Any = missing_,
         default: typing.Any = missing_,
         data_key: str | None = None,
+        alternative: str | None = None,
         attribute: str | None = None,
         validate: None
         | (
@@ -194,6 +196,7 @@ class Field(FieldABC):
 
         self.attribute = attribute
         self.data_key = data_key
+        self.alternative = alternative
         self.validate = validate
         if validate is None:
             self.validators = []

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -388,12 +388,66 @@ class TestValidatesDecorator:
         errors = schema.validate({"foo-name": "data"})
         assert "foo-name" in errors
         assert errors["foo-name"] == ["nope"]
+        schema = BadSchema()
+        errors = schema.validate(
+            [{"foo-name": "data"}, {"foo-name": "data2"}], many=True
+        )
+        assert errors == {0: {"foo-name": ["nope"]}, 1: {"foo-name": ["nope"]}}
+
+    def test_validates_with_alternative(self):
+        class BadSchema(Schema):
+            foo = fields.String(alternative="foo-name")
+
+            @validates("foo")
+            def validate_string(self, data):
+                raise ValidationError("nope")
+
+        schema = BadSchema()
+        errors = schema.validate({"foo-name": "data"})
+        assert "foo-name" in errors
+        assert errors["foo-name"] == ["nope"]
 
         schema = BadSchema()
         errors = schema.validate(
             [{"foo-name": "data"}, {"foo-name": "data2"}], many=True
         )
         assert errors == {0: {"foo-name": ["nope"]}, 1: {"foo-name": ["nope"]}}
+
+    def test_validates_data_key_with_alternative(self):
+        class BadSchema(Schema):
+            foo = fields.String(data_key="foo-name", alternative="alt-foo")
+
+            @validates("foo")
+            def validate_string(self, data):
+                raise ValidationError("nope")
+
+        schema = BadSchema()
+        errors = schema.validate({"foo-name": "data"})
+        assert "foo-name" in errors
+        assert errors["foo-name"] == ["nope"]
+
+        schema = BadSchema()
+        errors = schema.validate(
+            [{"foo-name": "data"}, {"foo-name": "data2"}], many=True
+        )
+        assert errors == {0: {"foo-name": ["nope"]}, 1: {"foo-name": ["nope"]}}
+
+    def test_validates_alternative_with_data_key(self):
+        class BadSchema(Schema):
+            foo = fields.String(data_key="foo-name", alternative="alt-foo")
+
+            @validates("foo")
+            def validate_string(self, data):
+                raise ValidationError("nope")
+
+        schema = BadSchema()
+        errors = schema.validate({"alt-foo": "data"})
+        assert "alt-foo" in errors
+        assert errors["alt-foo"] == ["nope"]
+
+        schema = BadSchema()
+        errors = schema.validate([{"alt-foo": "data"}, {"alt-foo": "data2"}], many=True)
+        assert errors == {0: {"alt-foo": ["nope"]}, 1: {"alt-foo": ["nope"]}}
 
 
 class TestValidatesSchemaDecorator:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1910,6 +1910,27 @@ class TestSchemaDeserialization:
         with pytest.raises(ValidationError):
             MySchema(unknown=EXCLUDE).load({"foo": 3, "bar": 5}, unknown=RAISE)
 
+    def test_unknown_fields_deserialization_with_alternative(self):
+        class MySchema(Schema):
+            foo = fields.Integer(alternative="Foo")
+
+        data = MySchema().load({"Foo": 1})
+        assert data["foo"] == 1
+        assert "Foo" not in data
+
+        data = MySchema(unknown=RAISE).load({"Foo": 1})
+        assert data["foo"] == 1
+        assert "Foo" not in data
+
+        # since it's an alternative "foo" is also an acceptable key
+        data = MySchema(unknown=RAISE).load({"foo": 1})
+        assert data["foo"] == 1
+        assert "Foo" not in data
+
+        data = MySchema(unknown=INCLUDE).load({"Foo": 1})
+        assert data["foo"] == 1
+        assert "Foo" not in data
+
     def test_unknown_fields_deserialization_with_data_key(self):
         class MySchema(Schema):
             foo = fields.Integer(data_key="Foo")


### PR DESCRIPTION
The problem:
`data_key` provides a way to map keys in a symmetric manner I often have to use two schemas to accomplish asymmetric mapping of keys so that the output matches my data classes.

Example:
```json
{ "myFoo": "bar" }
```
```python
class MySchema(Schema):
    foo = String(data_key="myFoo")

class SchemaTwo(Schema):
    foo = String()

symmetric = MySchema().dump(MySchema.load({"myFoo":"bar"}))
# >> {"myFoo":"bar"}
asymmetric = SchemaTwo().dump(MySchema.load({"myFoo":"bar"}))
# >> {"foo":"bar"}
```

Proposal:
We should add a new attribute in the fields class that supports an alternative key to the schema key name. This would allow schemas to load data either from the schema the field_objects name or from an alternate key in the data.

Example:
```python
class SingleSchema(Schema):
    foo = String(alternative="myFoo")

asymmetric = SingleSchema().dump(SingleSchema.load({"myFoo":"bar"}))
# >> {"foo":"bar"}
```

Reference From other frameworks:
- https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/com/google/gson/annotations/SerializedName.html (see alternatives)

Benefits:
- One schema is less than two :)
- Less questions about 

Status:
I have done some work here to implement this feature. I have a bunch more tests to write and I wanted to submit this RFC before spending more time writing tests. 