### PR TITLE
Update pre-commit deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
   rev: 1.19.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==24.10.0]
+    additional_dependencies: [black==25.1.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ ci:
   autoupdate_schedule: monthly
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.12.5
   hooks:
     - id: ruff
     - id: ruff-format
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.33.0
+  rev: 0.33.2
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.5
   hooks:
-    - id: ruff
+    - id: ruff-check
     - id: ruff-format
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.33.2

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F841, SLF001
+# ruff: noqa: SLF001
 from __future__ import annotations
 
 import abc

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -530,7 +530,7 @@ class Nested(Field):
             else:
                 nested = typing.cast("Schema", self.nested)
             # defer the import of `marshmallow.schema` to avoid circular imports
-            from marshmallow.schema import Schema
+            from marshmallow.schema import Schema  # noqa: PLC0415
 
             if isinstance(nested, dict):
                 nested = Schema.from_dict(nested)
@@ -591,7 +591,9 @@ class Nested(Field):
             raise self.make_error("type", input=value, type=value.__class__.__name__)
 
     def _load(
-        self, value: typing.Any, partial: bool | types.StrSequenceOrSet | None = None
+        self,
+        value: typing.Any,
+        partial: bool | types.StrSequenceOrSet | None = None,  # noqa: FBT001
     ):
         try:
             valid_data = self.schema.load(value, unknown=self.unknown, partial=partial)
@@ -606,7 +608,7 @@ class Nested(Field):
         value: typing.Any,
         attr: str | None,
         data: typing.Mapping[str, typing.Any] | None,
-        partial: bool | types.StrSequenceOrSet | None = None,
+        partial: bool | types.StrSequenceOrSet | None = None,  # noqa: FBT001
         **kwargs,
     ):
         """Same as :meth:`Field._deserialize` with additional ``partial`` argument.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -558,7 +558,7 @@ class Nested(Field):
                         f"`Schema`, not {nested.__class__}."
                     )
                 else:
-                    schema_class = class_registry.get_class(nested, all=False)
+                    schema_class = class_registry.get_class(nested, all=False)  # type: ignore[unreachable]
                 self._schema = schema_class(
                     many=self.many,
                     only=self.only,

--- a/src/marshmallow/orderedset.py
+++ b/src/marshmallow/orderedset.py
@@ -23,7 +23,7 @@
 from collections.abc import MutableSet
 
 
-class OrderedSet(MutableSet):
+class OrderedSet(MutableSet):  # noqa: PLW1641
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]  # sentinel node for doubly linked list

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -1,6 +1,5 @@
 """Utility methods for marshmallow."""
 
-# ruff: noqa: T201, T203
 from __future__ import annotations
 
 import datetime as dt

--- a/tests/base.py
+++ b/tests/base.py
@@ -161,17 +161,6 @@ class Blog:
         return item.name in [each.name for each in self.collaborators]
 
 
-class DummyModel:
-    def __init__(self, foo):
-        self.foo = foo
-
-    def __eq__(self, other):
-        return self.foo == other.foo
-
-    def __str__(self):
-        return f"bar {self.foo}"
-
-
 ###### Schemas #####
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -234,7 +234,7 @@ def test_decorated_processor_inheritance():
             item["overridden"] = "overridden"
             return item
 
-        deleted = None
+        deleted = None  # type: ignore[assignment]
 
     parent_dumped = ParentSchema().dump({})
     assert parent_dumped == {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -189,7 +189,7 @@ class FooSerializer(Schema):
 
 def test_multiple_classes_with_same_name_raises_error():
     # Import a class with the same name
-    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: F401
+    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: PLC0415, F401
 
     class MySchema(Schema):
         foo = fields.Nested("FooSerializer")
@@ -204,14 +204,14 @@ def test_multiple_classes_with_same_name_raises_error():
 
 def test_multiple_classes_with_all():
     # Import a class with the same name
-    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: F401
+    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: PLC0415, F401
 
     classes = class_registry.get_class("FooSerializer", all=True)
     assert len(classes) == 2
 
 
 def test_can_use_full_module_path_to_class():
-    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: F401
+    from .foo_serializer import FooSerializer as FooSerializer1  # noqa: PLC0415, F401
 
     # Using full paths is ok
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -438,7 +438,7 @@ class TestFieldSerialization:
         )
 
     def test_structured_dict_value_serialize(self, user):
-        user.various_data = {"foo": decimal.Decimal("1")}
+        user.various_data = {"foo": decimal.Decimal(1)}
         field = fields.Dict(values=fields.Decimal)
         assert field.serialize("various_data", user) == {"foo": 1}
 
@@ -448,7 +448,7 @@ class TestFieldSerialization:
         assert field.serialize("various_data", user) == {"1": "bar"}
 
     def test_structured_dict_key_value_serialize(self, user):
-        user.various_data = {1: decimal.Decimal("1")}
+        user.various_data = {1: decimal.Decimal(1)}
         field = fields.Dict(keys=fields.Str, values=fields.Decimal)
         assert field.serialize("various_data", user) == {"1": 1}
 


### PR DESCRIPTION
I fixed all issues with line-specific ignores because I figured they were not worth or possible to fix but the rule was still worth being kept enabled.

ruff

- Imports not on top due to circular imports
- `partial` is a boolean positional arg, we may want to make it kw-only in a next major but until then we ought to keep it as it is
- `OrderedSet` doesn't define `__hash__` but we don't really mind, as it is meant to be used internally and we don't need `__hash__`.

mypy

- method overridden with `None` in child class in tests

There is still a mypy false-positive "unreachable line" I can't figure out the reason for. I didn't find any related issue in mypy.

Closes #2828.