### PR TITLE
Fix NestedField Type hint for Lambda Schema types

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -173,3 +173,4 @@ Contributors (chronological)
 - Ivo Reumkens `@vanHoi <https://github.com/vanHoi>`_
 - Aditya Tewary `@aditkumar72 <https://github.com/aditkumar72>`_
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
+- Peter C `@somethingnew2-0 <https://github.com/somethingnew2-0>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -536,7 +536,7 @@ class Nested(Field):
         | type
         | str
         | dict[str, Field | type]
-        | typing.Callable[[], SchemaABC | dict[str, Field | type]],
+        | typing.Callable[[], SchemaABC | type | dict[str, Field | type]],
         *,
         dump_default: typing.Any = missing_,
         default: typing.Any = missing_,


### PR DESCRIPTION
Providing a lambda with a returning callable type is handled by Marshmallow (such as below), but not allowed by the type-hinting. Fix that

```
class PrimarySchema(Schema):
    other = fields.Nested(lambda: OtherSchema)
```

