### PR TITLE
Add ipaddress types to Schema.TYPE_MAPPING

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,11 @@ Bug fixes:
 - Fix typing of ``error_essages`` argument to `marshmallow.fields.Field` (:pr:`1636`).
   Thanks :user:`repole` for reporting and :user:`dhruvildarji` for the PR.
 
+Other changes:
+
+- Add ``ipaddress.*`` to `marshmallow.Schema.TYPE_MAPPING` (:issue:`1695`).
+  Thanks :user:`liberforce` for the suggestion and :user:`dhruvildarji` for the PR.
+
 4.2.2 (2026-02-04)
 ------------------
 

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -8,6 +8,7 @@ import datetime as dt
 import decimal
 import functools
 import inspect
+import ipaddress
 import json
 import operator
 import typing
@@ -290,6 +291,10 @@ class Schema(metaclass=SchemaMeta):
         dt.date: ma_fields.Date,
         dt.timedelta: ma_fields.TimeDelta,
         decimal.Decimal: ma_fields.Decimal,
+        ipaddress.IPv4Address: ma_fields.IPv4,
+        ipaddress.IPv6Address: ma_fields.IPv6,
+        ipaddress.IPv4Interface: ma_fields.IPv4Interface,
+        ipaddress.IPv6Interface: ma_fields.IPv6Interface,
     }
     #: Overrides for default schema-level error messages
     error_messages: dict[str, str] = {}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import ipaddress
 import math
 import random
 from collections import OrderedDict
@@ -2549,3 +2550,17 @@ def test_set_dict_class(dict_cls):
     result = MySchema().dump({"foo": "bar"})
     assert result == {"foo": "bar"}
     assert isinstance(result, dict_cls)
+
+
+class TestIPTypeMappings:
+    @pytest.mark.parametrize(
+        ("ip_type", "expected_field_cls"),
+        [
+            (ipaddress.IPv4Address, fields.IPv4),
+            (ipaddress.IPv6Address, fields.IPv6),
+            (ipaddress.IPv4Interface, fields.IPv4Interface),
+            (ipaddress.IPv6Interface, fields.IPv6Interface),
+        ],
+    )
+    def test_ip_types_in_type_mapping(self, ip_type, expected_field_cls):
+        assert Schema.TYPE_MAPPING[ip_type] is expected_field_cls

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import ipaddress
 import math
 import random
 from collections import OrderedDict
@@ -2550,17 +2549,3 @@ def test_set_dict_class(dict_cls):
     result = MySchema().dump({"foo": "bar"})
     assert result == {"foo": "bar"}
     assert isinstance(result, dict_cls)
-
-
-class TestIPTypeMappings:
-    @pytest.mark.parametrize(
-        ("ip_type", "expected_field_cls"),
-        [
-            (ipaddress.IPv4Address, fields.IPv4),
-            (ipaddress.IPv6Address, fields.IPv6),
-            (ipaddress.IPv4Interface, fields.IPv4Interface),
-            (ipaddress.IPv6Interface, fields.IPv6Interface),
-        ],
-    )
-    def test_ip_types_in_type_mapping(self, ip_type, expected_field_cls):
-        assert Schema.TYPE_MAPPING[ip_type] is expected_field_cls


### PR DESCRIPTION
## Summary

Closes #1695.

Adds mappings from Python's `ipaddress` types to their corresponding marshmallow field classes in `Schema.TYPE_MAPPING`:

| Python type | Marshmallow field |
|---|---|
| `ipaddress.IPv4Address` | `fields.IPv4` |
| `ipaddress.IPv6Address` | `fields.IPv6` |
| `ipaddress.IPv4Interface` | `fields.IPv4Interface` |
| `ipaddress.IPv6Interface` | `fields.IPv6Interface` |

This enables libraries like `marshmallow_dataclass` to automatically resolve these types from annotations.

**Note:** The generic `IP` and `IPInterface` fields are intentionally excluded since there is no single Python type that maps to them. `IPv4Network`/`IPv6Network` are also excluded since marshmallow does not have corresponding network field classes.

## Test plan

- [x] Added parametrized tests in `TestIPTypeMappings` verifying all 4 new type mappings
- [x] All 1136 existing tests pass