### PR TITLE
fix: prevent OneOf.options()from emitting phantom pairs

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import re
 import typing
+import warnings
 from abc import ABC, abstractmethod
-from itertools import zip_longest
 from operator import attrgetter
 
 from marshmallow.exceptions import ValidationError
@@ -594,6 +594,16 @@ class OneOf(Validator):
         self.labels = labels if labels is not None else []
         self.labels_text = ", ".join(str(label) for label in self.labels)
         self.error: str = error or self.default_message
+        if labels is not None:
+            try:
+                if len(self.labels) > len(self.choices):
+                    warnings.warn(
+                        "The number of labels exceeds the number of choices. "
+                        "Extra labels will be ignored in options().",
+                        stacklevel=2,
+                    )
+            except TypeError:
+                pass
 
     def _repr_args(self) -> str:
         return f"choices={self.choices!r}, labels={self.labels!r}"
@@ -626,7 +636,8 @@ class OneOf(Validator):
             of an attribute of the choice objects. Defaults to `str()`.
         """
         valuegetter = valuegetter if callable(valuegetter) else attrgetter(valuegetter)
-        pairs = zip_longest(self.choices, self.labels, fillvalue="")
+        labels = list(self.labels) + [""] * max(0, len(self.choices) - len(self.labels))
+        pairs = zip(self.choices, labels, strict=False)
 
         return ((valuegetter(choice), label) for choice, label in pairs)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,7 @@
 """Tests for marshmallow.validate"""
 
 import re
+import warnings
 
 import pytest
 
@@ -725,13 +726,24 @@ def test_oneof_options():
     expected = [("1", "one"), ("2", "two"), ("3", "")]
     assert list(oneof.options()) == expected
 
-    oneof = validate.OneOf([1, 2], ["one", "two", "three"])
-    expected = [("1", "one"), ("2", "two"), ("", "three")]
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        oneof = validate.OneOf([1, 2], ["one", "two", "three"])
+    expected = [("1", "one"), ("2", "two")]
     assert list(oneof.options()) == expected
 
     oneof = validate.OneOf([1, 2])
     expected = [("1", ""), ("2", "")]
     assert list(oneof.options()) == expected
+
+
+def test_oneof_options_labels_exceed_choices():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        oneof = validate.OneOf([1, 2], ["one", "two", "three"])
+        assert len(w) == 1
+
+    assert list(oneof.options()) == [("1", "one"), ("2", "two")]
 
 
 def test_oneof_text():


### PR DESCRIPTION
### Description
Replaced it with zip bounded by the number of choices, added a warning when labels exceed choices, and included the related test coverage.

### Related Issue
Fix: #2869