### PR TITLE
Simplify Hooks

### DIFF
--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -100,7 +100,7 @@ def run_timeit(quotes, iterations, repeat, profile=False):
         profile.disable()
         profile.dump_stats("marshmallow.pprof")
 
-    usec = best * 1e6 / iterations
+    usec = best * 1e6 / iterations / len(quotes)
     return usec
 
 

--- a/src/marshmallow/types.py
+++ b/src/marshmallow/types.py
@@ -8,5 +8,4 @@
 import typing
 
 StrSequenceOrSet = typing.Union[typing.Sequence[str], typing.AbstractSet[str]]
-Tag = typing.Union[str, typing.Tuple[str, bool]]
 Validator = typing.Callable[[typing.Any], typing.Any]


### PR DESCRIPTION
- Replace slow tuple-keyed dicts with string-keyed dicts
- Load the hook config into `cls._hook` at setup rather than searching `fn.__marshmallow_hook__` at run-time
- Skip mismatched `many` hooks while iterating rather than indexing and filtering them


* pypy (3.10): ~30% speedup
* cpython (3.10): <1% difference
* cpython (3.11, 3.12): ~3.5% speedup