### PR TITLE
Fix Enum field by-name lookup to only return actual members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Bug fixes:
   Thanks: user:`T90REAL` for the report and :user:`rstar327` for the PR.
 - Fix behavior when passing a dot-delited attribute name to ``partial`` for a key with ``data_key`` set (:pr:`2903`).
   Thanks :user:`bysiber` for the PR.
-
+- Fix Enum field by-name lookup to only return actual members (:pr:`2902`).
+  Thanks :user:`bysiber` for the PR.
 
 4.2.2 (2026-02-04)
 ------------------

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1938,9 +1938,10 @@ class Enum(Field[_EnumT]):
             except ValueError as error:
                 raise self.make_error("unknown", choices=self.choices_text) from error
         try:
-            return getattr(self.enum, val)
-        except AttributeError as error:
+            ret = self.enum[val]
+        except KeyError as error:
             raise self.make_error("unknown", choices=self.choices_text) from error
+        return ret
 
 
 class Method(Field):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1197,6 +1197,14 @@ class TestFieldDeserialization:
         ):
             field.deserialize("dummy")
 
+    @pytest.mark.parametrize("non_member", ["mro", "__class__", "__members__"])
+    def test_enum_field_by_symbol_rejects_non_member_attributes(self, non_member):
+        field = fields.Enum(GenderEnum)
+        with pytest.raises(
+            ValidationError, match="Must be one of: male, female, non_binary."
+        ):
+            field.deserialize(non_member)
+
     def test_enum_field_by_symbol_not_string(self):
         field = fields.Enum(GenderEnum)
         with pytest.raises(ValidationError, match="Not a valid string."):


### PR DESCRIPTION
## Summary

The `Enum` field's by-name deserialization uses `getattr(self.enum, val)` to look up members. However, `getattr` returns **any** attribute of the Enum class, not just actual enum members. This means inputs like `"mro"`, `"__class__"`, or `"__members__"` silently return non-Enum objects instead of raising a validation error.

## Problem

```python
from enum import Enum

class Color(Enum):
    RED = 1
    GREEN = 2

# Current behavior - these don't raise errors:
getattr(Color, "mro")         # <built-in method mro>
getattr(Color, "__members__")  # mappingproxy({...})
getattr(Color, "__class__")    # <class 'EnumType'>
```

When a user submits one of these attribute names as input, the `Enum` field returns the raw attribute/method object instead of an Enum member. Downstream code expecting an Enum member would break or behave unpredictably.

## Fix

Replace `getattr(self.enum, val)` with `self.enum[val]`. The `[]` operator on Enum classes only looks up actual members (via `EnumMeta.__getitem__`), so non-member names correctly raise `KeyError`, which we catch and convert to a validation error.

```python
# Before
getattr(Color, "mro")     # returns <built-in method mro>

# After  
Color["mro"]               # raises KeyError
Color["RED"]               # returns Color.RED ✓
```
