### PR TITLE
Make casing consistent across docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1066,7 +1066,7 @@ Features:
   The ``strict`` parameter is removed.
 - *Backwards-incompatible*: ``Schema().load`` and ``Schema().dump`` return ``data`` instead of a
   ``(data, errors)`` tuple (:issue:`598`).
-- *Backwards-incomaptible*: ``Schema().load(None)`` raises a
+- *Backwards-incompatible*: ``Schema().load(None)`` raises a
   ``ValidationError`` (:issue:`511`).
 
 See :ref:`upgrading_3_0` for a guide on updating your code.
@@ -1269,7 +1269,7 @@ Bug fixes:
   This is a backport of the fix in :pr:`857`. Thanks :user:`cristi23` for the
   thorough bug report and the PR.
 
-Deprecation/Removal:
+Deprecation/Removals:
 
 - Python 2.6 is no longer officially supported (:issue:`1274`).
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
-Contributing Guidelines
+Contributing guidelines
 =======================
 
 So you're interested in contributing to marshmallow or `one of our associated
@@ -7,21 +7,21 @@ welcome contributions from anyone willing to work in good faith with
 other contributors and the community (see also our
 :doc:`code_of_conduct`).
 
-Security Contact Information
+Security contact information
 ----------------------------
 
 To report a security vulnerability, please use the
 `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure.
 
-Questions, Feature Requests, Bug Reports, and Feedback…
+Questions, feature requests, bug reports, and feedback…
 -------------------------------------------------------
 
 …should all be reported on the `Github Issue Tracker`_ .
 
 .. _`Github Issue Tracker`: https://github.com/marshmallow-code/marshmallow/issues?state=open
 
-Ways to Contribute
+Ways to contribute
 ------------------
 
 - Comment on some of marshmallow's `open issues <https://github.com/marshmallow-code/marshmallow/issues>`_ (especially those `labeled "feedback welcome" <https://github.com/marshmallow-code/marshmallow/issues?q=is%3Aopen+is%3Aissue+label%3A%22feedback+welcome%22>`_). Share a solution or workaround. Make a suggestion for how a feature can be made better. Opinions are welcome!
@@ -34,10 +34,10 @@ Ways to Contribute
 - Send a PR for an open issue (especially one `labeled "help wanted" <https://github.com/marshmallow-code/marshmallow/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22>`_). The next section details how to contribute code.
 
 
-Contributing Code
+Contributing code
 -----------------
 
-Setting Up for Local Development
+Setting up for local development
 ++++++++++++++++++++++++++++++++
 
 1. Fork marshmallow_ on Github.
@@ -63,20 +63,20 @@ Setting Up for Local Development
     # The pre-commit CLI was installed above
     $ pre-commit install --allow-missing-config
 
-Git Branch Structure
+Git branch structure
 ++++++++++++++++++++
 
-Marshmallow abides by the following branching model:
+marshmallow abides by the following branching model:
 
 ``dev``
     Current development branch. **New features should branch off here**.
 
 ``X.Y-line``
-    Maintenance branch for release ``X.Y``. **Bug fixes should be sent to the most recent release branch.** The maintainer will forward-port the fix to ``dev``. Note: exceptions may be made for bug fixes that introduce large code changes.
+    Maintenance branch for release ``X.Y``. **Bug fixes should be sent to the most recent release branch.** A maintainer will forward-port the fix to ``dev``. Note: exceptions may be made for bug fixes that introduce large code changes.
 
 **Always make a new branch for your work**, no matter how small. Also, **do not put unrelated changes in the same branch or pull request**. This makes it more difficult to merge your changes.
 
-Pull Requests
+Pull requests
 ++++++++++++++
 
 1. Create a new local branch.
@@ -134,7 +134,7 @@ Changes in the `docs/` directory will automatically trigger a rebuild.
 
 .. _contributing_examples:
 
-Contributing Examples
+Contributing examples
 +++++++++++++++++++++
 
 Have a usage example you'd like to share? A custom `Field` that others might find useful? Feel free to add it to the `examples <https://github.com/marshmallow-code/marshmallow/tree/dev/examples>`_ directory and send a pull request.

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -8,7 +8,7 @@ organization.
 
 .. _coc-when-something-happens:
 
-When Something Happens
+When something happens
 ----------------------
 
 If you see a Code of Conduct violation, follow these steps:
@@ -32,7 +32,7 @@ resolve the situation.
 recipients of the violation over the comfort of the violator.** See
 :ref:`some examples below <coc-enforcement-examples>`.
 
-Our Pledge
+Our pledge
 ----------
 
 In the interest of fostering an open and welcoming environment, we as
