### PR TITLE
Minor DateTime field logic refactor

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -920,8 +920,7 @@ class UUID(String):
         try:
             if isinstance(value, bytes) and len(value) == 16:
                 return uuid.UUID(bytes=value)
-            else:
-                return uuid.UUID(value)
+            return uuid.UUID(value)
         except (ValueError, AttributeError, TypeError) as error:
             raise self.make_error("invalid_uuid") from error
 
@@ -1281,28 +1280,21 @@ class DateTime(Field):
         format_func = self.SERIALIZATION_FUNCS.get(data_format)
         if format_func:
             return format_func(value)
-        else:
-            return value.strftime(data_format)
+        return value.strftime(data_format)
 
     def _deserialize(self, value, attr, data, **kwargs) -> dt.datetime:
         if not value:  # Falsy values, e.g. '', None, [] are not valid
             raise self.make_error("invalid", input=value, obj_type=self.OBJ_TYPE)
         data_format = self.format or self.DEFAULT_FORMAT
         func = self.DESERIALIZATION_FUNCS.get(data_format)
-        if func:
-            try:
+        try:
+            if func:
                 return func(value)
-            except (TypeError, AttributeError, ValueError) as error:
-                raise self.make_error(
-                    "invalid", input=value, obj_type=self.OBJ_TYPE
-                ) from error
-        else:
-            try:
-                return self._make_object_from_format(value, data_format)
-            except (TypeError, AttributeError, ValueError) as error:
-                raise self.make_error(
-                    "invalid", input=value, obj_type=self.OBJ_TYPE
-                ) from error
+            return self._make_object_from_format(value, data_format)
+        except (TypeError, AttributeError, ValueError) as error:
+            raise self.make_error(
+                "invalid", input=value, obj_type=self.OBJ_TYPE
+            ) from error
 
     @staticmethod
     def _make_object_from_format(value, data_format) -> dt.datetime:
@@ -1525,9 +1517,8 @@ class TimeDelta(Field):
             delta = utils.timedelta_to_microseconds(value)
             unit = utils.timedelta_to_microseconds(base_unit)
             return delta // unit
-        else:
-            assert self.serialization_type is float
-            return value.total_seconds() / base_unit.total_seconds()
+        assert self.serialization_type is float
+        return value.total_seconds() / base_unit.total_seconds()
 
     def _deserialize(self, value, attr, data, **kwargs):
         try:
@@ -2057,8 +2048,7 @@ class Function(Field):
                 msg = f"No context available for Function field {attr!r}"
                 raise ValidationError(msg)
             return func(value, self.parent.context)
-        else:
-            return func(value)
+        return func(value)
 
 
 class Constant(Field):


### PR DESCRIPTION
I also removed a few unneeded else after return. Pylint complains about this. I agree this is arguable and some may think the else makes it more readable.