### PR TITLE
Update field docstring to reflect "attribute" argument affecting deserialization

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -87,7 +87,7 @@ class Field(FieldABC):
     :param data_key: The name of the dict key in the external representation, i.e.
         the input of `load` and the output of `dump`.
         If `None`, the key will match the name of the field.
-    :param attribute: The name of the attribute to get the value from when serializing.
+    :param attribute: The name of the attribute to get the value from when (de)serializing.
         If `None`, assumes the attribute has the same name as the field.
         Note: This should only be used for very specific use cases such as
         outputting multiple fields for a single attribute. In most cases,


### PR DESCRIPTION
I believe this simple change should resolve the documentation ambiguity in #2145. However, I'm a first-time contributor so please let me know if an explanation here would be better.

Also, should I perhaps open a PR following this to reflect the data_key condition?