@@ -43,7 +43,7 @@ identity and expression, level of experience, technical preferences,
 nationality, personal appearance, race, religion, or sexual identity and
 orientation.
 
-Our Standards
+Our standards
 -------------
 
 Examples of behavior that contributes to creating a positive environment
@@ -112,7 +112,7 @@ to maintain the comfort and safety of its members.
 
 .. _coc-other-community-standards:
 
-Other Community Standards
+Other community standards
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As a project on GitHub, this project is additionally covered by the
@@ -123,7 +123,7 @@ Enforcement of those guidelines after violations overlapping with the
 above are the responsibility of the entities, and enforcement may happen
 in any or all of the services/communities.
 
-Maintainer Enforcement Process
+Maintainer enforcement process
 ------------------------------
 
 Once the maintainers get involved, they will follow a documented series
@@ -133,7 +133,7 @@ members. This section covers actual concrete steps.
 
 .. _coc-contacting-maintainers:
 
-Contacting Maintainers
+Contacting maintainers
 ~~~~~~~~~~~~~~~~~~~~~~
 
 As a small and young project, we don't yet have a Code of Conduct
@@ -147,7 +147,7 @@ message is noticed quickly.
 
 .. _coc-further-enforcement:
 
-Further Enforcement
+Further enforcement
 ~~~~~~~~~~~~~~~~~~~
 
 If you've already followed the :ref:`initial enforcement steps
@@ -177,7 +177,7 @@ in any social setting that puts our members at risk.
 Members expelled from events or venues with any sort of paid attendance
 will not be refunded.
 
-Who Watches the Watchers?
+Who watches the watchers?
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Maintainers and other leaders who do not follow or enforce the Code of
@@ -194,10 +194,10 @@ procedures.
 
 .. _coc-enforcement-examples:
 
-Enforcement Examples
+Enforcement examples
 --------------------
 
-The Best Case
+The best case
 ~~~~~~~~~~~~~
 
 The vast majority of situations work out like this. This interaction is
@@ -211,7 +211,7 @@ common, and generally positive.
     Alex: "oh sorry, sure." -> edits old comment to say "it was really
     confusing!"
 
-The Maintainer Case
+The maintainer case
 ~~~~~~~~~~~~~~~~~~~
 
 Sometimes, though, you need to get maintainers involved. Maintainers
@@ -248,7 +248,7 @@ something **will take priority**.
     KeeperOfCommitBits: "@patt Thanks for that. I hear you on the
     stress. Burnout sucks :/. Have a good one!"
 
-The Nope Case
+The nope case
 ~~~~~~~~~~~~~
 
     PepeTheFrog🐸: "Hi, I am a literal actual nazi and I think white

--- a/docs/custom_fields.rst
+++ b/docs/custom_fields.rst
@@ -1,5 +1,4 @@
-
-Custom Fields
+Custom fields
 =============
 
 There are three ways to create a custom-formatted field for a `Schema`:
@@ -10,7 +9,7 @@ There are three ways to create a custom-formatted field for a `Schema`:
 
 The method you choose will depend on the manner in which you intend to reuse the field.
 
-Creating A Field Class
+Creating a field class
 ----------------------
 
 To create a custom field class, create a subclass of :class:`marshmallow.fields.Field` and implement its :meth:`_serialize <marshmallow.fields.Field._serialize>` and/or :meth:`_deserialize <marshmallow.fields.Field._deserialize>` methods.
@@ -43,7 +42,7 @@ To create a custom field class, create a subclass of :class:`marshmallow.fields.
         created_at = fields.DateTime()
         pin_code = PinCode()
 
-Method Fields
+Method fields
 -------------
 
 A :class:`Method <marshmallow.fields.Method>` field will serialize to the value returned by a method of the Schema. The method must take an ``obj`` parameter which is the object to be serialized.
@@ -59,7 +58,7 @@ A :class:`Method <marshmallow.fields.Method>` field will serialize to the value 
         def get_days_since_created(self, obj):
             return dt.datetime.now().day - obj.created_at.day
 
-Function Fields
+Function fields
 ---------------
 
 A :class:`Function <marshmallow.fields.Function>` field will serialize the value of a function that is passed directly to it. Like a :class:`Method <marshmallow.fields.Method>` field, the function must take a single argument ``obj``.
@@ -97,7 +96,7 @@ Both :class:`Function <marshmallow.fields.Function>` and :class:`Method <marshma
 
 .. _adding-context:
 
-Adding Context to `Method` and `Function` Fields
+Adding context to `Method` and `Function` fields
 ------------------------------------------------
 
 A :class:`Function <marshmallow.fields.Function>` or :class:`Method <marshmallow.fields.Method>` field may need information about its environment to know how to serialize a value.
