### PR TITLE
test: Update legacy timezone US/Central to America/Chicago

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -11,7 +11,7 @@ import pytz
 from marshmallow import Schema, fields, post_load, validate, missing
 from marshmallow.exceptions import ValidationError
 
-central = pytz.timezone("US/Central")
+central = pytz.timezone("America/Chicago")
 
 
 class GenderEnum(IntEnum):


### PR DESCRIPTION
The timezone `US/Central` is a legacy name and points to `America/Chicago`. tzdata >= 2023c-8 in Debian and Ubuntu moved those legacy names into a separate tzdata-legacy package.