### PR TITLE
Run mypy against tests

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,7 +70,7 @@ jobs:
   publish-to-pypi:
     name: PyPI release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [mypy, build, tests, lint-pre-release]
+    needs: [build, tests, lint-pre-release]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,17 +6,6 @@ on:
   pull_request:
 
 jobs:
-  mypy:
-    name: mypy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.0.0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install tox
-      - run: python -m tox -e mypy-test
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -36,6 +25,7 @@ jobs:
         include:
           - { name: "3.9", python: "3.9", tox: py39 }
           - { name: "3.13", python: "3.13", tox: py313 }
+          - { name: "mypy", python: "3.13", tox: mypy }
     steps:
       - uses: actions/checkout@v4.0.0
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,3 @@ repos:
   hooks:
   - id: blacken-docs
     additional_dependencies: [black==24.10.0]
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.14.1
-  hooks:
-  - id: mypy
-    additional_dependencies: [types-simplejson, packaging]
-    # these files are checked under `tox -e mypy-test`
-    exclude: ^tests/mypy_test_cases/.*$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,11 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 no_implicit_optional = true
 
+[[tool.mypy.overrides]]
+module = "tests.*"
+check_untyped_defs = true
+disable_error_code = ["call-overload", "index"]
+
 [tool.pytest.ini_options]
 norecursedirs = ".git .ropeproject .tox docs env venv tests/mypy_test_cases"
 addopts = "-v --tb=short"

--- a/src/marshmallow/class_registry.py
+++ b/src/marshmallow/class_registry.py
@@ -74,9 +74,7 @@ def get_class(classname: str, all: typing.Literal[False] = ...) -> SchemaType: .
 
 
 @typing.overload
-def get_class(
-    classname: str, all: typing.Literal[True] = ...
-) -> list[SchemaType] | SchemaType: ...
+def get_class(classname: str, all: typing.Literal[True] = ...) -> list[SchemaType]: ...
 
 
 def get_class(classname: str, all: bool = False) -> list[SchemaType] | SchemaType:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -654,9 +654,14 @@ class Pluck(Nested):
         self,
         nested: Schema | SchemaMeta | str | typing.Callable[[], Schema],
         field_name: str,
+        *,
+        many: bool = False,
+        unknown: str | None = None,
         **kwargs: Unpack[_BaseFieldKwargs],
     ):
-        super().__init__(nested, only=(field_name,), **kwargs)
+        super().__init__(
+            nested, only=(field_name,), many=many, unknown=unknown, **kwargs
+        )
         self.field_name = field_name
 
     @property
@@ -771,7 +776,9 @@ class Tuple(Field[tuple]):
     default_error_messages = {"invalid": "Not a valid tuple."}
 
     def __init__(
-        self, tuple_fields: typing.Iterable[Field], **kwargs: Unpack[_BaseFieldKwargs]
+        self,
+        tuple_fields: typing.Iterable[Field] | typing.Iterable[type[Field]],
+        **kwargs: Unpack[_BaseFieldKwargs],
     ):
         super().__init__(**kwargs)
         if not utils.is_collection(tuple_fields):
@@ -1155,8 +1162,8 @@ class Boolean(Field[bool]):
     def __init__(
         self,
         *,
-        truthy: set | None = None,
-        falsy: set | None = None,
+        truthy: typing.Iterable | None = None,
+        falsy: typing.Iterable | None = None,
         **kwargs: Unpack[_BaseFieldKwargs],
     ):
         super().__init__(**kwargs)
@@ -1522,7 +1529,7 @@ class TimeDelta(Field[dt.timedelta]):
             raise self.make_error("invalid") from error
 
 
-_MappingType = typing.TypeVar("_MappingType", bound=collections.abc.Mapping)
+_MappingType = typing.TypeVar("_MappingType", bound=_Mapping)
 
 
 class Mapping(Field[_MappingType]):

