### PR TITLE
Fix OneOf.options() emitting phantom entries when labels outnumber choices

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -174,7 +174,7 @@ Contributors (chronological)
 - Aditya Tewary `@aditkumar72 <https://github.com/aditkumar72>`_
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Peter C `@somethingnew2-0 <https://github.com/somethingnew2-0>`_
-- Marcel Jackwerth `@mrcljx` <https://github.com/mrcljx>`_
+- Marcel Jackwerth `@mrcljx <https://github.com/mrcljx>`_
 - Fares Abubaker `@Fares-Abubaker <https://github.com/Fares-Abubaker>`_
 - Dharanikumar Sekar `@dharani7998 <https://github.com/dharani7998>`_
 - Nicolas Simonds `@0xDEC0DE <https://github.com/0xDEC0DE>`_
@@ -184,5 +184,5 @@ Contributors (chronological)
 - jfo `@jafournier <https://github.com/jafournier>`_
 - thanhlecongg `@thanhlecongg <https://github.com/thanhlecongg>`_
 - Emmanuel Ferdman  `@emmanuel-ferdman  <https://github.com/emmanuel-ferdman>`_
-- Fridayworks  `@worksbyfriday  <https://github.com/worksbyfriday`_
-
+- Fridayworks `@worksbyfriday  <https://github.com/worksbyfriday>`_
+- `@rstar327 <https://github.com/rstar327>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Bug fixes:
   prevent using them within Schemas (:issue:`2924`). Thanks :user:`MartingaleCoda` for reporting.
 - Allow `required` to be set on `marshmallow.fields.Contant` (:issue:`2900`).
   Thanks :user:`nosnickid` for the report and :user:`worksbyfriday` for the PR.
+- Fix `marshmallow.validate.OneOf` emitting extra pairs when labels outnumber choices (:issue:`2869`).
+  Thanks: user:`T90REAL` for the report and :user:`rstar327` for the PR.
 
 
 4.2.2 (2026-02-04)

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -203,7 +203,7 @@ class URL(Validator):
         # Check first if the scheme is valid
         scheme = None
         if "://" in value:
-            scheme = value.split("://")[0].lower()
+            scheme = value.split("://", maxsplit=1)[0].lower()
             if scheme not in self.schemes:
                 raise ValidationError(message)
 
@@ -634,7 +634,7 @@ class OneOf(Validator):
 
         return (
             (valuegetter(choice), label)
-            for choice, label in zip(choices, padded_labels)
+            for choice, label in zip(choices, padded_labels, strict=True)
         )
 
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 import typing
 from abc import ABC, abstractmethod
-from itertools import zip_longest
 from operator import attrgetter
 
 from marshmallow.exceptions import ValidationError
@@ -626,9 +625,17 @@ class OneOf(Validator):
             of an attribute of the choice objects. Defaults to `str()`.
         """
         valuegetter = valuegetter if callable(valuegetter) else attrgetter(valuegetter)
-        pairs = zip_longest(self.choices, self.labels, fillvalue="")
+        choices = tuple(self.choices)
+        labels = tuple(self.labels)
+        # Pad labels with empty strings if fewer than choices, truncate if more
+        padded_labels = labels[: len(choices)] + ("",) * max(
+            0, len(choices) - len(labels)
+        )
 
-        return ((valuegetter(choice), label) for choice, label in pairs)
+        return (
+            (valuegetter(choice), label)
+            for choice, label in zip(choices, padded_labels)
+        )
 
 
 class ContainsOnly(OneOf):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -726,12 +726,16 @@ def test_oneof_options():
     assert list(oneof.options()) == expected
 
     oneof = validate.OneOf([1, 2], ["one", "two", "three"])
-    expected = [("1", "one"), ("2", "two"), ("", "three")]
+    expected = [("1", "one"), ("2", "two")]
     assert list(oneof.options()) == expected
 
     oneof = validate.OneOf([1, 2])
     expected = [("1", ""), ("2", "")]
     assert list(oneof.options()) == expected
+
+    # Empty choices with extra labels should produce no options
+    oneof = validate.OneOf(choices=[], labels=["extra"])
+    assert list(oneof.options()) == []
 
 
 def test_oneof_text():


### PR DESCRIPTION
Fixes #2869

`OneOf.options()` used `zip_longest(choices, labels, fillvalue="")` which produced phantom `('', 'label')` entries when `labels` was longer than `choices`. These phantom entries have no corresponding choice and are misleading.

This PR replaces `zip_longest` with explicit padding/truncation so that `options()` always returns exactly as many pairs as there are choices:
- Extra labels beyond the number of choices are silently ignored
- Missing labels are padded with empty strings (preserving existing behavior)

```python
# Before
OneOf(choices=[], labels=["extra"]).options()  # [('', 'extra')]

# After
OneOf(choices=[], labels=["extra"]).options()  # []
```

All 1132 tests pass.