### PR TITLE
Fix Constant field rejecting None values during load

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -183,3 +183,4 @@ Contributors (chronological)
 - Xiao `@T90REAL <https://github.com/T90REAL>`_
 - jfo `@jafournier <https://github.com/jafournier>`_
 - thanhlecongg `@thanhlecongg <https://github.com/thanhlecongg>`_
+- Emmanuel Ferdman  `@emmanuel-ferdman  <https://github.com/emmanuel-ferdman>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+unreleased
+----------
+
+Bug fixes:
+
+- Fix behavior of ``fields.Contant(None)`` (:issue:`2868`).
+  Thanks :user:`T90REAL` for reporting and `emmanuel-ferdman` for the fix.
+
 
 4.2.1 (2026-01-23)
 ------------------

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2065,10 +2065,10 @@ class Constant(Field[_ContantT]):
     _CHECK_ATTRIBUTE = False
 
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
+        kwargs["load_default"] = constant
+        kwargs["dump_default"] = constant
         super().__init__(**kwargs)
         self.constant = constant
-        self.load_default = constant
-        self.dump_default = constant
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1413,6 +1413,15 @@ class TestFieldDeserialization:
         assert sch.load({})["foo"] == 42
         assert sch.load({"foo": 24})["foo"] == 42
 
+    def test_constant_none_allows_none_value(self):
+        class MySchema(Schema):
+            foo = fields.Constant(None)
+
+        sch = MySchema()
+        assert sch.load({"foo": None})["foo"] is None
+        assert sch.load({})["foo"] is None
+        assert sch.load({"foo": "ignored"})["foo"] is None
+
     def test_field_deserialization_with_user_validator_function(self):
         field = fields.String(validate=predicate(lambda s: s.lower() == "valid"))
         assert field.deserialize("Valid") == "Valid"


### PR DESCRIPTION
# PR summary: 
`Constant(None)` was rejecting null values during load with "Field may not be null" because `allow_none` was being inferred before the constant value was assigned. Moving the default assignments before `super().__init__()`, lets the base class correctly infer `allow_none=True` when the constant is `None`.

Fixes #2868.