### PR TITLE
Remove min Python 3 minor version in docs and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,16 +77,10 @@ Get It Now
 
     $ pip install -U marshmallow
 
-
 Documentation
 =============
 
 Full documentation is available at https://marshmallow.readthedocs.io/ .
-
-Requirements
-============
-
-- Python >= 3.9
 
 Ecosystem
 =========

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-**marshmallow** requires Python >= 3.8. It has no external dependencies other than the `packaging` library.
+**marshmallow** has no external dependencies other than the `packaging` library.
 
 Installing/Upgrading from the PyPI
 ----------------------------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -62,7 +62,7 @@ Upgrading to 3.0
 Python compatibility
 ********************
 
-The marshmallow 3.x series supports Python >= 3.8.
+The marshmallow 3.x series requires Python 3.
 
 
 Schemas are always strict


### PR DESCRIPTION
I forgot to update those before releasing and it might not be the first time.

What about we remove the mention of the minor version from the doc pages?

I'd be tempted to also remove it from the README. Especially since we support all maintained Python versions anyway.