### PR TITLE
Fix Constant field with required=True raising ValueError

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2065,10 +2065,21 @@ class Constant(Field[_ContantT]):
     _CHECK_ATTRIBUTE = False
 
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
+        # Extract required before passing to super().__init__ because
+        # Constant always sets load_default (to the constant value),
+        # which would conflict with the required=True check in Field.__init__.
+        is_required = kwargs.pop("required", False)
         kwargs["load_default"] = constant
         kwargs["dump_default"] = constant
         super().__init__(**kwargs)
+        self.required = is_required
         self.constant = constant
+
+    def _validate_missing(self, value: typing.Any) -> None:
+        # Skip the required check for Constant fields since the constant
+        # value is always available via load_default. Only check allow_none.
+        if value is None and not self.allow_none:
+            self.make_error("null")
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1422,6 +1422,16 @@ class TestFieldDeserialization:
         assert sch.load({})["foo"] is None
         assert sch.load({"foo": "ignored"})["foo"] is None
 
+    def test_constant_with_required(self):
+        class MySchema(Schema):
+            type_ = fields.Constant("foo", required=True)
+
+        sch = MySchema()
+        assert sch.fields["type_"].required is True
+        assert sch.load({})["type_"] == "foo"
+        assert sch.load({"type_": "ignored"})["type_"] == "foo"
+        assert sch.dump({}) == {"type_": "foo"}
+
     def test_field_deserialization_with_user_validator_function(self):
         field = fields.String(validate=predicate(lambda s: s.lower() == "valid"))
         assert field.deserialize("Valid") == "Valid"


### PR DESCRIPTION
Fixes #2900

`fields.Constant` always sets `load_default` to the constant value internally. Since #2894 added a check that rejects `load_default` on required fields, `Constant(constant, required=True)` now raises `ValueError`.

This PR fixes the issue by:
1. Extracting `required` from kwargs before calling `super().__init__()`, then setting it after
2. Overriding `_validate_missing` in `Constant` to skip the required-field check, since the constant value is always available via `load_default`

```python
# Before
fields.Constant("foo", required=True)
# ValueError: 'load_default' must not be set for required fields.

# After
class MySchema(Schema):
    type_ = fields.Constant("foo", required=True)

MySchema().load({})       # {'type_': 'foo'}
MySchema().dump({})       # {'type_': 'foo'}
MySchema().fields["type_"].required  # True
```

All 1133 tests pass.