### PR TITLE
Context.__enter__ returns self

### DIFF
--- a/src/marshmallow/experimental/context.py
+++ b/src/marshmallow/experimental/context.py
@@ -28,6 +28,8 @@ Example usage:
         # {'name_suffixed': 'foobar'}
 """
 
+from __future__ import annotations
+
 import contextlib
 import contextvars
 import typing
@@ -43,8 +45,9 @@ class Context(contextlib.AbstractContextManager, typing.Generic[_T]):
         self.context = context
         self.token: contextvars.Token | None = None
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> Context[_T]:
         self.token = _CURRENT_CONTEXT.set(self.context)
+        return self
 
     def __exit__(self, *args, **kwargs) -> None:
         _CURRENT_CONTEXT.reset(typing.cast(contextvars.Token, self.token))


### PR DESCRIPTION
it's a common pattern with context managers to return `self` in `__enter__` to allow method chaining.

in particular, it nicely allows the value of `get()` to be correctly typed

```python
from marshmallow.experimental.context import Context

with Context[bool](True) as context:
    # Don't need to do Context[bool].get().
    # value is inferred to be bool.
    value = context.get()
```