### PR TITLE
Use Abstract Base Classes to define FieldABC and SchemaABC

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -171,3 +171,4 @@ Contributors (chronological)
 - Karthikeyan Singaravelan `@tirkarthi  <https://github.com/tirkarthi>`_
 - Marco Satti `@marcosatti  <https://github.com/marcosatti>`_
 - Ivo Reumkens `@vanHoi <https://github.com/vanHoi>`_
+- Aditya Tewary `@aditkumar72 <https://github.com/aditkumar72>`_

--- a/src/marshmallow/base.py
+++ b/src/marshmallow/base.py
@@ -8,40 +8,49 @@ These are necessary to avoid circular imports between core.py and fields.py.
     Users should not need to use this module directly.
 """
 from __future__ import annotations
+from abc import ABC, abstractmethod
 
 
-class FieldABC:
+class FieldABC(ABC):
     """Abstract base class from which all Field classes inherit."""
 
     parent = None
     name = None
     root = None
 
+    @abstractmethod
     def serialize(self, attr, obj, accessor=None):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def deserialize(self, value):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def _serialize(self, value, attr, obj, **kwargs):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def _deserialize(self, value, attr, data, **kwargs):
-        raise NotImplementedError
+        pass
 
 
-class SchemaABC:
+class SchemaABC(ABC):
     """Abstract base class from which all Schemas inherit."""
 
+    @abstractmethod
     def dump(self, obj, *, many: bool | None = None):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def dumps(self, obj, *, many: bool | None = None):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def load(self, data, *, many: bool | None = None, partial=None, unknown=None):
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def loads(
         self,
         json_data,
@@ -51,4 +60,4 @@ class SchemaABC:
         unknown=None,
         **kwargs,
     ):
-        raise NotImplementedError
+        pass

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -1,5 +1,6 @@
 """The :class:`Schema` class, including its metaclass and options (class Meta)."""
 from __future__ import annotations
+from abc import ABCMeta
 
 from collections import defaultdict, OrderedDict
 from collections.abc import Mapping
@@ -80,7 +81,7 @@ def _get_fields_by_mro(klass, ordered=False):
     )
 
 
-class SchemaMeta(type):
+class SchemaMeta(ABCMeta):
     """Metaclass for the Schema class. Binds the declared fields to
     a ``_declared_fields`` attribute, which is a dictionary mapping attribute
     names to field objects. Also sets the ``opts`` class attribute, which is


### PR DESCRIPTION
This PR fixes #1449 to refactor base.py to use Abstract Base Classes. It also fixes meta class conflict by using ABCMeta as a super class for SchemaMeta.