### PR TITLE
Let IP fields inherit String

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1741,7 +1741,7 @@ class Email(String):
         self.validators.insert(0, validator)
 
 
-class IP(Field):
+class IP(String):
     """A IP address field.
 
     :param bool exploded: If `True`, serialize ipv6 address in long form, ie. with groups
@@ -1800,7 +1800,7 @@ class IPv6(IP):
     DESERIALIZATION_CLASS = ipaddress.IPv6Address
 
 
-class IPInterface(Field):
+class IPInterface(String):
     """A IPInterface field.
 
     IP interface is the non-strict form of the IPNetwork type where arbitrary host


### PR DESCRIPTION
Any reason not to inherit `String` here?

Due to this, in apispec, the type wouldn't be set to string. This is being addressed there by setting type to string and the proper format, but I suppose it makes sense to "fix" this here as well.

- https://github.com/marshmallow-code/apispec/pull/892
- https://github.com/marshmallow-code/flask-smorest/issues/623