### PR TITLE
Remove utils.from_rfc, rfcformat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ As a consequence of this change:
   - `from_iso_date`, `from_iso_time` and `from_iso_datetime` are removed from `marshmallow.utils`.
 
 - Remove `isoformat`, `to_iso_time` and `to_iso_datetime` from `marshmallow.utils` (:pr:`2766`).
+- Remove `from_rfc`, and `rfcformat` from `marshmallow.utils` (:pr:`2767`).
 
 - *Backwards-incompatible*: `marshmallow.fields.Boolean` no longer serializes non-boolean values (:pr:`2725`).
 - *Backwards-incompatible*: Custom validators must raise a `ValidationError <marshmallow.exceptions.ValidationError>` for invalid values.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -334,26 +334,48 @@ Custom fields that define a `_bind_to_schema <marshmallow.Fields._bind_to_schema
     class MyField(fields.Field):
         def _bind_to_schema(self, parent, field_name): ...
 
-Use standard library functions for parsing ISO 8601 dates, times, and datetimes
-*******************************************************************************
+Use standard library functions to handle RFC 822 and ISO 8601 dates, times, and datetimes
+*****************************************************************************************
 
-The ``from_iso_*`` utilities are removed from marshmallow in favor of using the standard library implementations.
+ISO 8601 and RFC 822 utilities are removed from ``marshmallow.utils`` in favor
+of using the standard library implementations.
 
 .. code-block:: python
 
     # 3.x
-    from marshmallow.utils import from_iso_date, from_iso_time, from_iso_datetime
+    import datetime as dt
+    from marshmallow.utils import (
+        from_iso_date,
+        from_iso_time,
+        from_iso_datetime,
+        to_iso_date,
+        to_iso_time,
+        isoformat,
+        from_rfc,
+        rfc_format,
+    )
 
     from_iso_date("2013-11-10")
     from_iso_time("01:23:45")
     from_iso_datetime("2013-11-10T01:23:45")
+    to_iso_date(dt.date(2013, 11, 10))
+    to_iso_time(dt.time(1, 23, 45))
+    isoformat(dt.datetime(2013, 11, 10, 1, 23, 45))
+    from_rfc("Sun, 10 Nov 2013 01:23:45 -0000")
+    rfc_format(dt.datetime(2013, 11, 10, 1, 23, 45))
 
     # 4.x
     import datetime as dt
+    import email.utils
 
     dt.date.fromisoformat("2013-11-10")
     dt.time.fromisoformat("01:23:45")
     dt.datetime.fromisoformat("2013-11-10T01:23:45")
+    dt.date(2013, 11, 10).isoformat()
+    dt.time(1, 23, 45).isoformat()
+    dt.datetime(2013, 11, 10, 1, 23, 45).isoformat()
+    email.utils.parsedate_to_datetime("Sun, 10 Nov 2013 01:23:45 -0000")
+    email.utils.format_datetime(dt.datetime(2013, 11, 10, 1, 23, 45))
 
 Upgrading to 3.13
 +++++++++++++++++

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -5,6 +5,7 @@ import collections
 import copy
 import datetime as dt
 import decimal
+import email.utils
 import ipaddress
 import math
 import numbers
@@ -1276,8 +1277,8 @@ class DateTime(_TemporalField[dt.datetime]):
     SERIALIZATION_FUNCS: dict[str, typing.Callable[[dt.datetime], str | float]] = {
         "iso": dt.datetime.isoformat,
         "iso8601": dt.datetime.isoformat,
-        "rfc": utils.rfcformat,
-        "rfc822": utils.rfcformat,
+        "rfc": email.utils.format_datetime,
+        "rfc822": email.utils.format_datetime,
         "timestamp": utils.timestamp,
         "timestamp_ms": utils.timestamp_ms,
     }
@@ -1285,8 +1286,8 @@ class DateTime(_TemporalField[dt.datetime]):
     DESERIALIZATION_FUNCS: dict[str, typing.Callable[[str], dt.datetime]] = {
         "iso": dt.datetime.fromisoformat,
         "iso8601": dt.datetime.fromisoformat,
-        "rfc": utils.from_rfc,
-        "rfc822": utils.from_rfc,
+        "rfc": email.utils.parsedate_to_datetime,
+        "rfc822": email.utils.parsedate_to_datetime,
         "timestamp": utils.from_timestamp,
         "timestamp_ms": utils.from_timestamp_ms,
     }

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -6,7 +6,6 @@ import datetime as dt
 import inspect
 import typing
 from collections.abc import Mapping
-from email.utils import format_datetime, parsedate_to_datetime
 
 EXCLUDE = "exclude"
 INCLUDE = "include"
@@ -62,22 +61,6 @@ def is_aware(datetime: dt.datetime) -> bool:
     return (
         datetime.tzinfo is not None and datetime.tzinfo.utcoffset(datetime) is not None
     )
-
-
-def from_rfc(datestring: str) -> dt.datetime:
-    """Parse a RFC822-formatted datetime string and return a datetime object.
-
-    https://stackoverflow.com/questions/885015/how-to-parse-a-rfc-2822-date-time-into-a-python-datetime  # noqa: B950
-    """
-    return parsedate_to_datetime(datestring)
-
-
-def rfcformat(datetime: dt.datetime) -> str:
-    """Return the RFC822-formatted representation of a datetime object.
-
-    :param datetime: The datetime.
-    """
-    return format_datetime(datetime)
 
 
 def from_timestamp(value: typing.Any) -> dt.datetime:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ from copy import copy, deepcopy
 import pytest
 
 from marshmallow import Schema, fields, utils
-from tests.base import central
 
 
 def test_missing_singleton_copy():
@@ -98,44 +97,6 @@ def test_is_collection():
     assert utils.is_collection([1, "foo", {}]) is True
     assert utils.is_collection(("foo", 2.3)) is True
     assert utils.is_collection({"foo": "bar"}) is False
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (dt.datetime(2013, 11, 10, 1, 23, 45), "Sun, 10 Nov 2013 01:23:45 -0000"),
-        (
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=dt.timezone.utc),
-            "Sun, 10 Nov 2013 01:23:45 +0000",
-        ),
-        (
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=central),
-            "Sun, 10 Nov 2013 01:23:45 -0600",
-        ),
-    ],
-)
-def test_rfc_format(value, expected):
-    assert utils.rfcformat(value) == expected
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("Sun, 10 Nov 2013 01:23:45 -0000", dt.datetime(2013, 11, 10, 1, 23, 45)),
-        (
-            "Sun, 10 Nov 2013 01:23:45 +0000",
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=dt.timezone.utc),
-        ),
-        (
-            "Sun, 10 Nov 2013 01:23:45 -0600",
-            dt.datetime(2013, 11, 10, 1, 23, 45, tzinfo=central),
-        ),
-    ],
-)
-def test_from_rfc(value, expected):
-    result = utils.from_rfc(value)
-    assert type(result) is dt.datetime
-    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Same as #2766.

Removed tests are covered in serialization/deserialization tests.