@@ -129,7 +128,7 @@ As an example, you might want your ``UserSchema`` to output whether or not a ``U
     result["likes_bikes"]  # => True
 
 
-Customizing Error Messages
+Customizing error messages
 --------------------------
 
 Validation error messages for fields can be configured at the class or instance level.
@@ -160,8 +159,8 @@ Error messages can also be passed to a `Field's` constructor.
         )
 
 
-Next Steps
+Next steps
 ----------
 
-- Need to add schema-level validation, post-processing, or error handling behavior? See the :doc:`Extending Schemas <extending>` page.
+- Need to add schema-level validation, post-processing, or error handling behavior? See the :doc:`Extending schemas <extending>` page.
 - For example applications using marshmallow, check out the :doc:`Examples <examples>` page.

--- a/docs/dashing.json
+++ b/docs/dashing.json
@@ -1,22 +1,22 @@
 {
-    "name": "Marshmallow",
-    "package": "marshmallow",
-    "index": "_build/index.html",
-    "selectors": {
-        "dl.class dt": {
-            "type": "Class",
-            "attr": "id"
-        },
-        "dl.exception dt": {
-            "type": "Exception",
-            "attr": "id"
-        },
-        "dl.function dt": {
-            "type": "Function",
-            "attr": "id"
-        }
+  "name": "marshmallow",
+  "package": "marshmallow",
+  "index": "_build/index.html",
+  "selectors": {
+    "dl.class dt": {
+      "type": "Class",
+      "attr": "id"
     },
-    "icon32x32": "",
-    "allowJS": false,
-    "ExternalURL": ""
+    "dl.exception dt": {
+      "type": "Exception",
+      "attr": "id"
+    },
+    "dl.function dt": {
+      "type": "Function",
+      "attr": "id"
+    }
+  },
+  "icon32x32": "",
+  "allowJS": false,
+  "ExternalURL": ""
 }

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -291,8 +291,8 @@ After registering a user and creating some todo items in the database, here is a
     }
 
 
-Inflection (Camel-casing Keys)
-==============================
+Inflection (camel-cased keys)
+=============================
 
 HTTP APIs will often use camel-cased keys for their input and output representations. This example shows how you can use the
 `Schema.on_bind_field <marshmallow.Schema.on_bind_field>` hook to automatically inflect keys.

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -1,9 +1,9 @@
 .. module:: marshmallow
 
-Extending Schemas
+Extending schemas
 =================
 
-Pre-processing and Post-processing Methods
+Pre-processing and post-processing methods
 ------------------------------------------
 
 Data pre-processing and post-processing methods can be registered using the `pre_load <marshmallow.decorators.pre_load>`, `post_load <marshmallow.decorators.post_load>`, `pre_dump <marshmallow.decorators.pre_dump>`, and `post_dump <marshmallow.decorators.post_dump>` decorators.
@@ -97,8 +97,7 @@ One common use case is to wrap data in a namespace upon serialization and unwrap
     user_objs = user_schema.load(users_data, many=True)
     # [<User(name='Keith Richards')>, <User(name='Charlie Watts')>]
 
-
-Raising Errors in Pre-/Post-processor Methods
+Raising errors in pre-/post-processor methods
 +++++++++++++++++++++++++++++++++++++++++++++
 
 Pre- and post-processing methods may raise a `ValidationError <marshmallow.exceptions.ValidationError>`. By default, errors will be stored on the ``"_schema"`` key in the errors dictionary.
@@ -151,8 +150,7 @@ If you want to store and error on a different key, pass the key name as the seco
         err.messages
     # {'_preprocessing': ['Input data must have a "data" key.']}
 
-
-Pre-/Post-processor Invocation Order
+Pre-/post-processor invocation order
 ++++++++++++++++++++++++++++++++++++
 
 In summary, the processing pipeline for deserialization is as follows:
@@ -215,10 +213,7 @@ The pipeline for serialization is similar, except that the ``pass_many=True`` pr
             def step2(self, data, **kwargs):
                 do_step2(data)
 
-
-.. _schemavalidation:
-
-Schema-level Validation
+Schema-level validation
 -----------------------
 
 You can register schema-level validation functions for a :class:`Schema` using the `marshmallow.validates_schema <marshmallow.decorators.validates_schema>` decorator. By default, schema-level validation errors will be stored on the ``_schema`` key of the errors dictionary.
@@ -245,7 +240,7 @@ You can register schema-level validation functions for a :class:`Schema` using t
         err.messages["_schema"]
     # => ["field_a must be greater than field_b"]
 
-Storing Errors on Specific Fields
+Storing errors on specific fields
 +++++++++++++++++++++++++++++++++
 
 It is possible to report errors on fields and subfields using a `dict`.
