### PR TITLE
Reject booleans in from_timestamp_ms, consistent with from_timestamp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Bug fixes:
   Thanks :user:`bysiber` for the PR.
 - Fix Enum field by-name lookup to only return actual members (:pr:`2902`).
   Thanks :user:`bysiber` for the PR.
+- `marshmallow.fields.DateTime` with ``format="timestamp_ms"`` properly
+  rejects bool values (:pr:`2904`). Thanks :user:`bysiber` for the PR.
 
 4.2.2 (2026-02-04)
 ------------------

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -55,6 +55,8 @@ def from_timestamp(value: typing.Any) -> dt.datetime:
 
 
 def from_timestamp_ms(value: typing.Any) -> dt.datetime:
+    if value is True or value is False:
+        raise ValueError("Not a valid POSIX timestamp")
     value = float(value)
     return from_timestamp(value / 1000)
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -589,6 +589,13 @@ class TestFieldDeserialization:
         assert field.deserialize(value) == expected_aware
 
     @pytest.mark.parametrize("fmt", ["timestamp", "timestamp_ms"])
+    @pytest.mark.parametrize("in_value", [True, False])
+    def test_boolean_timestamp_field_deserialization(self, fmt, in_value):
+        field = fields.DateTime(format=fmt)
+        with pytest.raises(ValidationError, match="Not a valid datetime."):
+            field.deserialize(in_value)
+
+    @pytest.mark.parametrize("fmt", ["timestamp", "timestamp_ms"])
     @pytest.mark.parametrize(
         "in_value",
         ["", "!@#", -1],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,7 @@ def test_from_timestamp_with_overflow_value():
     with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
         utils.from_timestamp(value)
 
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -144,6 +145,7 @@ def test_from_timestamp_ms(value, expected):
 def test_from_timestamp_ms_rejects_booleans(value):
     with pytest.raises(ValueError, match=r"Not a valid POSIX timestamp"):
         utils.from_timestamp_ms(value)
+
 
 # Regression test for https://github.com/marshmallow-code/marshmallow/issues/540
 def test_function_field_using_type_annotation():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,23 @@ def test_from_timestamp_with_overflow_value():
     with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
         utils.from_timestamp(value)
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1676386740000, dt.datetime(2023, 2, 14, 14, 59, 00)),
+        (1000, dt.datetime(1970, 1, 1, 0, 0, 1)),
+    ],
+)
+def test_from_timestamp_ms(value, expected):
+    result = utils.from_timestamp_ms(value)
+    assert type(result) is dt.datetime
+    assert result == expected
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_from_timestamp_ms_rejects_booleans(value):
+    with pytest.raises(ValueError, match=r"Not a valid POSIX timestamp"):
+        utils.from_timestamp_ms(value)
 
 # Regression test for https://github.com/marshmallow-code/marshmallow/issues/540
 def test_function_field_using_type_annotation():


### PR DESCRIPTION
## Summary

`from_timestamp_ms` doesn't reject boolean values, unlike `from_timestamp`. This allows `DateTime(format="timestamp_ms")` to silently accept `True`/`False` as valid timestamps.

## Problem

`from_timestamp` has an explicit boolean guard:
```python
def from_timestamp(value):
    if value is True or value is False:
        raise ValueError("Not a valid POSIX timestamp")
    value = float(value)
    ...
```

But `from_timestamp_ms` converts to float first:
```python
def from_timestamp_ms(value):
    value = float(value)          # float(True) = 1.0, float(False) = 0.0
    return from_timestamp(value / 1000)  # boolean check sees 0.001, not True
```

Since `float(True)` produces `1.0`, by the time `from_timestamp` is called, the value is already a float and the `value is True` identity check fails. This means:
- `DateTime(format="timestamp")` correctly rejects `True`/`False`
- `DateTime(format="timestamp_ms")` silently accepts them, deserializing `True` as a datetime

## Fix

Add the same boolean rejection to `from_timestamp_ms` before the `float()` conversion.
