### PR TITLE
Fix get_value TypeError with out-of-range int index

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -123,6 +123,10 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        # If key is an int, we can't use getattr (requires string)
+        # Just return the default value
+        if isinstance(key, int):
+            return default
         return getattr(obj, key, default)
 
 


### PR DESCRIPTION
## Description

Fixes #2893 - utils.get_value raises TypeError instead of returning default value when passing an out-of-range int index.

## Problem

When passing an out-of-range int index to utils.get_value, a TypeError was raised instead of returning the provided default value.

This happened because:
1. obj[key] raises IndexError for out-of-range int
2. The except block falls back to getattr(obj, key, default)
3. getattr() fails with TypeError because it requires a string attribute name

## Solution

When catching an exception from obj[key] and key is an int, return the default value instead of calling getattr().

## Test Cases

Before fix:
```python
from marshmallow import utils
lst = [0, 1, 2, 3, 4, 5]
utils.get_value(lst, 999, default=3)  # TypeError: getattr(): attribute name must be string
```

After fix:
```python
utils.get_value(lst, 999, default=3)  # Returns 3
```