### PR TITLE
Docs improvement: Move search box up the sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,14 +81,14 @@ html_theme_options = {
 }
 
 html_sidebars = {
-    "index": ["about.html", "donate.html", "useful-links.html", "searchbox.html"],
+    "index": ["about.html", "searchbox.html", "donate.html", "useful-links.html"],
     "**": [
         "about.html",
+        "searchbox.html",
         "donate.html",
         "useful-links.html",
         "localtoc.html",
         "relations.html",
-        "searchbox.html",
     ],
 }
 


### PR DESCRIPTION
Currently on non-index pages, the search box is the last thing to appear in the sidebar. When viewing a page with a large "Table of Contents" section ([example](https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html)), the search box is very low on the page and readers must scroll down for a long time to find the search box. I recommend moving the search box up the sidebar so it appears '[above the fold](https://en.wikipedia.org/wiki/Above_the_fold)' on most resolutions.

Let me know if you have any questions. Thanks!