### PR TITLE
Marshmallow guru

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 marshmallow: simplified object serialization
 ********************************************
 
-|pypi| |build-status| |pre-commit| |docs|
+|pypi| |build-status| |pre-commit| |docs| |gurubase|
 
 .. |pypi| image:: https://badgen.net/pypi/v/marshmallow
     :target: https://pypi.org/project/marshmallow/
@@ -19,6 +19,10 @@ marshmallow: simplified object serialization
 .. |docs| image:: https://readthedocs.org/projects/marshmallow/badge/
    :target: https://marshmallow.readthedocs.io/
    :alt: Documentation
+
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20marshmallow%20Guru-006BFF
+   :target: https://gurubase.io/g/marshmallow
+   :alt: marshmallow Guru
 
 **marshmallow** is an ORM/ODM/framework-agnostic library for converting complex datatypes, such as objects, to and from native Python datatypes.
 
@@ -80,7 +84,7 @@ Get It Now
 Documentation
 =============
 
-Full documentation is available at https://marshmallow.readthedocs.io/ .
+Full documentation is available at https://marshmallow.readthedocs.io/ . You can also [Ask marshmallow Guru](https://gurubase.io/g/marshmallow), it is a marshmallow-focused AI to answer your questions.
 
 Ecosystem
 =========

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Get It Now
 Documentation
 =============
 
-Full documentation is available at https://marshmallow.readthedocs.io/ . You can also [Ask marshmallow Guru](https://gurubase.io/g/marshmallow), it is a marshmallow-focused AI to answer your questions.
+Full documentation is available at https://marshmallow.readthedocs.io/ . You can also `Ask marshmallow Guru <https://gurubase.io/g/marshmallow>`_, it is a marshmallow-focused AI to answer your questions.
 
 Ecosystem
 =========


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [marshmallow Guru](https://gurubase.io/g/marshmallow) to Gurubase. marshmallow Guru uses the data from this repo and data from the [docs](https://marshmallow.readthedocs.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "marshmallow Guru", which highlights that marshmallow now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable marshmallow Guru in Gurubase, just let me know that's totally fine.