### PR TITLE
Remove utils.isoformat, to_iso_time, to_iso_date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,9 @@ As a consequence of this change:
   - YYYY-MM-DD is now accepted as a datetime and deserialized as naive 00:00 AM.
   - `from_iso_date`, `from_iso_time` and `from_iso_datetime` are removed from `marshmallow.utils`.
 
-- *Backwards-incompatible*: `marshmallow.fields.Boolean` no longer serializes non-boolean values.
+- Remove `isoformat`, `to_iso_time` and `to_iso_datetime` from `marshmallow.utils` (:pr:`2766`).
+
+- *Backwards-incompatible*: `marshmallow.fields.Boolean` no longer serializes non-boolean values (:pr:`2725`).
 - *Backwards-incompatible*: Custom validators must raise a `ValidationError <marshmallow.exceptions.ValidationError>` for invalid values.
   Returning `False` is no longer supported (:issue:`1775`).
 - *Backwards-incompatible*: Rename ``schema`` parameter to ``parent`` in `marshmallow.fields.Field._bind_to_schema` (:issue:`1360`).

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1274,8 +1274,8 @@ class DateTime(_TemporalField[dt.datetime]):
     """
 
     SERIALIZATION_FUNCS: dict[str, typing.Callable[[dt.datetime], str | float]] = {
-        "iso": utils.isoformat,
-        "iso8601": utils.isoformat,
+        "iso": dt.datetime.isoformat,
+        "iso8601": dt.datetime.isoformat,
         "rfc": utils.rfcformat,
         "rfc822": utils.rfcformat,
         "timestamp": utils.timestamp,
@@ -1387,7 +1387,10 @@ class Time(_TemporalField[dt.time]):
     :param kwargs: The same keyword arguments that :class:`Field` receives.
     """
 
-    SERIALIZATION_FUNCS = {"iso": utils.to_iso_time, "iso8601": utils.to_iso_time}
+    SERIALIZATION_FUNCS = {
+        "iso": dt.time.isoformat,
+        "iso8601": dt.time.isoformat,
+    }
 
     DESERIALIZATION_FUNCS = {
         "iso": dt.time.fromisoformat,
@@ -1419,7 +1422,10 @@ class Date(_TemporalField[dt.date]):
         "format": '"{input}" cannot be formatted as a date.',
     }
 
-    SERIALIZATION_FUNCS = {"iso": utils.to_iso_date, "iso8601": utils.to_iso_date}
+    SERIALIZATION_FUNCS = {
+        "iso": dt.date.isoformat,
+        "iso8601": dt.date.isoformat,
+    }
 
     DESERIALIZATION_FUNCS = {
         "iso": dt.date.fromisoformat,

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -132,22 +132,6 @@ def timestamp_ms(value: dt.datetime) -> float:
     return timestamp(value) * 1000
 
 
-def isoformat(datetime: dt.datetime) -> str:
-    """Return the ISO8601-formatted representation of a datetime object.
-
-    :param datetime: The datetime.
-    """
-    return datetime.isoformat()
-
-
-def to_iso_time(time: dt.time) -> str:
-    return dt.time.isoformat(time)
-
-
-def to_iso_date(date: dt.date) -> str:
-    return dt.date.isoformat(date)
-
-
 def ensure_text_type(val: str | bytes) -> str:
     if isinstance(val, bytes):
         val = val.decode("utf-8")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,7 +13,6 @@ from marshmallow import (
     Schema,
     class_registry,
     fields,
-    utils,
     validate,
     validates,
     validates_schema,
@@ -433,7 +432,7 @@ def test_dumps_returns_json(user):
 
 
 def test_naive_datetime_field(user, serialized_user):
-    expected = utils.isoformat(user.created)
+    expected = user.created.isoformat()
     assert serialized_user["created"] == expected
 
 
@@ -443,12 +442,12 @@ def test_datetime_formatted_field(user, serialized_user):
 
 
 def test_datetime_iso_field(user, serialized_user):
-    assert serialized_user["created_iso"] == utils.isoformat(user.created)
+    assert serialized_user["created_iso"] == user.created.isoformat()
 
 
 def test_tz_datetime_field(user, serialized_user):
     # Datetime is corrected back to GMT
-    expected = utils.isoformat(user.updated)
+    expected = user.updated.isoformat()
     assert serialized_user["updated"] == expected
 
 
@@ -1596,7 +1595,7 @@ def test_default_dateformat(user):
         updated = fields.DateTime(format="%m-%d")
 
     serialized = DateFormatSchema().dump(user)
-    assert serialized["created"] == utils.isoformat(user.created)
+    assert serialized["created"] == user.created.isoformat()
     assert serialized["updated"] == user.updated.strftime("%m-%d")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,28 +135,6 @@ def test_rfc_format(value, expected):
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        (dt.datetime(2013, 11, 10, 1, 23, 45), "2013-11-10T01:23:45"),
-        (
-            dt.datetime(2013, 11, 10, 1, 23, 45, 123456, tzinfo=dt.timezone.utc),
-            "2013-11-10T01:23:45.123456+00:00",
-        ),
-        (
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=dt.timezone.utc),
-            "2013-11-10T01:23:45+00:00",
-        ),
-        (
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=central),
-            "2013-11-10T01:23:45-06:00",
-        ),
-    ],
-)
-def test_isoformat(value, expected):
-    assert utils.isoformat(value) == expected
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
         ("Sun, 10 Nov 2013 01:23:45 -0000", dt.datetime(2013, 11, 10, 1, 23, 45)),
         (
             "Sun, 10 Nov 2013 01:23:45 +0000",


### PR DESCRIPTION
Set the standard lib method directly in fields.py. We did the same for `from_isoformat`.