### PR TITLE
Fix typing of validates_schema

### DIFF
--- a/src/marshmallow/decorators.py
+++ b/src/marshmallow/decorators.py
@@ -69,10 +69,7 @@ from __future__ import annotations
 
 import functools
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, cast
-
-if TYPE_CHECKING:
-    from marshmallow import types
+from typing import Any, Callable, cast
 
 PRE_DUMP = "pre_dump"
 POST_DUMP = "post_dump"
@@ -95,7 +92,7 @@ def validates(field_name: str) -> Callable[..., Any]:
 
 
 def validates_schema(
-    fn: types.SchemaValidator | None = None,
+    fn: Callable[..., Any] | None = None,
     pass_many: bool = False,  # noqa: FBT001, FBT002
     pass_original: bool = False,  # noqa: FBT001, FBT002
     skip_on_field_errors: bool = True,  # noqa: FBT001, FBT002


### PR DESCRIPTION
we should probably use [`ParamSpec`](https://docs.python.org/3/library/typing.html#typing.ParamSpec) eventually, but i'm hesitant to do that on v3 since we don't type-check tests on v3 and i'm worried about adding an incorrect type