### PR TITLE
Make first argument to loads positional-only

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ As a consequence of this change:
   `marshmallow.fields.TimeDelta` (:pr:`2654`).
 - Rename ``json_data`` parameter of `marshmallow.Schema.loads` to ``s``
   for compatibility with most render module implementations (`json`, ``simplejson``, etc.) (:pr:`2764`).
+  Also make it a positional-only argument.
 
 Thanks :user:`ddelange` for the PR.
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -727,6 +727,7 @@ class Schema(metaclass=SchemaMeta):
     def loads(
         self,
         s: str | bytes | bytearray,
+        /,
         *,
         many: bool | None = None,
         partial: bool | types.StrSequenceOrSet | None = None,


### PR DESCRIPTION
users shouldn't pass `s` as a keyword argument. and this gives us the freedom to rename the argument without it being a breaking change