### PR TITLE
(fix) missing constant with len validation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -179,3 +179,4 @@ Contributors (chronological)
 - Dharanikumar Sekar `@dharani7998 <https://github.com/dharani7998>`_
 - Nicolas Simonds `@0xDEC0DE <https://github.com/0xDEC0DE>`_
 - Florian Laport `@Florian-Laport <https://github.com/Florian-Laport>`_
+- `@agentgodzilla <https://github.com/agentgodzilla>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Changelog
 
 Other changes:
 
+- Add `__len__` implementation to `missing` so that it can be used with
+  `validate.Length <marshmallow.validate.Length>` (:pr:`2861`).
+  Thanks :user:`agentgodzilla` for the PR.
 - Drop support for Python 3.9 (:pr:`2363`).
 - Test against Python 3.14.
 

--- a/src/marshmallow/constants.py
+++ b/src/marshmallow/constants.py
@@ -21,4 +21,5 @@ class _Missing:
     def __len__(self):
         return 0
 
+
 missing: typing.Final = _Missing()

--- a/src/marshmallow/constants.py
+++ b/src/marshmallow/constants.py
@@ -18,5 +18,7 @@ class _Missing:
     def __repr__(self):
         return "<marshmallow.missing>"
 
+    def __len__(self):
+        return 0
 
 missing: typing.Final = _Missing()

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -14,6 +14,7 @@ from marshmallow import (
     RAISE,
     Schema,
     fields,
+    missing,
     validate,
 )
 from marshmallow.exceptions import ValidationError
@@ -1004,6 +1005,13 @@ class TestFieldDeserialization:
     def test_function_field_deserialization_with_callable(self):
         field = fields.Function(lambda x: None, deserialize=lambda val: val.upper())
         assert field.deserialize("foo") == "FOO"
+
+    def test_function_field_deserialization_missing_with_length_validator(self):
+        field = fields.Function(
+            deserialize=lambda value: value.get("some-key", missing),
+            validate=validate.Length(min=0),
+        )
+        assert field.deserialize({}) is missing
 
     def test_function_field_passed_deserialize_only_is_load_only(self):
         field = fields.Function(deserialize=lambda val: val.upper())


### PR DESCRIPTION
Currently if you utilize the `missing` constant as fallback value for a field in a schema alongside a length validator it fails with the following error `"object of type '_Missing' has no len()`

I'm using missing like this because I have some function fields that parse some optional data (in an annoying list of dictionaries), and if you include a standard pythonic default value of `None, [], {}, ""` the blank field is still included in `load()` results instead of being excluded, where as if you use missing it gets dropped from result as expected. 

If you'd like to know more about my use case or my schema just let me know