### PR TITLE
Validate unknown with type checking rather than at runtime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,8 @@ Thanks :user:`ddelange` for the PR.
 - Methods decorated with `marshmallow.pre_load`, `marshmallow.post_load`, `marshmallow.validates_schema`,
   receive ``unknown`` as a keyword argument (:pr:`1632`).
   Thanks :user:`jforand` for the PR.
+- Passing invalid values for ``unknown`` will cause an error in type checkers.
+  Runtime checking is removed (:pr:`2771`).
 
 Deprecations/Removals:
 
@@ -130,8 +132,8 @@ Documentation:
 
 Deprecations:
 
-- The ``ordered`` `class Meta <marshmallow.Schema.Meta>` option is deprecated (:issue:`2146`, :pr:`2762`). 
-  Field order is already preserved by default. Set `marshmallow.Schema.dict_class` to `collections.OrderedDict` 
+- The ``ordered`` `class Meta <marshmallow.Schema.Meta>` option is deprecated (:issue:`2146`, :pr:`2762`).
+  Field order is already preserved by default. Set `marshmallow.Schema.dict_class` to `collections.OrderedDict`
   to maintain the previous behavior.
 
 3.25.1 (2025-01-11)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -506,7 +506,7 @@ class Nested(Field):
         only: types.StrSequenceOrSet | None = None,
         exclude: types.StrSequenceOrSet = (),
         many: bool = False,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
         **kwargs: Unpack[_BaseFieldKwargs],
     ):
         # Raise error if only or exclude is passed as string, not list of strings
@@ -656,7 +656,7 @@ class Pluck(Nested):
         field_name: str,
         *,
         many: bool = False,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
         **kwargs: Unpack[_BaseFieldKwargs],
     ):
         super().__init__(

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -201,7 +201,7 @@ class SchemaOpts:
         self.include = getattr(meta, "include", {})
         self.load_only = getattr(meta, "load_only", ())
         self.dump_only = getattr(meta, "dump_only", ())
-        self.unknown = typing.cast(types.UnknownOption, getattr(meta, "unknown", RAISE))
+        self.unknown = getattr(meta, "unknown", RAISE)
         self.register = getattr(meta, "register", True)
         self.many = getattr(meta, "many", False)
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -36,7 +36,6 @@ from marshmallow.utils import (
     is_instance_or_subclass,
     missing,
     set_value,
-    validate_unknown_parameter_value,
 )
 
 
@@ -202,7 +201,7 @@ class SchemaOpts:
         self.include = getattr(meta, "include", {})
         self.load_only = getattr(meta, "load_only", ())
         self.dump_only = getattr(meta, "dump_only", ())
-        self.unknown = validate_unknown_parameter_value(getattr(meta, "unknown", RAISE))
+        self.unknown = typing.cast(types.UnknownOption, getattr(meta, "unknown", RAISE))
         self.register = getattr(meta, "register", True)
         self.many = getattr(meta, "many", False)
 
@@ -372,7 +371,7 @@ class Schema(metaclass=SchemaMeta):
         """Fields to exclude from serialized results"""
         dump_only: typing.ClassVar[tuple[Field] | list[Field]]
         """Fields to exclude from serialized results"""
-        unknown: typing.ClassVar[str]
+        unknown: typing.ClassVar[types.UnknownOption]
         """Whether to exclude, include, or raise an error for unknown fields in the data.
         Use `EXCLUDE`, `INCLUDE` or `RAISE`.
         """
@@ -392,7 +391,7 @@ class Schema(metaclass=SchemaMeta):
         load_only: types.StrSequenceOrSet = (),
         dump_only: types.StrSequenceOrSet = (),
         partial: bool | types.StrSequenceOrSet | None = None,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
     ):
         # Raise error if only or exclude is passed as string, not list of strings
         if only is not None and not is_collection(only):
@@ -409,10 +408,8 @@ class Schema(metaclass=SchemaMeta):
         self.load_only = set(load_only) or set(self.opts.load_only)
         self.dump_only = set(dump_only) or set(self.opts.dump_only)
         self.partial = partial
