### PR TITLE
Use PEP 604 where possible

### DIFF
--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -61,7 +61,7 @@ Example: ::
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, Tuple, cast
 
 PRE_DUMP = "pre_dump"
 POST_DUMP = "post_dump"
@@ -72,9 +72,7 @@ VALIDATES_SCHEMA = "validates_schema"
 
 
 class MarshmallowHook:
-    __marshmallow_hook__ = (
-        None
-    )  # type: Optional[Dict[Union[Tuple[str, bool], str], Any]]
+    __marshmallow_hook__ = None  # type: Dict[Tuple[str, bool] | str, Any] | None
 
 
 def validates(field_name: str) -> Callable[..., Any]:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -157,9 +157,9 @@ class Field(FieldABC):
         default: typing.Any = missing_,
         data_key: str | None = None,
         attribute: str | None = None,
-        validate: None
-        | (
-            typing.Callable[[typing.Any], typing.Any]
+        validate: (
+            None
+            | typing.Callable[[typing.Any], typing.Any]
             | typing.Iterable[typing.Callable[[typing.Any], typing.Any]]
         ) = None,
         required: bool = False,
@@ -2024,14 +2024,14 @@ class Function(Field):
 
     def __init__(
         self,
-        serialize: None
-        | (
-            typing.Callable[[typing.Any], typing.Any]
+        serialize: (
+            None
+            | typing.Callable[[typing.Any], typing.Any]
             | typing.Callable[[typing.Any, dict], typing.Any]
         ) = None,
-        deserialize: None
-        | (
-            typing.Callable[[typing.Any], typing.Any]
+        deserialize: (
+            None
+            | typing.Callable[[typing.Any], typing.Any]
             | typing.Callable[[typing.Any, dict], typing.Any]
         ) = None,
         **kwargs,


### PR DESCRIPTION
I couldn't remove `Union` from types.py (#1962) so this is the only place where I could remove it.