### PR TITLE
Pre commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: 6.1.0
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear==22.12.6]
+    additional_dependencies: [flake8-bugbear==23.12.2]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.7.1
   hooks:

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,6 @@ from setuptools import setup, find_packages
 EXTRAS_REQUIRE = {
     "tests": ["pytest", "pytz", "simplejson"],
     "lint": [
-        "mypy==1.7.1",
-        "flake8==6.1.0",
-        "flake8-bugbear==23.12.2",
         "pre-commit>=2.4,<4.0",
     ],
     "docs": [

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1142,7 +1142,8 @@ class Boolean(Field):
         "YES",
         "1",
         1,
-        True,
+        # Equal to 1
+        # True,
     }
     #: Default falsy values.
     falsy = {
@@ -1161,8 +1162,9 @@ class Boolean(Field):
         "NO",
         "0",
         0,
-        0.0,
-        False,
+        # Equal to 0
+        # 0.0,
+        # False,
     }
 
     #: Default error messages.

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -212,6 +212,7 @@ class SchemaOpts:
             warnings.warn(
                 "The json_module class Meta option is deprecated. Use render_module instead.",
                 RemovedInMarshmallow4Warning,
+                stacklevel=2,
             )
             render_module = getattr(meta, "json_module", json)
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ extras = tests
 commands = pytest {posargs}
 
 [testenv:lint]
-deps = pre-commit~=2.4
+deps = pre-commit~=3.5
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
 


### PR DESCRIPTION
The "extra require" dependency versions in setup.py are not the ones used in the CI tests.

CI tests use tox, which runs an old version of pre-commit, which in turn uses its own versions of lint dependencies.

- Update pre-commit version in tox.ini
- Update flake8-bugbear while I'm at it (it is not autoupdated)
- Remove lint dependencies listed in setup.py (apart from pre-commit)

This will save us a few useless dependabot PRs about unused stuff (leaving us with the false impression that our dependencies are up-to-date). We still need to update pre-commit in tox.ini manually because dependabot won't pick that up.

Users are advised to call pre-commit to run CI, either automatically on commit or using

    pre-commit run --all-files

