### PR TITLE
Improve type hint formatting to resolve PyCharm warnings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -175,3 +175,4 @@ Contributors (chronological)
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Peter C `@somethingnew2-0 <https://github.com/somethingnew2-0>`_
 - Marcel Jackwerth `@mrcljx` <https://github.com/mrcljx>`_
+- Fares Abubaker `@Fares-Abubaker <https://github.com/Fares-Abubaker>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.23.2 (2024-12-12)
+*******************
+
+Bug fixes:
+
+- Improve type hint formatting for ``Field``, ``Nested``, and ``Function`` fields
+  to resolve PyCharm warnings (:pr:`2657`).
+
 3.23.1 (2024-11-01)
 *******************
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marshmallow"
-version = "3.23.1"
+version = "3.23.2"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 readme = "README.rst"
 license = { file = "LICENSE" }

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -166,9 +166,9 @@ class Field(FieldABC):
         data_key: str | None = None,
         attribute: str | None = None,
         validate: (
-            None
-            | typing.Callable[[typing.Any], typing.Any]
+            typing.Callable[[typing.Any], typing.Any]
             | typing.Iterable[typing.Callable[[typing.Any], typing.Any]]
+            | None
         ) = None,
         required: bool = False,
         allow_none: bool | None = None,
@@ -321,8 +321,9 @@ class Field(FieldABC):
         self,
         attr: str,
         obj: typing.Any,
-        accessor: typing.Callable[[typing.Any, str, typing.Any], typing.Any]
-        | None = None,
+        accessor: (
+            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+        ) = None,
         **kwargs,
     ):
         """Pulls the value for the given key from the object, applies the
@@ -538,11 +539,15 @@ class Nested(Field):
 
     def __init__(
         self,
-        nested: SchemaABC
-        | SchemaMeta
-        | str
-        | dict[str, Field | type[Field]]
-        | typing.Callable[[], SchemaABC | SchemaMeta | dict[str, Field | type[Field]]],
+        nested: (
+            SchemaABC
+            | SchemaMeta
+            | str
+            | dict[str, Field | type[Field]]
+            | typing.Callable[
+                [], SchemaABC | SchemaMeta | dict[str, Field | type[Field]]
+            ]
+        ),
         *,
         dump_default: typing.Any = missing_,
         default: typing.Any = missing_,
@@ -2024,14 +2029,14 @@ class Function(Field):
     def __init__(
         self,
         serialize: (
-            None
-            | typing.Callable[[typing.Any], typing.Any]
+            typing.Callable[[typing.Any], typing.Any]
             | typing.Callable[[typing.Any, dict], typing.Any]
+            | None
         ) = None,
         deserialize: (
-            None
-            | typing.Callable[[typing.Any], typing.Any]
+            typing.Callable[[typing.Any], typing.Any]
             | typing.Callable[[typing.Any, dict], typing.Any]
+            | None
         ) = None,
         **kwargs,
     ):


### PR DESCRIPTION
This PR refactors the type hints for `Field`, `Nested`, and `Function` fields to ensure compatibility with PyCharm’s type checker. Previously, certain multiline unions and formatting choices caused PyCharm to show spurious warnings. By adjusting the formatting—using parentheses for multiline unions and, where needed, Optional and Union—these warnings are resolved without altering the underlying logic. This change will improve the developer experience for anyone using PyCharm with this codebase.

Fixes #2268