### PR TITLE
Default Nested Partial Fix

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -657,7 +657,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
                         f[len_prefix:] for f in partial if f.startswith(prefix)
                     ]
                     d_kwargs["partial"] = sub_partial
-                else:
+                elif partial is not None:
                     d_kwargs["partial"] = partial
 
                 def getter(

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -374,7 +374,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         context: dict | None = None,
         load_only: types.StrSequenceOrSet = (),
         dump_only: types.StrSequenceOrSet = (),
-        partial: bool | types.StrSequenceOrSet = False,
+        partial: bool | types.StrSequenceOrSet | None = None,
         unknown: str | None = None,
     ):
         # Raise error if only or exclude is passed as string, not list of strings
@@ -590,7 +590,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         *,
         error_store: ErrorStore,
         many: bool = False,
-        partial=False,
+        partial=None,
         unknown=RAISE,
         index=None,
     ) -> _T | list[_T]:
@@ -1089,7 +1089,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         *,
         many: bool,
         original_data,
-        partial: bool | types.StrSequenceOrSet,
+        partial: bool | types.StrSequenceOrSet | None,
     ):
         # This has to invert the order of the dump processors, so run the pass_many
         # processors first.
@@ -1166,7 +1166,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         data,
         original_data,
         many: bool,
-        partial: bool | types.StrSequenceOrSet,
+        partial: bool | types.StrSequenceOrSet | None,
         field_errors: bool = False,
     ):
         for attr_name in self._hooks[(VALIDATES_SCHEMA, pass_many)]:

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -2236,6 +2236,21 @@ class TestValidation:
         with pytest.raises(ValidationError):
             SchemaB().load(b_dict, partial=("z.y",))
 
+    def test_nested_partial_default(self):
+        class SchemaA(Schema):
+            x = fields.Integer(required=True)
+            y = fields.Integer(required=True)
+
+        class SchemaB(Schema):
+            z = fields.Nested(SchemaA(partial=("x",)))
+
+        b_dict = {"z": {"y": 42}}
+        # Nested partial args should be respected.
+        result = SchemaB().load(b_dict)
+        assert result["z"]["y"] == 42
+        with pytest.raises(ValidationError):
+            SchemaB().load({"z": {"x": 0}})
+
 
 @pytest.mark.parametrize("FieldClass", ALL_FIELDS)
 def test_required_field_failure(FieldClass):  # noqa


### PR DESCRIPTION
Fixes #2149

https://github.com/marshmallow-code/marshmallow/commit/59a432971b6cfac86162e06fec30c8f2c4e66b7b regressed the behavior of schemas using `partial` when they are passed to `Nested`. 

The default value for `partial` in schema arguments was normalized to `None` in the few places it was `False`. This ensures that `partial=False` is treated as an explicit request to disable partial loading in nested schemas, and `partial=None` is treated as a request to defer to nested schemas' partial behavior.

This changes the behavior of schemas without `partial` defined when they contain nested schemas with `partial` defined, but the behavior introduced by 3.0.0b19 was untested, undocumented, and counterintuitive, so I am hesitant to label this backwards incompatible.