### PR TITLE
Use 3.11 for RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,11 @@ sphinx:
   configuration: docs/conf.py
 formats:
   - pdf
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
3.8 was dropped by recent Sphinx 2 (https://www.sphinx-doc.org/en/master/changes.html), hence the failure in #2171 I guess. I wonder how the former 7.0.x updates passed.