@@ -300,8 +295,7 @@ When multiple schema-leval validator return errors, the error structures are mer
     #     ]
     #    }
 
-
-Using Original Input Data
+Using original input data
 -------------------------
 
 If you want to use the original, unprocessed input, you can add ``pass_original=True`` to
@@ -332,7 +326,7 @@ If you want to use the original, unprocessed input, you can add ``pass_original=
 
    The default behavior for unspecified fields can be controlled with the ``unknown`` option, see :ref:`Handling Unknown Fields <unknown>` for more information.
 
-Overriding How Attributes Are Accessed
+Overriding how attributes are accessed
 --------------------------------------
 
 By default, marshmallow uses `utils.get_value` to pull attributes from various types of objects for serialization. This will work for *most* use cases.
@@ -350,7 +344,7 @@ However, if you want to specify how values are accessed from an object, you can 
         def get_attribute(self, obj, key, default):
             return obj.get(key, default)
 
-Custom Error Handling
+Custom error handling
 ---------------------
 
 By default, :meth:`Schema.load` will raise a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` if passed invalid data.
@@ -379,15 +373,14 @@ You can specify a custom error-handling function for a :class:`Schema` by overri
     schema = UserSchema()
     schema.load({"email": "invalid-email"})  # raises AppError
 
-
-Custom "class Meta" Options
+Custom "class Meta" options
 ---------------------------
 
 ``class Meta`` options are a way to configure and modify a :class:`Schema's <Schema>` behavior. See the :class:`API docs <Schema.Meta>` for a listing of available options.
 
 You can add custom ``class Meta`` options by subclassing :class:`SchemaOpts`.
 
-Example: Enveloping, Revisited
+Example: Enveloping, revisited
 ++++++++++++++++++++++++++++++
 
 Let's build upon the example above for adding an envelope to serialized output. This time, we will allow the envelope key to be customizable with ``class Meta`` options.
@@ -461,7 +454,7 @@ Our application schemas can now inherit from our custom schema class.
     result = ser.dump(user)
     result  # {"user": {"name": "Keith", "email": "keith@stones.com"}}
 
-Using Context
+Using context
 -------------
 
 The ``context`` attribute of a `Schema` is a general-purpose store for extra information that may be needed for (de)serialization. It may be used in both ``Schema`` and ``Field`` methods.
@@ -474,7 +467,7 @@ The ``context`` attribute of a `Schema` is a general-purpose store for extra inf
     schema.context["request"] = request
     schema.dump(user)
 
-Custom Error Messages
+Custom error messages
 ---------------------
 
 To customize the schema-level error messages that `load <marshmallow.Schema.load>` and `loads <marshmallow.Schema.loads>` use when raising a `ValidationError <marshmallow.exceptions.ValidationError>`, override the `error_messages <marshmallow.Schema.error_messages>` class variable:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 
 **marshmallow** has no external dependencies other than the `packaging` library.
 
-Installing/Upgrading from the PyPI
+Installing/upgrading from the PyPI
 ----------------------------------
 
 To install the latest stable version from the PyPI:

--- a/docs/marshmallow.fields.rst
+++ b/docs/marshmallow.fields.rst
@@ -9,7 +9,7 @@ Base Field Class
 .. autoclass:: marshmallow.fields.Field
     :private-members:
 
-Field Subclasses
+Field subclasses
 ----------------
 
 .. automodule:: marshmallow.fields

--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -1,4 +1,4 @@
-Nesting Schemas
+Nesting schemas
 ===============
 
 Schemas can be nested to represent relationships between objects (e.g. foreign key relationships). For example, a ``Blog`` may have an author represented by a User object.
@@ -63,7 +63,7 @@ The serialized blog will have the nested user representation.
 
 .. _specifying-nested-fields:
 
-Specifying Which Fields to Nest
+Specifying which fields to nest
 -------------------------------
 
 You can explicitly specify which attributes of the nested objects you want to (de)serialize with the ``only`` argument to the schema.
