### PR TITLE
Fix get_value TypeError with out-of-range int index

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -123,7 +123,10 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            return default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,14 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_out_of_range_int_returns_default():
+    lst = [0, 1, 2]
+    assert utils.get_value(lst, 999, default=3) == 3
+
+    d = {1: "a", 2: "b"}
+    assert utils.get_value(d, 4, default="z") == "z"
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893

`utils.get_value` raises `TypeError` instead of returning the `default` value when given an out-of-range `int` index on a list. This happens because the fallback `getattr(obj, key, default)` requires a string attribute name, and passing an `int` raises `TypeError`.

This PR catches the `TypeError` from `getattr` and returns `default` instead.

```python
# Before
utils.get_value([0, 1, 2], 999, default=3)
# TypeError: attribute name must be string, not 'int'

# After
utils.get_value([0, 1, 2], 999, default=3)
# 3
```

All 1133 tests pass.