### PR TITLE
Improve types for get_declared_fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+3.25.0 (unreleased)
+*******************
+
+Features:
+
+- Typing: Improve type annotations for ``SchemaMeta.get_declared_fields``.
+
 3.24.2 (2025-01-08)
 *******************
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -41,7 +41,7 @@ from marshmallow.utils import (
 from marshmallow.warnings import RemovedInMarshmallow4Warning
 
 
-def _get_fields(attrs):
+def _get_fields(attrs) -> list[tuple[str, ma_fields.Field]]:
     """Get fields from a class
 
     :param attrs: Mapping of class attributes
@@ -124,10 +124,10 @@ class SchemaMeta(ABCMeta):
     def get_declared_fields(
         mcs,
         klass: SchemaMeta,
-        cls_fields: list,
-        inherited_fields: list,
+        cls_fields: list[tuple[str, ma_fields.Field]],
+        inherited_fields: list[tuple[str, ma_fields.Field]],
         dict_cls: type[dict] = dict,
-    ):
+    ) -> dict[str, ma_fields.Field]:
         """Returns a dictionary of field_name => `Field` pairs declared on the class.
         This is exposed mainly so that plugins can add additional fields, e.g. fields
         computed from class Meta options.


### PR DESCRIPTION
this is helpful for libraries like marshmallow-sqlalchemy that override get_declared_fields to automatically add fields