### PR TITLE
Exemplify using type aliases for Context

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -94,13 +94,16 @@ manager class that can be used to both set and retrieve context.
         suffix: str
 
 
+    UserSchemaContext = Context[UserContext]
+
+
     class UserSchema(Schema):
         name_suffixed = fields.Function(
-            lambda obj: obj["name"] + Context[UserContext].get()["suffix"]
+            lambda obj: obj["name"] + UserSchemaContext.get()["suffix"]
         )
 
 
-    with Context[UserContext]({"suffix": "bar"}):
+    with UserSchemaContext({"suffix": "bar"}):
         UserSchema().dump({"name": "foo"})
         # {'name_suffixed': 'foobar'}
 

--- a/src/marshmallow/experimental/context.py
+++ b/src/marshmallow/experimental/context.py
@@ -14,13 +14,16 @@ Example usage:
         suffix: str
 
 
+    UserSchemaContext = Context[UserContext]
+
+
     class UserSchema(Schema):
         name_suffixed = fields.Function(
-            lambda user: user["name"] + Context[UserContext].get()["suffix"]
+            lambda user: user["name"] + UserSchemaContext.get()["suffix"]
         )
 
 
-    with Context[UserContext]({"suffix": "bar"}):
+    with UserSchemaContext({"suffix": "bar"}):
         print(UserSchema().dump({"name": "foo"}))
         # {'name_suffixed': 'foobar'}
 """


### PR DESCRIPTION
shows usage of aliasing Context[ContextType] to make things a little nicer