--- a/tests/base.py
+++ b/tests/base.py
@@ -177,7 +177,7 @@ class DummyModel:
 class Uppercased(fields.String):
     """Custom field formatting example."""
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         if value:
             return value.upper()
 
@@ -186,7 +186,7 @@ def get_lowername(obj):
     if obj is None:
         return missing
     if isinstance(obj, dict):
-        return obj.get("name").lower()
+        return obj.get("name", "").lower()
     else:
         return obj.name.lower()
 
@@ -228,7 +228,7 @@ class UserSchema(Schema):
         if obj is None:
             return missing
         if isinstance(obj, dict):
-            age = obj.get("age")
+            age = obj.get("age", 0)
         else:
             age = obj.age
         try:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -312,15 +312,17 @@ class TestValidatesDecorator:
 
         with pytest.raises(ValidationError) as excinfo:
             schema.load([{"foo": 42}, {"foo": 43}], many=True)
-        assert excinfo.value.messages
+        error_messages = excinfo.value.messages
         result = excinfo.value.valid_data
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0] == {"foo": 42}
         assert result[1] == {}
-        assert 1 in errors
-        assert "foo" in errors[1]
-        assert errors[1]["foo"] == ["The answer to life the universe and everything."]
+        assert 1 in error_messages
+        assert "foo" in error_messages[1]
+        assert error_messages[1]["foo"] == [
+            "The answer to life the universe and everything."
+        ]
 
     def test_field_not_present(self):
         class BadSchema(ValidatesSchema):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -119,10 +119,10 @@ def test_decorated_processor_returning_none(unknown):
     schema = PostSchema(unknown=unknown)
     assert schema.dump({"value": 3}) is None
     assert schema.load({"value": 3}) is None
-    schema = PreSchema(unknown=unknown)
-    assert schema.dump({"value": 3}) == {}
+    pre_schema = PreSchema(unknown=unknown)
+    assert pre_schema.dump({"value": 3}) == {}
     with pytest.raises(ValidationError) as excinfo:
-        schema.load({"value": 3})
+        pre_schema.load({"value": 3})
     assert excinfo.value.messages == {"_schema": ["Invalid input type."]}
 
 
@@ -306,15 +306,15 @@ class TestValidatesDecorator:
 
         with pytest.raises(ValidationError) as excinfo:
             schema.load({"foo": 41})
-        errors = excinfo.value.messages
+        assert excinfo.value.messages
         result = excinfo.value.valid_data
-        assert errors
         assert result == {}
 
         with pytest.raises(ValidationError) as excinfo:
             schema.load([{"foo": 42}, {"foo": 43}], many=True)
-        errors = excinfo.value.messages
+        assert excinfo.value.messages
         result = excinfo.value.valid_data
+        assert isinstance(result, list)
         assert len(result) == 2
         assert result[0] == {"foo": 42}
         assert result[1] == {}
@@ -608,7 +608,7 @@ class TestValidatesSchemaDecorator:
 
             @validates_schema(skip_on_field_errors=True)
             def consistency_validation(self, data, **kwargs):
-                errors = {}
+                errors: dict[str, str | dict] = {}
                 if data["bar"]["baz"] != data["foo"]:
                     errors["bar"] = {"baz": "Non-matching value"}
                 if data["bam"] > data["foo"]:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -140,7 +140,7 @@ class TestIncludeOption:
         assert list(result.keys()) == expected_fields
 
     def test_added_fields_are_inherited(self):
-        class AddFieldsChild(self.AddFieldsSchema):
+        class AddFieldsChild(self.AddFieldsSchema):  # type: ignore[name-defined]
             email = fields.Str()
 
         s = AddFieldsChild()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -57,7 +57,9 @@ def test_serializer_class_registry_register_same_classname_different_module():
     type("MyTestRegSchema", (Schema,), {"__module__": "modA"})
 
     assert "MyTestRegSchema" in class_registry._registry
