### PR TITLE
Fix TypeError in utils.get_value with out-of-range int index

### DIFF
--- a/reproduce_issue.py
+++ b/reproduce_issue.py
@@ -1,0 +1,29 @@
+"""Reproduction script for marshmallow issue #2893."""
+# ruff: noqa: T201, BLE001
+
+from marshmallow import utils
+
+
+def test_get_value_out_of_range_int():
+    """Test get_value with out-of-range int index."""
+    lst = [0, 1, 2, 3, 4, 5]
+    try:
+        val = utils.get_value(lst, 999, default=3)
+        print(f"Case 1 (List out of range): {val}")
+    except TypeError as e:
+        print(f"Case 1 (List out of range) FAILED with TypeError: {e}")
+    except Exception as e:
+        print(f"Case 1 (List out of range) FAILED with {type(e).__name__}: {e}")
+
+    dictionary = {1: "a", 2: "b", 3: "c"}
+    try:
+        val = utils.get_value(dictionary, 4, default="z")
+        print(f"Case 2 (Dict missing int key): {val}")
+    except TypeError as e:
+        print(f"Case 2 (Dict missing int key) FAILED with TypeError: {e}")
+    except Exception as e:
+        print(f"Case 2 (Dict missing int key) FAILED with {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    test_get_value_out_of_range_int()

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -118,12 +118,12 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
-        return getattr(obj, key, default)
+        return getattr(obj, key, default) if isinstance(key, str) else default
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        return getattr(obj, key, default) if isinstance(key, str) else default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,6 +78,17 @@ def test_get_value():
 
     assert utils.get_value(lst, MyInt(1)) == 2
 
+    # regression tests for https://github.com/marshmallow-code/marshmallow/issues/2893
+    assert utils.get_value(lst, 999, default=3) == 3
+    dictionary = {1: "a", 2: "b"}
+    assert utils.get_value(dictionary, 4, default="z") == "z"
+
+    class NoGetItem:
+        pass
+
+    obj = NoGetItem()
+    assert utils.get_value(obj, 1, default="default") == "default"
+
 
 def test_set_value():
     d: dict[str, int | dict] = {}


### PR DESCRIPTION
Fixes #2893. When passing an out-of-range int index to utils.get_value, a TypeError was raised because it tried to fallback to getattr() with an int key. This PR ensures getattr() is only called if the key is a string.