### PR TITLE
Remove unused utils.is_keyed_tuple

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -57,13 +57,6 @@ def is_instance_or_subclass(val, class_) -> bool:
         return isinstance(val, class_)
 
 
-def is_keyed_tuple(obj) -> bool:
-    """Return True if ``obj`` has keyed tuple behavior, such as
-    namedtuples or SQLAlchemy's KeyedTuples.
-    """
-    return isinstance(obj, tuple) and hasattr(obj, "_fields")
-
-
 # https://stackoverflow.com/a/27596917
 def is_aware(datetime: dt.datetime) -> bool:
     return (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,20 +94,6 @@ def test_set_value():
         utils.set_value(d, "foo.bar", 42)
 
 
-def test_is_keyed_tuple():
-    Point = namedtuple("Point", ["x", "y"])
-    p = Point(24, 42)
-    assert utils.is_keyed_tuple(p) is True
-    t = (24, 42)
-    assert utils.is_keyed_tuple(t) is False
-    d = {"x": 42, "y": 24}
-    assert utils.is_keyed_tuple(d) is False
-    s = "xy"
-    assert utils.is_keyed_tuple(s) is False
-    lst = [24, 42]
-    assert utils.is_keyed_tuple(lst) is False
-
-
 def test_is_collection():
     assert utils.is_collection([1, "foo", {}]) is True
     assert utils.is_collection(("foo", 2.3)) is True


### PR DESCRIPTION
This doesn't seem to be used anymore. Should we keep it?