### PR TITLE
Remove leaky lru_cache

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -174,3 +174,4 @@ Contributors (chronological)
 - Aditya Tewary `@aditkumar72 <https://github.com/aditkumar72>`_
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Peter C `@somethingnew2-0 <https://github.com/somethingnew2-0>`_
+- Marcel Jackwerth `@mrcljx` <https://github.com/mrcljx>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.21.3 (unreleased)
+*******************
+
+Bug fixes:
+
+- Fix memory leak that prevented schema instances from getting GC'd (:pr:`2277`).
+  Thanks :user:`mrcljx` for the PR.
+
 3.21.2 (2024-05-01)
 *******************
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -13,7 +13,6 @@ import warnings
 from abc import ABCMeta
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping
-from functools import lru_cache
 
 from marshmallow import base, class_registry, types
 from marshmallow import fields as ma_fields
@@ -1056,7 +1055,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
             raise error
         self.on_bind_field(field_name, field_obj)
 
-    @lru_cache(maxsize=8)  # noqa (https://github.com/PyCQA/flake8-bugbear/issues/310)
     def _has_processors(self, tag) -> bool:
         return bool(self._hooks[(tag, True)] or self._hooks[(tag, False)])
 


### PR DESCRIPTION
### Problem

After calling the `endpoint`, the instance `db_session` was not freed, causing a warning to be emitted.

```python
def endpoint(request):
  data = MySchema(context={"db_session": create_db_session()}).load(request.json)
  return "OK"
```

The reason is that the `MySchema` instance is kept in a _global_ LRU cache. Calling `endpoint` multiple times will eventually release the older `db_session` instances, though.

### Analysis

The `@lru_cache(max_size=8)` decorator was used on a method, causing instances of `self` to be cached and outlive their intended scope. This led to unexpected behavior where instances persisted beyond a single web request, retaining references and consuming memory unnecessarily.

This problem was called out by PyCQA/flake8-bugbear#310 but ignored via `noqa`.

### Options

1. Use `cachetools.cachedmethod` (requires a third party dependency)
2. Implement manually
3. Remove LRU cache

### Proposal

The LRU cache was introduced in #1309 (the PR reported 3% performance increase on the test base). I'm not sure the LRU cache actually has that much of an effect in real world scenarios:

1. The cost of two tuple constructions and two dict lookups is small in the first place
2. If more than 2 schema instances are used, `max_size` is exhausted, leading to cache misses.
   - A cold `load` causes 3 misses, 0 hits (warm -> 3 hits)
   - A cold `dump` causes 2 misses, 0 hits (warm -> 3 hits).
3. A more complex schema guarantees 100% misses, as too many instances are involved.

```python
class Child(ma.Schema):
  pass

class Parent(ma.Schema):
  a = ma.fields.Nested(Child)
  b = ma.fields.Nested(Child)
  c = ma.fields.Nested(Child)

ma.Schema._has_processors.cache_clear()
p = Parent()
p.load({"a": {}, "b": {}, "c": {}})
p.load({"a": {}, "b": {}, "c": {}})
ma.Schema._has_processors.cache_info() # CacheInfo(hits=0, misses=24, maxsize=8, currsize=8)
```