### PR TITLE
Disable RUF043 in tests: allow metacharacters in match patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ ignore = [
   "PLR0915", # allow lots of statements
   "PT007",   # ignore false positives due to https://github.com/astral-sh/ruff/issues/14743
   "PT011",   # don't require match when using pytest.raises
+  "RUF043",  # allow metacharacters in match patterns
   "S",       # allow asserts
   "SIM117",  # allow nested with statements because it's more readable sometimes
   "SLF001",  # allow private attribute access


### PR DESCRIPTION
This disables [RUF043](https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern/) in tests.

This should fix #2856.

I don't think this rule is that interesting. It requires cumbersome code for all those string that contain a dot.