### PR TITLE
fix(utils): handle TypeError from getattr with non-string keys in get_value

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -123,7 +123,12 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            # getattr requires a string attribute name; if key is
+            # a non-string (e.g. int), fall back to the default.
+            return default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,24 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_with_out_of_range_int_key():
+    """get_value returns default when an int key is out of range.
+
+    Regression test for https://github.com/marshmallow-code/marshmallow/issues/2893
+    """
+    # List with out-of-range index
+    lst = [0, 1, 2, 3, 4, 5]
+    assert utils.get_value(lst, 999, default=3) == 3
+
+    # Dict with int keys, missing key
+    d = {1: "a", 2: "b"}
+    assert utils.get_value(d, 4, default="z") == "z"
+
+    # In-range int key still works
+    assert utils.get_value(lst, 2, default=None) == 2
+    assert utils.get_value(d, 1, default=None) == "a"
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
## Summary

- `utils.get_value` raises `TypeError` when given an out-of-range integer key for a list or a missing integer key for a dict, because the `getattr` fallback requires a string attribute name
- Wrapped the `getattr` fallback in `_get_value_for_key` with `try/except TypeError` to gracefully return the default value for non-string keys
- Added regression test covering list out-of-range, dict missing int key, and in-range cases

Closes #2893

## Test plan

- [x] `test_get_value_with_out_of_range_int_key` — 4 assertions covering list OOR, dict missing key, and both in-range
- [x] Full test suite passes (1133 tests, 0 failures)
- [x] `ruff check` and `ruff format --check` clean

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)