### PR TITLE
Fix call to get_declared_fields: pass dict_cls

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -117,6 +117,7 @@ class SchemaMeta(ABCMeta):
             klass=klass,
             cls_fields=cls_fields,
             inherited_fields=inherited_fields,
+            dict_cls=dict,
         )
         return klass
 


### PR DESCRIPTION
Fixes #2152.

Now that `dict`s are ordered, there is no point using an `OrderedDict` to store fields, so while working on #1896, I simplified the logic to always use a `dict`.

This screws up classes overriding `get_declared_fields` that still expect a dict class to be passed (#2152).

Step back and pass dict class again. (Keep default value in `get_declared_fields` implementation.)