-        self.unknown = (
-            self.opts.unknown
-            if unknown is None
-            else validate_unknown_parameter_value(unknown)
+        self.unknown: types.UnknownOption | None = (
+            self.opts.unknown if unknown is None else unknown
         )
         self._normalize_nested_options()
         #: Dictionary mapping field_names -> :class:`Field` objects
@@ -586,7 +583,7 @@ class Schema(metaclass=SchemaMeta):
         error_store: ErrorStore,
         many: bool = False,
         partial=None,
-        unknown=RAISE,
+        unknown: types.UnknownOption | None = RAISE,
         index=None,
     ) -> typing.Any | list[typing.Any]:
         """Deserialize ``data``.
@@ -699,7 +696,7 @@ class Schema(metaclass=SchemaMeta):
         *,
         many: bool | None = None,
         partial: bool | types.StrSequenceOrSet | None = None,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
     ):
         """Deserialize a data structure to an object defined by this Schema's fields.
 
@@ -731,7 +728,7 @@ class Schema(metaclass=SchemaMeta):
         *,
         many: bool | None = None,
         partial: bool | types.StrSequenceOrSet | None = None,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
         **kwargs,
     ):
         """Same as :meth:`load`, except it uses `marshmallow.Schema.Meta.render_module` to deserialize
@@ -821,7 +818,7 @@ class Schema(metaclass=SchemaMeta):
         *,
         many: bool | None = None,
         partial: bool | types.StrSequenceOrSet | None = None,
-        unknown: str | None = None,
+        unknown: types.UnknownOption | None = None,
         postprocess: bool = True,
     ):
         """Deserialize `data`, returning the deserialized result.
@@ -843,11 +840,7 @@ class Schema(metaclass=SchemaMeta):
         error_store = ErrorStore()
         errors: dict[str, list[str]] = {}
         many = self.many if many is None else bool(many)
-        unknown = (
-            self.unknown
-            if unknown is None
-            else validate_unknown_parameter_value(unknown)
-        )
+        unknown = self.unknown if unknown is None else unknown
         if partial is None:
             partial = self.partial
         # Run preprocessors
@@ -1092,7 +1085,7 @@ class Schema(metaclass=SchemaMeta):
         many: bool,
         original_data,
         partial: bool | types.StrSequenceOrSet | None,
-        unknown: str,
+        unknown: types.UnknownOption | None,
     ):
         # This has to invert the order of the dump processors, so run the pass_collection
         # processors first.
@@ -1172,7 +1165,7 @@ class Schema(metaclass=SchemaMeta):
         many: bool,
         partial: bool | types.StrSequenceOrSet | None,
         field_errors: bool = False,
-        unknown: str,
+        unknown: types.UnknownOption | None,
     ):
         for attr_name, hook_many, validator_kwargs in self._hooks[VALIDATES_SCHEMA]:
             if hook_many != pass_collection:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -408,7 +408,7 @@ class Schema(metaclass=SchemaMeta):
         self.load_only = set(load_only) or set(self.opts.load_only)
         self.dump_only = set(dump_only) or set(self.opts.dump_only)
         self.partial = partial
