### PR TITLE
Fix Constant(None) field rejecting null input

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2065,10 +2065,13 @@ class Constant(Field[_ContantT]):
     _CHECK_ATTRIBUTE = False
 
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
+        # Set load_default and dump_default before calling super().__init__
+        # so that allow_none is correctly computed when constant is None
+        # (fixes issue #2868)
+        kwargs.setdefault("load_default", constant)
+        kwargs.setdefault("dump_default", constant)
         super().__init__(**kwargs)
         self.constant = constant
-        self.load_default = constant
-        self.dump_default = constant
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1413,6 +1413,22 @@ class TestFieldDeserialization:
         assert sch.load({})["foo"] == 42
         assert sch.load({"foo": 24})["foo"] == 42
 
+    def test_constant_none_allows_null_input(self):
+        """Test that Constant(None) correctly allows null input (issue #2868)."""
+
+        class MySchema(Schema):
+            sentinel = fields.Constant(None)
+
+        schema = MySchema()
+        # Should not raise ValidationError
+        result = schema.load({"sentinel": None})
+        assert result["sentinel"] is None
+        # Should also work with any other input
+        result = schema.load({"sentinel": "anything"})
+        assert result["sentinel"] is None
+        # Dump should also work
+        assert schema.dump({"sentinel": "anything"})["sentinel"] is None
+
     def test_field_deserialization_with_user_validator_function(self):
         field = fields.String(validate=predicate(lambda s: s.lower() == "valid"))
         assert field.deserialize("Valid") == "Valid"


### PR DESCRIPTION
## Summary

When `Constant` field is initialized with `None` as the constant value, loading a payload containing null would incorrectly raise:

```
ValidationError: {'sentinel': ['Field may not be null.']}
```

### Root Cause

The issue was in the initialization order:
1. `Constant.__init__` calls `super().__init__(**kwargs)`
2. `Field.__init__` computes `allow_none` based on `load_default` (line 213)
3. At this point, `load_default` is still `missing_` (not passed in kwargs)
4. So `allow_none` is computed as `False`
5. Only afterwards does `Constant.__init__` set `self.load_default = constant`
6. But `allow_none` has already been incorrectly set

### Fix

Pass `load_default` and `dump_default` to the parent constructor via `kwargs.setdefault()` so that `allow_none` is computed correctly when the constant is `None`.

## Test Plan

Added test `test_constant_none_allows_null_input` that verifies:
- Loading `{"sentinel": None}` works without raising ValidationError
- Loading `{"sentinel": "anything"}` also works (constant always wins)
- Dumping also works correctly

Fixes #2868