### PR TITLE
Fix Constant field with required=True raising ValueError

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -184,3 +184,5 @@ Contributors (chronological)
 - jfo `@jafournier <https://github.com/jafournier>`_
 - thanhlecongg `@thanhlecongg <https://github.com/thanhlecongg>`_
 - Emmanuel Ferdman  `@emmanuel-ferdman  <https://github.com/emmanuel-ferdman>`_
+- Fridayworks  `@worksbyfriday  <https://github.com/worksbyfriday`_
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Bug fixes:
 
 - Make `marshmallow.fields.Number` and `marshmallow.fields.Mapping` abstract base classes to
   prevent using them within Schemas (:issue:`2924`). Thanks :user:`MartingaleCoda` for reporting.
+- Allow `required` to be set on `marshmallow.fields.Contant` (:issue:`2900`).
+  Thanks :user:`nosnickid` for the report and :user:`worksbyfriday` for the PR.
 
 
 4.2.2 (2026-02-04)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2075,6 +2075,8 @@ class Constant(Field[_ContantT]):
             self.allow_none = True
 
     def _validate_missing(self, value):
+        # Omit check for value is missing_
+        # Below is just a paranoid check
         if value is None and not self.allow_none:
             raise self.make_error("null")
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2065,10 +2065,18 @@ class Constant(Field[_ContantT]):
     _CHECK_ATTRIBUTE = False
 
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
-        kwargs["load_default"] = constant
-        kwargs["dump_default"] = constant
         super().__init__(**kwargs)
         self.constant = constant
+        self.load_default = constant
+        self.dump_default = constant
+        # If allow_none was not explicitly provided and the constant is None,
+        # None should be considered valid (mirrors Field.__init__ logic).
+        if kwargs.get("allow_none") is None and constant is None:
+            self.allow_none = True
+
+    def _validate_missing(self, value):
+        if value is None and not self.allow_none:
+            raise self.make_error("null")
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1422,6 +1422,14 @@ class TestFieldDeserialization:
         assert sch.load({})["foo"] is None
         assert sch.load({"foo": "ignored"})["foo"] is None
 
+    def test_constant_with_required(self):
+        class MySchema(Schema):
+            foo = fields.Constant(42, required=True)
+
+        sch = MySchema()
+        assert sch.load({})["foo"] == 42
+        assert sch.load({"foo": 99})["foo"] == 42
+
     def test_field_deserialization_with_user_validator_function(self):
         field = fields.String(validate=predicate(lambda s: s.lower() == "valid"))
         assert field.deserialize("Valid") == "Valid"


### PR DESCRIPTION
## Summary

Fixes #2900.

`Constant(42, required=True)` raises `ValueError: 'load_default' must not be set for required fields.` because #2894 moved `load_default` assignment into kwargs before `super().__init__()`.

The fix:
- Sets `load_default` and `dump_default` after `super().__init__()` (avoiding the conflict check)
- Overrides `_validate_missing` to skip the `required` check, since a Constant always provides a value regardless of input
- Preserves the #2894 fix for `Constant(None)` by explicitly setting `allow_none = True` when the constant is `None` and `allow_none` was not provided

## Test plan

- [x] Existing `test_constant_none_allows_none_value` still passes (#2894 regression)
- [x] New `test_constant_with_required` verifies `Constant(42, required=True)` works
- [x] All 1133 tests pass