@@ -129,7 +129,7 @@ You can replace nested data with a single value (or flat list of values if ``man
 
 .. _partial-loading:
 
-Partial Loading
+Partial loading
 ---------------
 
 Nested schemas also inherit the ``partial`` parameter of the parent ``load`` call.
@@ -165,7 +165,7 @@ You can specify a subset of the fields to allow partial loading using dot delimi
 
 .. _two-way-nesting:
 
-Two-way Nesting
+Two-way nesting
 ---------------
 
 If you have two objects that nest each other, you can pass a callable to `Nested <marshmallow.fields.Nested>`.
@@ -258,7 +258,7 @@ This is useful for avoiding circular imports when your schemas are located in di
 
 .. _self-nesting:
 
-Nesting A Schema Within Itself
+Nesting a schema within itself
 ------------------------------
 
 If the object to be marshalled has a relationship to an object of the same type, you can nest the `Schema` within itself by passing a callable that returns an instance of the same schema.
@@ -303,7 +303,7 @@ If the object to be marshalled has a relationship to an object of the same type,
     #     }
     # }
 
-Next Steps
+Next steps
 ----------
 
 - Want to create your own field type? See the :doc:`Custom Fields <custom_fields>` page.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -5,7 +5,7 @@ Quickstart
 
 This guide will walk you through the basics of creating schemas for serializing and deserializing data.
 
-Declaring Schemas
+Declaring schemas
 -----------------
 
 Let's start with a basic user "model".
@@ -41,7 +41,7 @@ Create a schema by defining a class with variables mapping attribute names to :c
 
     For a full reference on the available field classes, see the :ref:`API Docs <api_fields>`.
 
-Creating Schemas From Dictionaries
+Creating schemas from dictionaries
 ----------------------------------
 
 You can create a schema from a dictionary of fields using the `from_dict <marshmallow.Schema.from_dict>` method.
@@ -56,7 +56,7 @@ You can create a schema from a dictionary of fields using the `from_dict <marshm
 
 `from_dict <marshmallow.Schema.from_dict>` is especially useful for generating schemas at runtime.
 
-Serializing Objects ("Dumping")
+Serializing objects ("dumping")
 -------------------------------
 
 Serialize objects by passing them to your schema's :meth:`dump <marshmallow.Schema.dump>` method, which returns the formatted result.
@@ -81,7 +81,7 @@ You can also serialize to a JSON-encoded string using :meth:`dumps <marshmallow.
     pprint(json_result)
     # '{"name": "Monty", "email": "monty@python.org", "created_at": "2014-08-17T14:54:16.049594+00:00"}'
 
-Filtering Output
+Filtering output
 ----------------
 
 You may not need to output all declared fields every time you use a schema. You can specify which fields to output with the ``only`` parameter.
@@ -95,7 +95,7 @@ You may not need to output all declared fields every time you use a schema. You 
 You can also exclude fields by passing in the ``exclude`` parameter.
 
 
-Deserializing Objects ("Loading")
+Deserializing objects ("loading")
 ---------------------------------
 
 The reverse of the `dump <Schema.dump>` method is `load <Schema.load>`, which validates and deserializes 
@@ -122,7 +122,7 @@ with a dictionary of validation errors, which we'll :ref:`revisit later <validat
 
 Notice that the datetime string was converted to a `datetime` object.
 
-Deserializing to Objects
+Deserializing to objects
 ++++++++++++++++++++++++
 
 In order to deserialize to an object, define a method of your :class:`Schema` and decorate it with `post_load <marshmallow.decorators.post_load>`. The method receives a dictionary of deserialized data.
@@ -150,7 +150,7 @@ Now, the `load <Schema.load>` method return a ``User`` instance.
     result = schema.load(user_data)
     print(result)  # => <User(name='Ronnie')>
 
-Handling Collections of Objects
+Handling collections of objects
 -------------------------------
 
 Set ``many=True`` when dealing with iterable collections of objects.
@@ -289,7 +289,7 @@ You may also pass a collection (list, tuple, generator) of callables to ``valida
     Need schema-level validation? See the :ref:`Extending Schemas <schemavalidation>` page.
 
 
-Field Validators as Methods
+Field validators as methods
 +++++++++++++++++++++++++++
 
 It is sometimes convenient to write validators as methods. Use the `validates <marshmallow.decorators.validates>` decorator to register field validator methods.
@@ -310,7 +310,7 @@ It is sometimes convenient to write validators as methods. Use the `validates <m
                 raise ValidationError("Quantity must not be greater than 30.")
 
 
-Required Fields
+Required fields
 ---------------
 
 Make a field required by passing ``required=True``. An error will be raised if the the value is missing from the input to :meth:`Schema.load`.
@@ -343,7 +343,7 @@ To customize the error message for required fields, pass a `dict` with a ``requi
         # 'name': ['Missing data for required field.']}
 
 
-Partial Loading
+Partial loading
 ---------------
 
 When using the same schema in multiple places, you may only want to skip ``required``
@@ -373,7 +373,7 @@ You can ignore missing fields entirely by setting ``partial=True``.
     # OR UserSchema(partial=True).load({'age': 42})
     print(result)  # => {'age': 42}
 
-Specifying Defaults
+Specifying defaults
 -------------------
 
 `load_default` specifies the default deserialization value for a field.
@@ -393,7 +393,7 @@ Likewise, `dump_default` specifies the default serialization value.
 
 .. _unknown:
 
-Handling Unknown Fields
+Handling unknown fields
 -----------------------
 
 By default, :meth:`load <Schema.load>` will raise a :exc:`ValidationError <marshmallow.exceptions.ValidationError>` if it encounters a key with no matching ``Field`` in the schema.
@@ -433,7 +433,7 @@ The ``unknown`` option value set in :meth:`load <Schema.load>` will override the
 This order of precedence allows you to change the behavior of a schema for different contexts.
 
 
-Validation Without Deserialization
+Validation without deserialization
 ----------------------------------
 
 If you only need to validate input data (without deserializing to an object), you can use :meth:`Schema.validate`.
@@ -444,7 +444,7 @@ If you only need to validate input data (without deserializing to an object), yo
     print(errors)  # {'email': ['Not a valid email address.']}
 
 
-"Read-only" and "Write-only" Fields
+"Read-only" and "write-only" fields
 -----------------------------------
 
 In the context of a web API, the ``dump_only`` and ``load_only`` parameters are conceptually equivalent to "read-only" and "write-only" fields, respectively.
@@ -462,7 +462,7 @@ In the context of a web API, the ``dump_only`` and ``load_only`` parameters are 
 
     When loading, dump-only fields are considered unknown. If the ``unknown`` option is set to ``INCLUDE``, values with keys corresponding to those fields are therefore loaded with no validation.
 
-Specifying Serialization/Deserialization Keys
+Specifying serialization/deserialization keys
 ---------------------------------------------
 
 Schemas will (de)serialize an input dictionary from/to an output dictionary whose keys are identical to the field names.
@@ -490,12 +490,12 @@ If you are consuming and producing data that does not match your schema, you can
 
 .. _meta_options:
 
-Implicit Field Creation
+Implicit field creation
 -----------------------
 
 When your model has many attributes, specifying the field type for every attribute can get repetitive, especially when many of the attributes are already native Python datatypes.
 
-The ``fields`` option allows you to specify implicitly-created fields. Marshmallow will choose an appropriate field type based on the attribute's type.
+The ``fields`` option allows you to specify implicitly-created fields. marshmallow will choose an appropriate field type based on the attribute's type.
 
 Let's refactor our User schema to be more concise.
 
@@ -524,9 +524,8 @@ Note that ``name`` will be automatically formatted as a :class:`String <marshmal
                 # No need to include 'uppername'
                 additional = ("name", "email", "created_at")
 
-Next Steps
+Next steps
 ----------
-
 - Need to represent relationships between objects? See the :doc:`Nesting Schemas <nesting>` page.
 - Want to create your own field type? See the :doc:`Custom Fields <custom_fields>` page.
 - Need to add schema-level validation, post-processing, or error handling behavior? See the :doc:`Extending Schemas <extending>` page.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -1,4 +1,4 @@
-Upgrading to Newer Releases
+Upgrading to newer releases
 ===========================
 
 This section documents migration paths to new releases.
@@ -336,7 +336,7 @@ page for an example.
 Schemas raise ``ValidationError`` when deserializing data with unknown keys
 ***************************************************************************
 
-Marshmallow 3.x schemas can deal with unknown keys in three different ways,
+marshmallow 3.x schemas can deal with unknown keys in three different ways,
 configurable with the ``unknown`` option:
 
 - ``EXCLUDE``: drop those keys (same as marshmallow 2)
@@ -1190,7 +1190,7 @@ In 2.0, validation/deserialization of `None` is consistent across field types. I
     # allow_none makes None a valid value
     fields.Int(allow_none=True).deserialize(None)  # None
 
-Default Values
+Default values
 **************
 
 Before version 2.0, certain fields (including `String <marshmallow.fields.String>`, `List <marshmallow.fields.List>`, `Nested <marshmallow.fields.Nested>`, and number fields) had implicit default values that would be used if their corresponding input value was `None` or missing.
@@ -1239,7 +1239,7 @@ In 2.0, these implicit defaults are removed.  A `Field's <marshmallow.fields.Fie
 As a consequence of this new behavior, the ``skip_missing`` class Meta option has been removed.
 
 
-Pre-processing and Post-processing Methods
+Pre-processing and post-processing methods
 ******************************************
 
 The pre- and post-processing API was significantly improved for better consistency and flexibility. The `pre_load <marshmallow.decorators.pre_load>`, `post_load <marshmallow.decorators.post_load>`, `pre_dump <marshmallow.decorators.pre_dump>`, and `post_dump <marshmallow.decorators.post_dump>` should be used to define processing hooks. `Schema.preprocessor` and `Schema.data_handler` are removed.
@@ -1286,7 +1286,7 @@ The pre- and post-processing API was significantly improved for better consisten
 
 See the :doc:`Extending Schemas <extending>` page for more information on the ``pre_*`` and ``post_*`` decorators.
 
-Schema Validators
+Schema validators
 *****************
 
 Similar to pre-processing and post-processing methods, schema validators are now defined as methods. Decorate schema validators with `validates_schema <marshmallow.decorators.validates_schema>`. `Schema.validator` is removed.
@@ -1321,7 +1321,7 @@ Similar to pre-processing and post-processing methods, schema validators are now
             if data["field_a"] < data["field_b"]:
                 raise ValidationError("field_a must be greater than field_b")
 
-Custom Accessors and Error Handlers
+Custom accessors and error handlers
 ***********************************
 
 Custom accessors and error handlers are now defined as methods. `Schema.accessor` and `Schema.error_handler` are deprecated.
@@ -1388,7 +1388,7 @@ The `make_object` method was deprecated from the `Schema <marshmallow.Schema>` A
         def make_user(self, data):
             return User(**data)
 
-Error Format when ``many=True``
+Error format when ``many=True``
 *******************************
 
 When validating a collection (i.e. when calling ``load`` or ``dump`` with ``many=True``), the errors dictionary will be keyed on the indices of invalid items.
@@ -1472,7 +1472,7 @@ In 2.0, `strict` mode was improved so that you can access all error messages for
     # }
 
 
-Custom Fields
+Custom fields
 *************
 
 Two changes must be made to make your custom fields compatible with version 2.0.
@@ -1513,7 +1513,7 @@ To make a field compatible with both marshmallow 1.x and 2.x, you can pass `*arg
                 raise ValidationError("Password too short.")
             return val
 
-Custom Error Messages
+Custom error messages
 *********************
 
 Error messages can be customized at the `Field` class or instance level.
@@ -1560,7 +1560,7 @@ The `fields.Select` field is deprecated in favor of the newly-added `OneOf` vali
     # 2.0
     fields.Str(validate=OneOf(["red", "blue"]))
 
-Accessing Context from Method fields
+Accessing context from method fields
 ************************************
 
 Use ``self.context`` to access a schema's context within a ``Method`` field.
@@ -1575,7 +1575,7 @@ Use ``self.context`` to access a schema's context within a ``Method`` field.
             return "bicycle" in self.context["blog"].title.lower()
 
 
-Validation Error Messages
+Validation error messages
 *************************
 
 The default error messages for many fields and validators have been changed for better consistency.
@@ -1653,7 +1653,7 @@ Validators were rewritten as class-based callables, making them easier to use wh
 
 The validator functions from 1.1 are deprecated and will be removed in 2.0.
 
-Deserializing the Empty String
+Deserializing the empty string
 ******************************
 
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -3,29 +3,29 @@ Why marshmallow?
 
 The Python ecosystem has many great libraries for data formatting and schema validation.
 
-In fact, marshmallow was influenced by a number of these libraries. Marshmallow is inspired by `Django REST Framework`_, `Flask-RESTful`_, and `colander <https://docs.pylonsproject.org/projects/colander/en/latest/>`_. It borrows a number of implementation and design ideas from these libraries to create a flexible and productive solution for marshalling, unmarshalling, and validating data.
+In fact, marshmallow was influenced by a number of these libraries. marshmallow is inspired by `Django REST Framework`_, `Flask-RESTful`_, and `colander <https://docs.pylonsproject.org/projects/colander/en/latest/>`_. It borrows a number of implementation and design ideas from these libraries to create a flexible and productive solution for marshalling, unmarshalling, and validating data.
 
 Here are just a few reasons why you might use marshmallow.
 
-Agnostic.
----------
+Agnostic
+--------
 
-Marshmallow makes no assumption about web frameworks or database layers. It will work with just about any ORM, ODM, or no ORM at all. This gives you the freedom to choose the components that fit your application's needs without having to change your data formatting code. If you wish, you can build integration layers to make marshmallow work more closely with your frameworks and libraries of choice (for examples, see `Flask-Marshmallow <https://github.com/marshmallow-code/flask-marshmallow>`_ and `Django REST Marshmallow <https://github.com/marshmallow-code/django-rest-marshmallow>`_).
+marshmallow makes no assumption about web frameworks or database layers. It will work with just about any ORM, ODM, or no ORM at all. This gives you the freedom to choose the components that fit your application's needs without having to change your data formatting code. If you wish, you can build integration layers to make marshmallow work more closely with your frameworks and libraries of choice (for examples, see `Flask-Marshmallow <https://github.com/marshmallow-code/flask-marshmallow>`_ and `Django REST Marshmallow <https://github.com/marshmallow-code/django-rest-marshmallow>`_).
 
-Concise, familiar syntax.
--------------------------
+Concise, familiar syntax
+------------------------
 
 If you have used `Django REST Framework`_ or  `WTForms <https://wtforms.readthedocs.io/en/stable/>`_, marshmallow's :class:`Schema <marshmallow.Schema>` syntax will feel familiar to you. Class-level field attributes define the schema for formatting your data. Configuration is added using the ``class Meta`` paradigm. Configuration options can be overridden at application runtime by passing arguments to the `Schema <marshmallow.Schema>` constructor. The :meth:`dump <marshmallow.Schema.dump>` and :meth:`load <marshmallow.Schema.load>` methods are used for serialization and deserialization (of course!).
 
-Class-based schemas allow for code reuse and configuration.
------------------------------------------------------------
+Class-based schemas allow for code reuse and configuration
+----------------------------------------------------------
 
-Unlike `Flask-RESTful`_, which uses dictionaries to define output schemas, marshmallow uses classes. This allows for easy code reuse and configuration. It also allows for powerful means for configuring and extending schemas, such as adding :doc:`post-processing and error handling behavior <extending>`.
+Unlike `Flask-RESTful`_, which uses dictionaries to define output schemas, marshmallow uses classes. This allows for easy code reuse and configuration. It also enables patterns for configuring and extending schemas, such as adding :doc:`post-processing and error handling behavior <extending>`.
 
-Consistency meets flexibility.
-------------------------------
+Consistency meets flexibility
+-----------------------------
 
-Marshmallow makes it easy to modify a schema's output at application runtime. A single :class:`Schema <marshmallow.Schema>` can produce multiple output formats while keeping the individual field outputs consistent.
+marshmallow makes it easy to modify a schema's output at application runtime. A single :class:`Schema <marshmallow.Schema>` can produce multiple output formats while keeping the individual field outputs consistent.
 
 As an example, you might have a JSON endpoint for retrieving all information about a video game's state. You then add a low-latency endpoint that only returns a minimal subset of information about game state. Both endpoints can be handled by the same `Schema <marshmallow.Schema>`.
 
@@ -56,10 +56,10 @@ In this example, a single schema produced three different outputs! The dynamic n
 .. _Flask-RESTful: https://flask-restful.readthedocs.io/
 
 
-Context-aware serialization.
-----------------------------
+Context-aware serialization
+---------------------------
 
-Marshmallow schemas can modify their output based on the context in which they are used. Field objects have access to a ``context`` dictionary that can be changed at runtime.
+marshmallow schemas can modify their output based on the context in which they are used. Field objects have access to a ``context`` dictionary that can be changed at runtime.
 
 Here's a simple example that shows how a `Schema <marshmallow.Schema>` can anonymize a person's name when a boolean is set on the context.
 
@@ -88,10 +88,10 @@ Here's a simple example that shows how a `Schema <marshmallow.Schema>` can anony
 
     See the relevant section of the :ref:`usage guide <adding-context>` to learn more about context-aware serialization.
 
-Advanced schema nesting.
-------------------------
+Advanced schema nesting
+-----------------------
 
-Most serialization libraries provide some means for nesting schemas within each other, but they often fail to meet common use cases in clean way. Marshmallow aims to fill these gaps by adding a few nice features for :doc:`nesting schemas <nesting>`:
+Most serialization libraries provide some means for nesting schemas within each other, but they often fail to meet common use cases in clean way. marshmallow aims to fill these gaps by adding a few nice features for :doc:`nesting schemas <nesting>`:
 
 - You can specify which :ref:`subset of fields <specifying-nested-fields>` to include on nested schemas.
 - :ref:`Two-way nesting <two-way-nesting>`. Two different schemas can nest each other.

--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -1,6 +1,6 @@
-"""Simple benchmark for Marshmallow serialization of a moderately complex object.
+"""Simple benchmark for marshmallow serialization of a moderately complex object.
 
-Uses the `timeit` module to benchmark serializing an object through Marshmallow.
+Uses the `timeit` module to benchmark serializing an object through marshmallow.
 """
 
 import argparse
@@ -125,7 +125,7 @@ def main():
     parser.add_argument(
         "--profile",
         action="store_true",
-        help="Whether or not to profile Marshmallow while running the benchmark.",
+        help="Whether or not to profile marshmallow while running the benchmark.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Use sentence-casing for all section titles, per the Python docs style guide:

> the use of sentence case in section titles is preferable, but consistency within a unit is more important than following this rule.

https://devguide.python.org/documentation/style-guide/#capitalization

Also, lowercase "marshmallow"

