### PR TITLE
Revert "Add type annotation for set_class (#2777)"

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -326,7 +326,7 @@ class Schema(base.SchemaABC, metaclass=SchemaMeta):
 
     OPTIONS_CLASS: type = SchemaOpts
 
-    set_class: type[typing.AbstractSet] = OrderedSet
+    set_class = OrderedSet
 
     # These get set by SchemaMeta
     opts: typing.Any


### PR DESCRIPTION
mypy gives an error with AbstractSet


```
Too many arguments for "AbstractSet"
```

we can't do `type[set]` because OrderedSet doesn't inherit from `set`