### PR TITLE
Fix typing for Schema.from_dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.23.3 (unreleased)
+*******************
+
+Bug fixes:
+
+- Typing: Fix typing for `Schema.from_dict <marshmallow.schema.Schema.from_dict>` (:issue:`1653`).
+  Thanks :user:`SteadBytes` for reporting.
+
 3.23.2 (2024-12-18)
 *******************
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -422,7 +422,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
     @classmethod
     def from_dict(
         cls,
-        fields: dict[str, ma_fields.Field | type[ma_fields.Field]],
+        fields: dict[str, ma_fields.Field],
         *,
         name: str = "GeneratedSchema",
     ) -> type[Schema]:
@@ -444,11 +444,10 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
         .. versionadded:: 3.0.0
         """
-        attrs = fields.copy()
-        attrs["Meta"] = type(
+        Meta = type(
             "GeneratedMeta", (getattr(cls, "Meta", object),), {"register": False}
         )
-        schema_cls = type(name, (cls,), attrs)
+        schema_cls = type(name, (cls,), {**fields.copy(), "Meta": Meta})
         return schema_cls
 
     ##### Override-able methods #####


### PR DESCRIPTION
with this change, the following code correctly errors in mypy:

```python
from marshmallow import Schema

MySchema = Schema.from_dict({"foo": fields.Str})
```

mypy error:

```
Dict entry 0 has incompatible type "str": "type[String]"; expected "str": "Field"Mypy[dict-item](https://mypy.readthedocs.io/en/latest/_refs.html#code-dict-item)
```

close #1653