-    assert len(class_registry._registry.get("MyTestRegSchema")) == 1
+    result = class_registry._registry.get("MyTestRegSchema")
+    assert isinstance(result, list)
+    assert len(result) == 1
     assert "modA.MyTestRegSchema" in class_registry._registry
     #  storing for classname and fullpath
     assert len(class_registry._registry) == reglen + 2
@@ -66,7 +68,9 @@ def test_serializer_class_registry_register_same_classname_different_module():
 
     assert "MyTestRegSchema" in class_registry._registry
     #  aggregating classes with same name from different modules
-    assert len(class_registry._registry.get("MyTestRegSchema")) == 2
+    result = class_registry._registry.get("MyTestRegSchema")
+    assert isinstance(result, list)
+    assert len(result) == 2
     assert "modB.MyTestRegSchema" in class_registry._registry
     #  storing for same classname (+0) and different module (+1)
     assert len(class_registry._registry) == reglen + 2 + 1
@@ -75,7 +79,9 @@ def test_serializer_class_registry_register_same_classname_different_module():
 
     assert "MyTestRegSchema" in class_registry._registry
     #  only the class with matching module has been replaced
-    assert len(class_registry._registry.get("MyTestRegSchema")) == 2
+    result = class_registry._registry.get("MyTestRegSchema")
+    assert isinstance(result, list)
+    assert len(result) == 2
     assert "modB.MyTestRegSchema" in class_registry._registry
     #  only the class with matching module has been replaced (+0)
     assert len(class_registry._registry) == reglen + 2 + 1
@@ -87,9 +93,13 @@ def test_serializer_class_registry_override_if_same_classname_same_module():
     type("MyTestReg2Schema", (Schema,), {"__module__": "SameModulePath"})
 
     assert "MyTestReg2Schema" in class_registry._registry
-    assert len(class_registry._registry.get("MyTestReg2Schema")) == 1
+    result = class_registry._registry.get("MyTestReg2Schema")
+    assert isinstance(result, list)
+    assert len(result) == 1
     assert "SameModulePath.MyTestReg2Schema" in class_registry._registry
-    assert len(class_registry._registry.get("SameModulePath.MyTestReg2Schema")) == 1
+    result = class_registry._registry.get("SameModulePath.MyTestReg2Schema")
+    assert isinstance(result, list)
+    assert len(result) == 1
     #  storing for classname and fullpath
     assert len(class_registry._registry) == reglen + 2
 
@@ -97,10 +107,15 @@ def test_serializer_class_registry_override_if_same_classname_same_module():
 
     assert "MyTestReg2Schema" in class_registry._registry
     #  overriding same class name and same module
-    assert len(class_registry._registry.get("MyTestReg2Schema")) == 1
+    result = class_registry._registry.get("MyTestReg2Schema")
+    assert isinstance(result, list)
+    assert len(result) == 1
+
     assert "SameModulePath.MyTestReg2Schema" in class_registry._registry
     #  overriding same fullpath
-    assert len(class_registry._registry.get("SameModulePath.MyTestReg2Schema")) == 1
+    result = class_registry._registry.get("SameModulePath.MyTestReg2Schema")
+    assert isinstance(result, list)
+    assert len(result) == 1
     #  overriding for same classname (+0) and different module (+0)
     assert len(class_registry._registry) == reglen + 2
 
@@ -212,5 +227,5 @@ def test_can_use_full_module_path_to_class():
     class Schema2(Schema):
         foo = fields.Nested("tests.test_registry.FooSerializer")
 
-    sch = Schema2()
-    assert sch.dump({"foo": {"_id": 42}})
+    sch2 = Schema2()
+    assert sch2.dump({"foo": {"_id": 42}})

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -87,7 +87,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_uncallable_object(self):
         with pytest.raises(TypeError):
-            fields.Function("uncallable")
+            fields.Function("uncallable")  # type: ignore[arg-type]
 
     def test_integer_field(self, user):
         field = fields.Integer()
