### PR TITLE
Avoid breaking inspect.signature on fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 3.24.2 (unreleased)
 *******************
 
+Changes:
+
+- Don't override ``__new__`` to avoid breaking usages of `inspect.signature` with
+  `Field <marshmallow.fields.Field>` classes.
+  This allows marshmallow-sqlalchemy users to upgrade marshmallow without
+  upgrading to marshmallow-sqlalchemy>=1.1.1.
+
 Documentation:
 
 - Add top-level API back to docs (:issue:`2739`).
@@ -30,7 +37,7 @@ Bug fixes:
 
 Deprecations:
 
-- Custom validators should raise a `ValidationError <marshmallow.exceptions.ValidationError>` for invalid values. 
+- Custom validators should raise a `ValidationError <marshmallow.exceptions.ValidationError>` for invalid values.
   Returning `False`` is no longer supported .
 - Deprecate ``context`` parameter of `Schema <marshmallow.schema.Schema>` (:issue:`1826`).
   Use `contextVars.ContextVar` to pass context data instead.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -139,16 +139,6 @@ class Field(FieldABC):
         "validator_failed": "Invalid value.",
     }
 
-    def __new__(cls, *args, **kwargs):
-        if cls is Field:
-            warnings.warn(
-                "`Field` should not be instantiated. Use `fields.Raw` or  "
-                "another field subclass instead.",
-                ChangedInMarshmallow4Warning,
-                stacklevel=2,
-            )
-        return super().__new__(cls)
-
     def __init__(
         self,
         *,
@@ -171,6 +161,13 @@ class Field(FieldABC):
         metadata: typing.Mapping[str, typing.Any] | None = None,
         **additional_metadata,
     ) -> None:
+        if self.__class__ is Field:
+            warnings.warn(
+                "`Field` should not be instantiated. Use `fields.Raw` or  "
+                "another field subclass instead.",
+                ChangedInMarshmallow4Warning,
+                stacklevel=2,
+            )
         # handle deprecated `default` and `missing` parameters
         if default is not missing_:
             warnings.warn(
@@ -963,16 +960,13 @@ class Number(Field, typing.Generic[_NumType]):
         "too_large": "Number too large.",
     }
 
-    def __new__(cls, *args, **kwargs):
-        if cls is Number:
+    def __init__(self, *, as_string: bool = False, **kwargs):
+        if self.__class__ is Number:
             warnings.warn(
                 "`Number` field should not be instantiated. Use `Integer`, `Float`, or `Decimal` instead.",
                 ChangedInMarshmallow4Warning,
                 stacklevel=2,
             )
-        return super().__new__(cls)
-
-    def __init__(self, *, as_string: bool = False, **kwargs):
         self.as_string = as_string
         super().__init__(**kwargs)
 
@@ -1579,21 +1573,18 @@ class Mapping(Field):
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid mapping type."}
 
-    def __new__(cls, *args, **kwargs):
-        if cls is Mapping:
-            warnings.warn(
-                "`Mapping` field should not be instantiated. Use `Dict` instead.",
-                ChangedInMarshmallow4Warning,
-                stacklevel=2,
-            )
-        return super().__new__(cls)
-
     def __init__(
         self,
         keys: Field | type[Field] | None = None,
         values: Field | type[Field] | None = None,
         **kwargs,
     ):
+        if self.__class__ is Mapping:
+            warnings.warn(
+                "`Mapping` field should not be instantiated. Use `Dict` instead.",
+                ChangedInMarshmallow4Warning,
+                stacklevel=2,
+            )
         super().__init__(**kwargs)
         if keys is None:
             self.key_field = None


### PR DESCRIPTION
Removes `__new__` overrides to avoid breaking usages of `inspect.signature` on `Field` classes. this allows marshmallow 3.24 to work with marshmallow-sqlalchemy<1.1.1

Relevant marshmallow-sqlalchemy fix: https://github.com/marshmallow-code/marshmallow-sqlalchemy/pull/628/files#diff-ac1f3e987a72b794c7c4318fcbd3bb325974b73fa46c3c511fdba347f60948acR60