### PR TITLE
fix: unhandled OSError and OverflowErrors from utils.from_timestamp

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -172,3 +172,4 @@ Contributors (chronological)
 - Marco Satti `@marcosatti  <https://github.com/marcosatti>`_
 - Ivo Reumkens `@vanHoi <https://github.com/vanHoi>`_
 - Aditya Tewary `@aditkumar72 <https://github.com/aditkumar72>`_
+- Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -197,7 +197,12 @@ def from_timestamp(value: typing.Any) -> dt.datetime:
 
     # Load a timestamp with utc as timezone to prevent using system timezone.
     # Then set timezone to None, to let the Field handle adding timezone info.
-    return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc).replace(tzinfo=None)
+    try:
+        return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc).replace(tzinfo=None)
+    except OverflowError as exc:
+        raise ValueError("Timestamp is too large") from exc
+    except OSError as exc:
+        raise ValueError("Error converting value to datetime") from exc
 
 
 def from_timestamp_ms(value: typing.Any) -> dt.datetime:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -228,6 +228,31 @@ def test_from_iso_date():
     assert_date_equal(result, d)
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1676386740, dt.datetime(2023, 2, 14, 14, 59, 00)),
+        (1676386740.58, dt.datetime(2023, 2, 14, 14, 59, 00, 580000)),
+    ],
+)
+def test_from_timestamp(value, expected):
+    result = utils.from_timestamp(value)
+    assert type(result) == dt.datetime
+    assert result == expected
+
+
+def test_from_timestamp_with_negative_value():
+    value = -10
+    with pytest.raises(ValueError, match=r"Not a valid POSIX timestamp"):
+        utils.from_timestamp(value)
+
+
+def test_from_timestamp_with_overflow_value():
+    value = 9223372036854775
+    with pytest.raises(ValueError):
+        utils.from_timestamp(value)
+
+
 def test_get_func_args():
     def f1(foo, bar):
         pass


### PR DESCRIPTION
When running [schemathesis](https://github.com/schemathesis/schemathesis) against my smorest app I found some unexpected 500 errors.  They where caused by  `utils.from_timestamp` which doesn't  handle the [OverflowError or OSError that can be raised by  datetime.fromtimestamp](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp)

What's has been done:

- OverflowError and OSError are caught and re-throwed as ValueError so that they can be handle properly.
- Tests for `utiles.from_timestamp` were added to avoid regression