@@ -232,8 +232,8 @@ class TestFieldSerialization:
         field = fields.Enum(HairColorEnum, by_value=True)
         assert field.serialize("hair_color", user) == "black hair"
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum, by_value=True)
-        assert field.serialize("sex", user) == 1
+        field2 = fields.Enum(GenderEnum, by_value=True)
+        assert field2.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
 
     def test_enum_field_by_value_field_serialization(self, user):
@@ -241,11 +241,11 @@ class TestFieldSerialization:
         field = fields.Enum(HairColorEnum, by_value=fields.String)
         assert field.serialize("hair_color", user) == "black hair"
         user.sex = GenderEnum.male
-        field = fields.Enum(GenderEnum, by_value=fields.Integer)
-        assert field.serialize("sex", user) == 1
+        field2 = fields.Enum(GenderEnum, by_value=fields.Integer)
+        assert field2.serialize("sex", user) == 1
         user.some_date = DateEnum.date_1
-        field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
-        assert field.serialize("some_date", user) == "29/02/2004"
+        field3 = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
+        assert field3.serialize("some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):
         user.m1 = 12
@@ -483,7 +483,7 @@ class TestFieldSerialization:
         m = fields.Method()
         m.parent = Schema()
 
-        assert m.serialize("", "", "") is missing_
+        assert m.serialize("", "", None) is missing_
 
     def test_serialize_with_data_key_param(self):
         class DumpToSchema(Schema):
@@ -851,13 +851,13 @@ class TestFieldSerialization:
             id = fields.Int()
 
         with pytest.raises(ValueError):
-            fields.List("string")
+            fields.List("string")  # type: ignore[arg-type]
         expected_msg = (
             "The list elements must be a subclass or instance of "
             "marshmallow.fields.Field"
         )
         with pytest.raises(ValueError, match=expected_msg):
-            fields.List(ASchema)
+            fields.List(ASchema)  # type: ignore[arg-type]
 
     def test_datetime_integer_tuple_field(self):
         obj = DateTimeIntegerTuple((dt.datetime.now(dt.timezone.utc), 42))
@@ -876,15 +876,15 @@ class TestFieldSerialization:
             id = fields.Int()
 
         with pytest.raises(ValueError):
-            fields.Tuple(["string"])
+            fields.Tuple(["string"])  # type: ignore[arg-type]
         with pytest.raises(ValueError):
-            fields.Tuple(fields.String)
+            fields.Tuple(fields.String)  # type: ignore[arg-type]
         expected_msg = (
             'Elements of "tuple_fields" must be subclasses or '
             "instances of marshmallow.fields.Field."
         )
         with pytest.raises(ValueError, match=expected_msg):
-            fields.Tuple([ASchema])
+            fields.Tuple([ASchema])  # type: ignore[arg-type]
 
     def test_serialize_does_not_apply_validators(self, user):
         field = fields.Raw(validate=lambda x: False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_get_value():
 
 
 def test_set_value():
-    d = {}
+    d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)
     assert d == {"foo": 42}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,mypy-test,py{39,310,311,312,313},docs
+envlist = lint,mypy,py{39,310,311,312,313},docs
 
 [testenv]
 extras = tests
@@ -10,9 +10,11 @@ deps = pre-commit~=3.5
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:mypy-test]
-deps = mypy
-commands = mypy --show-error-codes --warn-unused-ignores tests/mypy_test_cases/
+[testenv:mypy]
+deps = 
+  mypy
+  types-simplejson
+commands = mypy --show-error-codes .
 
 [testenv:docs]
 extras = docs


### PR DESCRIPTION
to discover invalid usages and typing issues.

- run mypy within tox instead of pre-commit so package gets installed (type-checking was incorrect when run through pre-commit)
- fix a few type issues in the code (will backport these to 3.x-line)
- address all mypy errors in tests