### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,7 +36,6 @@ jobs:
       matrix:
         include:
           - {name: '3.8', python: '3.8', tox: py38}
-          - {name: '3.11', python: '3.11', tox: py311}
           - {name: '3.12', python: '3.12', tox: py312}
     steps:
       - uses: actions/checkout@v4.0.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,8 +10,8 @@ jobs:
     name: mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v4.7.0
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
@@ -21,8 +21,8 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v4.7.0
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip wheel
@@ -37,11 +37,13 @@ jobs:
         include:
           - {name: '3.8', python: '3.8', tox: py38}
           - {name: '3.11', python: '3.11', tox: py311}
+          - {name: '3.12', python: '3.12', tox: py312}
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - run: python -m pip install --upgrade pip
       - run: python -m pip install tox
       - run: python -m tox -e ${{ matrix.tox }}
@@ -52,8 +54,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v4.7.0
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
@@ -65,8 +67,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-python@v4.3.0
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v4.7.0
       - name: install requirements
         run: python -m pip install build twine
       - name: build dists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     test_suite="tests",
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,mypy-test,py38,py39,py310,py311,docs
+envlist = lint,mypy-test,py{38,39,310,311,312},docs
 
 [testenv]
 extras = tests


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/