-        self.unknown: types.UnknownOption | None = (
+        self.unknown: types.UnknownOption = (
             self.opts.unknown if unknown is None else unknown
         )
         self._normalize_nested_options()
@@ -583,7 +583,7 @@ class Schema(metaclass=SchemaMeta):
         error_store: ErrorStore,
         many: bool = False,
         partial=None,
-        unknown: types.UnknownOption | None = RAISE,
+        unknown: types.UnknownOption = RAISE,
         index=None,
     ) -> typing.Any | list[typing.Any]:
         """Deserialize ``data``.

--- a/src/marshmallow/types.py
+++ b/src/marshmallow/types.py
@@ -15,6 +15,8 @@ StrSequenceOrSet = typing.Union[typing.Sequence[str], typing.AbstractSet[str]]
 #: Type for validator functions
 Validator = typing.Callable[[typing.Any], typing.Any]
 
+UnknownOption = typing.Literal["exclude", "include", "raise"]
+
 
 class RenderModule(typing.Protocol):
     def dumps(

--- a/src/marshmallow/types.py
+++ b/src/marshmallow/types.py
@@ -7,15 +7,23 @@
 
 from __future__ import annotations
 
+try:
+    from typing import TypeAlias
+except ImportError:  # Remove when dropping Python 3.9
+    from typing_extensions import TypeAlias
+
 import typing
 
 #: A type that can be either a sequence of strings or a set of strings
-StrSequenceOrSet = typing.Union[typing.Sequence[str], typing.AbstractSet[str]]
+StrSequenceOrSet: TypeAlias = typing.Union[
+    typing.Sequence[str], typing.AbstractSet[str]
+]
 
 #: Type for validator functions
-Validator = typing.Callable[[typing.Any], typing.Any]
+Validator: TypeAlias = typing.Callable[[typing.Any], typing.Any]
 
-UnknownOption = typing.Literal["exclude", "include", "raise"]
+#: A valid option for the ``unknown`` schema option and argument
+UnknownOption: TypeAlias = typing.Literal["exclude", "include", "raise"]
 
 
 class RenderModule(typing.Protocol):

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -8,9 +8,9 @@ import typing
 from collections.abc import Mapping
 from email.utils import format_datetime, parsedate_to_datetime
 
-EXCLUDE = "exclude"
-INCLUDE = "include"
-RAISE = "raise"
+EXCLUDE: typing.Final = "exclude"
+INCLUDE: typing.Final = "include"
+RAISE: typing.Final = "raise"
 _UNKNOWN_VALUES = {EXCLUDE, INCLUDE, RAISE}
 
 
@@ -224,11 +224,3 @@ def timedelta_to_microseconds(value: dt.timedelta) -> int:
     https://github.com/python/cpython/blob/v3.13.1/Lib/_pydatetime.py#L805-L807
     """
     return (value.days * (24 * 3600) + value.seconds) * 1000000 + value.microseconds
-
-
-def validate_unknown_parameter_value(obj: typing.Any) -> str:
-    if obj not in _UNKNOWN_VALUES:
-        raise ValueError(
-            f"Object {obj!r} is not a valid value for the 'unknown' parameter"
-        )
-    return obj

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -11,7 +11,6 @@ from email.utils import format_datetime, parsedate_to_datetime
 EXCLUDE: typing.Final = "exclude"
 INCLUDE: typing.Final = "include"
 RAISE: typing.Final = "raise"
-_UNKNOWN_VALUES = {EXCLUDE, INCLUDE, RAISE}
 
 
 class _Missing:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2493,30 +2493,6 @@ def test_class_registry_returns_schema_type():
     assert SchemaClass is DefinitelyUniqueSchema
 
 
-@pytest.mark.parametrize("usage_location", ["meta", "init", "load"])
-def test_unknown_parameter_value_is_validated(usage_location):
-    class MySchema(Schema):
-        foo = fields.String()
-
-    with pytest.raises(
-        ValueError,
-        match="Object 'badval' is not a valid value for the 'unknown' parameter",
-    ):
-        # Meta.unknown setting gets caught at class creation time, since that's when
-        # metaclass __new__ runs
-        if usage_location == "meta":
-
-            class SubSchema(MySchema):
-                class Meta:
-                    unknown = "badval"
-
-        # usages in init and load are caught at call time, as expected
-        elif usage_location == "init":
-            MySchema(unknown="badval")
-        else:
-            MySchema().load({"foo": "bar"}, unknown="badval")
-
-
 @pytest.mark.parametrize("dict_cls", (dict, OrderedDict))
 def test_set_dict_class(dict_cls):
     """Demonstrate how to specify dict_class as class attribute"""


### PR DESCRIPTION
Add type annotations such that invalid values for `unknown` raise an error in type checkers like mypy. Removes the run-time checking added in https://github.com/marshmallow-code/marshmallow/pull/1989

<img src="https://github.com/user-attachments/assets/8bcab02a-0e78-4e3a-995b-37c9ce5899e1" width="500" />

For each of the underlined cases above, mypy gives an error like this:

```
Argument "unknown" to "MySchema" has incompatible type "Literal['bad']"; expected "Literal['exclude', 'include', 'raise'] | None"
```