### PR TITLE
Fix nested partial to use attr_name instead of data_key for prefix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -186,3 +186,4 @@ Contributors (chronological)
 - Emmanuel Ferdman  `@emmanuel-ferdman  <https://github.com/emmanuel-ferdman>`_
 - Fridayworks `@worksbyfriday  <https://github.com/worksbyfriday>`_
 - `@rstar327 <https://github.com/rstar327>`_
+- Kadir Can Ozden  `@bysiber  <https://github.com/bysiber>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Bug fixes:
   Thanks :user:`nosnickid` for the report and :user:`worksbyfriday` for the PR.
 - Fix `marshmallow.validate.OneOf` emitting extra pairs when labels outnumber choices (:issue:`2869`).
   Thanks: user:`T90REAL` for the report and :user:`rstar327` for the PR.
+- Fix behavior when passing a dot-delited attribute name to ``partial`` for a key with ``data_key`` set (:pr:`2903`).
+  Thanks :user:`bysiber` for the PR.
 
 
 4.2.2 (2026-02-04)

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -654,7 +654,7 @@ class Schema(metaclass=SchemaMeta):
                 d_kwargs = {}
                 # Allow partial loading of nested schemas.
                 if partial_is_collection:
-                    prefix = field_name + "."
+                    prefix = attr_name + "."
                     len_prefix = len(prefix)
                     sub_partial = [
                         f[len_prefix:] for f in partial if f.startswith(prefix)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -2299,6 +2299,26 @@ class TestValidation:
         with pytest.raises(ValidationError):
             SchemaB().load({"z": {"x": 0}})
 
+    def test_nested_partial_tuple_with_data_key(self):
+        class AddressSchema(Schema):
+            zip_code = fields.String(required=True)
+            city = fields.String(required=True)
+
+        class PersonSchema(Schema):
+            address = fields.Nested(
+                AddressSchema, data_key="homeAddress", required=True
+            )
+
+        data = {"homeAddress": {"city": "Springfield"}}
+        # partial uses attr_name ("address.zip_code"), not data_key
+        result = PersonSchema().load(data, partial=("address.zip_code",))
+        assert result["address"]["city"] == "Springfield"
+        assert "zip_code" not in result["address"]
+        # Without partial, it should fail on the missing required field
+        with pytest.raises(ValidationError) as excinfo:
+            PersonSchema().load(data)
+        assert "zip_code" in excinfo.value.messages["homeAddress"]
+
 
 @pytest.mark.parametrize("FieldClass", ALL_FIELDS)
 def test_required_field_failure(FieldClass):


### PR DESCRIPTION
## Summary

When using dot-delimited `partial` with nested schemas, the sub-partial prefix is derived from `field_name` (the `data_key`) instead of `attr_name`. This causes the nested partial to silently break when a field has `data_key` set.

## Problem

The `partial` parameter accepts dot-delimited attribute names:
```python
schema.load(data, partial=("address.zip_code",))
```

In `_deserialize`, the top-level partial check correctly uses `attr_name`:
```python
partial_is_collection and attr_name in partial
```

But the nested sub-partial extraction uses `field_name` (which is the `data_key` if set):
```python
prefix = field_name + "."  # field_name could be "homeAddress" (data_key)
```

If a field is declared as `address = Nested(AddressSchema, data_key="homeAddress")`, then:
- `attr_name` = `"address"`
- `field_name` = `"homeAddress"` (from data_key)
- User passes `partial=("address.zip_code",)`
- `prefix` = `"homeAddress."` — doesn't match `"address.zip_code"`
- Result: `sub_partial` is empty, nested schema doesn't get `partial`

## Fix

Use `attr_name` instead of `field_name` for the prefix, consistent with how the top-level partial check works.
