### PR TITLE
More documentation cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Bug fixes:
 
 Support:
 
-- Documentation: clean up `marshmallow.fields` API reference (:issue:`2307`).
+- Documentation: Various documentation cleanups, including more concise docs in the `marshmallow.fields` API reference (:issue:`2307`).
   Thanks :user:`AbdealiLoKo` for reporting.
 
 3.23.2 (2024-12-18)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -116,25 +116,6 @@ class Field(FieldABC):
     :param dict error_messages: Overrides for `Field.default_error_messages`.
     :param metadata: Extra information to be stored as field metadata.
 
-    .. versionchanged:: 2.0.0
-        Removed `error` parameter. Use ``error_messages`` instead.
-
-    .. versionchanged:: 2.0.0
-        Added `allow_none` parameter, which makes validation/deserialization of `None`
-        consistent across fields.
-
-    .. versionchanged:: 2.0.0
-        Added `load_only` and `dump_only` parameters, which allow field skipping
-        during the (de)serialization process.
-
-    .. versionchanged:: 2.0.0
-        Added `missing` parameter, which indicates the value for a field if the field
-        is not found during deserialization.
-
-    .. versionchanged:: 2.0.0
-        ``default`` value is only used if explicitly set. Otherwise, missing values
-        inputs are excluded from serialized output.
-
     .. versionchanged:: 3.0.0b8
         Add ``data_key`` parameter for the specifying the key in the input and
         output data. This parameter replaced both ``load_from`` and ``dump_to``.
@@ -426,9 +407,6 @@ class Field(FieldABC):
         :param kwargs: Field-specific keyword arguments.
         :raise ValidationError: In case of formatting or validation failure.
         :return: The deserialized value.
-
-        .. versionchanged:: 2.0.0
-            Added ``attr`` and ``data`` parameters.
 
         .. versionchanged:: 3.0.0
             Added ``**kwargs`` to signature.
@@ -749,10 +727,6 @@ class List(Field):
 
     :param cls_or_instance: A field class or instance.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
-
-    .. versionchanged:: 2.0.0
-        The ``allow_none`` parameter now applies to deserialization and
-        has the same semantics as the other fields.
 
     .. versionchanged:: 3.0.0rc9
         Does not serialize scalar values to single-item lists.
@@ -1465,9 +1439,6 @@ class TimeDelta(Field):
     will always be truncated to microseconds.
     For example, `1.12345` interpreted as microseconds will result in `timedelta(microseconds=1)`.
 
-    .. versionchanged:: 2.0.0
-        Always serializes to an integer value to avoid rounding errors.
-        Add `precision` parameter.
     .. versionchanged:: 3.17.0
         Allow (de)serialization to `float` through use of a new `serialization_type` parameter.
         `int` is the default to retain previous behaviour.
@@ -1950,9 +1921,6 @@ class Method(Field):
         a value The method must take a single argument ``value``, which is the
         value to deserialize.
 
-    .. versionchanged:: 2.0.0
-        Removed optional ``context`` parameter on methods. Use ``self.context`` instead.
-
     .. versionchanged:: 2.3.0
         Deprecated ``method_name`` parameter in favor of ``serialize`` and allow
         ``serialize`` to not be passed at all.
@@ -2071,8 +2039,6 @@ class Constant(Field):
     ``dump_only=True`` or ``load_only=True`` respectively.
 
     :param constant: The constant to return for the field attribute.
-
-    .. versionadded:: 2.0.0
     """
 
     _CHECK_ATTRIBUTE = False

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -105,8 +105,9 @@ class Field(FieldABC):
     :param required: Raise a :exc:`ValidationError` if the field value
         is not supplied during deserialization.
     :param allow_none: Set this to `True` if `None` should be considered a valid value during
-        validation/deserialization. If ``load_default=None`` and ``allow_none`` is unset,
-        will default to ``True``. Otherwise, the default is ``False``.
+        validation/deserialization. If set to `False` (the default), `None` is considered invalid input.
+        If ``load_default`` is explicitly set to `None` and ``allow_none`` is unset,
+        `allow_none` is implicitly set to ``True``.
     :param load_only: If `True` skip this field during serialization, otherwise
         its value will be present in the serialized data.
     :param dump_only: If `True` skip this field during deserialization, otherwise

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -280,13 +280,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
     .. versionchanged:: 3.0.0
         `prefix` parameter removed.
-
-    .. versionchanged:: 2.0.0
-        `__validators__`, `__preprocessors__`, and `__data_handlers__` are removed in favor of
-        `marshmallow.decorators.validates_schema`,
-        `marshmallow.decorators.pre_load` and `marshmallow.decorators.post_dump`.
-        `__accessor__` and `__error_handler__` are deprecated. Implement the
-        `handle_error` and `get_attribute` methods instead.
     """
 
     TYPE_MAPPING = {
@@ -462,8 +455,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param many: Value of ``many`` on dump or load.
         :param partial: Value of ``partial`` on load.
 
-        .. versionadded:: 2.0.0
-
         .. versionchanged:: 3.0.0rc9
             Receives `many` and `partial` (on deserialization) as keyword arguments.
         """
@@ -471,8 +462,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
     def get_attribute(self, obj: typing.Any, attr: str, default: typing.Any):
         """Defines how to pull values from an object to serialize.
-
-        .. versionadded:: 2.0.0
 
         .. versionchanged:: 3.0.0a1
             Changed position of ``obj`` and ``attr``.
@@ -507,9 +496,6 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
         :param obj: The object(s) to serialize.
         :param bool many: `True` if ``data`` should be serialized as a collection.
         :return: A dictionary of the serialized data
-
-        .. versionchanged:: 1.0.0
-            Renamed from ``marshal``.
         """
         if many and obj is not None:
             return [self._serialize(d, many=False) for d in obj]


### PR DESCRIPTION
- clarify `allow_none` behavior. close #2040
- Remove old versionchanged and versionadded usages for 1.x and 2.x