### PR TITLE
Implement new `Bytes` field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import abc
+import base64
 import collections
 import copy
 import datetime as dt
@@ -48,6 +49,7 @@ __all__ = [
     "AwareDateTime",
     "Bool",
     "Boolean",
+    "Bytes",
     "Constant",
     "Date",
     "DateTime",
@@ -880,8 +882,33 @@ class String(Field[str]):
 
 class Bytes(Field[bytes]):
     """
-    Marshmallow field type for any bytes array.
+    A field for deserializing strings into byte arrays.
+
+    :param encoding: Specifies the string encoding used when encoding/decoding to/from strings.
+    :param errors: Error behaviour when converting to/from a :class:`str`, inherited from it's constructor.
+    :param serialize: Specifies the return type when serializing.
+        `base64` and `str` use the value of `encoding` for the string.
+    :param kwargs: The same keyword arguments that :class:`Field` receives.
+
+    .. versionadded:: 4.3.0
     """
+    #: Default error messages.
+    default_error_messages = {
+        "not_bytes": "Not a bytes-like object.",
+        "unicode": "Invalid unicode string.",
+    }
+
+    def __init__(
+        self,
+        encoding: str = "utf-8",
+        errors: str = "strict",
+        serialize: typing.Literal["int", "str", "bytes", "base64"] = "base64",
+        **kwargs: Unpack[_BaseFieldKwargs],
+    ):
+        super().__init__(**kwargs)
+        self.encoding = encoding
+        self.errors = errors
+        self.serialize = serialize
 
     def _deserialize(
         self,
@@ -892,15 +919,11 @@ class Bytes(Field[bytes]):
     ) -> bytes:
         try:
             match value:
-                case bytes() as b:
-                    return b
-                case bytearray() as ba:
-                    return bytes(ba)
                 case str() as s:
                     return bytes(
                         s,
-                        encoding="utf-8",
-                        errors="ignore",
+                        encoding=self.encoding,
+                        errors=self.errors,
                     )
                 case int() as i:
                     return i.to_bytes(
@@ -908,12 +931,40 @@ class Bytes(Field[bytes]):
                         byteorder="big",
                         signed=i < 0,
                     )
-                case obj:
-                    if isinstance(obj, (typing.SupportsBytes, typing.Iterable)):
-                        return bytes(obj)
-            raise ValidationError("not a bytes-like object")
+                case _:
+                    return bytes(obj)
         except TypeError as e:
-            raise ValidationError("not a bytes-like object") from e
+            raise self.make_error("not_bytes")  from e
+        except UnicodeError as e:
+            raise self.make_error("unicode")  from e
+
+    def _serialize(self,
+        value: bytes,
+        attr: str | None,
+        obj: typing.Any,
+        **kwargs: typing.Any,
+    ) -> str | int | bytes:
+        try:
+            match self.serialize:
+                case "str":
+                    return str(
+                        value,
+                        encoding=self.encoding,
+                        errors=self.errors,
+                    )
+                case "base64":
+                    return base64.standard_b64encode(value)
+                case "int":
+                    return int.from_bytes(
+                        value,
+                        byteorder="big",
+                    )
+                case "bytes":
+                    return value
+                case _:
+                    typing.assert_never(self.serialize)
+        except UnicodeError as e:
+            raise self.make_error("unicode")  from e
 
 
 class UUID(Field[uuid.UUID]):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -933,7 +933,7 @@ class Bytes(Field[bytes]):
                         signed=i < 0,
                     )
                 case _:
-                    return bytes(obj)
+                    return bytes(value)
         except TypeError as e:
             raise self.make_error("not_bytes") from e
         except UnicodeError as e:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -878,6 +878,44 @@ class String(Field[str]):
             raise self.make_error("invalid_utf8") from error
 
 
+class Bytes(Field[bytes]):
+  """
+  Marshmallow field type for any bytes array.
+  """
+
+  def _deserialize(
+    self,
+    value: typing.Any,
+    attr: str | None,
+    data: typing.Mapping[str, typing.Any] | None,
+    **kwargs: typing.Any,
+  ) -> bytes:
+    try:
+      match value:
+        case bytes() as b:
+          return b
+        case bytearray() as ba:
+          return bytes(ba)
+        case str() as s:
+          return bytes(
+            s,
+            encoding="utf-8",
+            errors="ignore",
+          )
+        case int() as i:
+          return i.to_bytes(
+            length=max(1, (7 + i.bit_length()) // 8),
+            byteorder="big",
+            signed=i < 0,
+          )
+        case obj:
+          if isinstance(obj, (typing.SupportsBytes, typing.Iterable)):
+            return bytes(obj)
+      raise ValidationError("not a bytes-like object")
+    except TypeError as e:
+      raise ValidationError("not a bytes-like object") from e
+
+
 class UUID(Field[uuid.UUID]):
     """A UUID field."""
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -879,41 +879,41 @@ class String(Field[str]):
 
 
 class Bytes(Field[bytes]):
-  """
-  Marshmallow field type for any bytes array.
-  """
+    """
+    Marshmallow field type for any bytes array.
+    """
 
-  def _deserialize(
-    self,
-    value: typing.Any,
-    attr: str | None,
-    data: typing.Mapping[str, typing.Any] | None,
-    **kwargs: typing.Any,
-  ) -> bytes:
-    try:
-      match value:
-        case bytes() as b:
-          return b
-        case bytearray() as ba:
-          return bytes(ba)
-        case str() as s:
-          return bytes(
-            s,
-            encoding="utf-8",
-            errors="ignore",
-          )
-        case int() as i:
-          return i.to_bytes(
-            length=max(1, (7 + i.bit_length()) // 8),
-            byteorder="big",
-            signed=i < 0,
-          )
-        case obj:
-          if isinstance(obj, (typing.SupportsBytes, typing.Iterable)):
-            return bytes(obj)
-      raise ValidationError("not a bytes-like object")
-    except TypeError as e:
-      raise ValidationError("not a bytes-like object") from e
+    def _deserialize(
+        self,
+        value: typing.Any,
+        attr: str | None,
+        data: typing.Mapping[str, typing.Any] | None,
+        **kwargs: typing.Any,
+    ) -> bytes:
+        try:
+            match value:
+                case bytes() as b:
+                    return b
+                case bytearray() as ba:
+                    return bytes(ba)
+                case str() as s:
+                    return bytes(
+                        s,
+                        encoding="utf-8",
+                        errors="ignore",
+                    )
+                case int() as i:
+                    return i.to_bytes(
+                        length=max(1, (7 + i.bit_length()) // 8),
+                        byteorder="big",
+                        signed=i < 0,
+                    )
+                case obj:
+                    if isinstance(obj, (typing.SupportsBytes, typing.Iterable)):
+                        return bytes(obj)
+            raise ValidationError("not a bytes-like object")
+        except TypeError as e:
+            raise ValidationError("not a bytes-like object") from e
 
 
 class UUID(Field[uuid.UUID]):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -892,6 +892,7 @@ class Bytes(Field[bytes]):
 
     .. versionadded:: 4.3.0
     """
+
     #: Default error messages.
     default_error_messages = {
         "not_bytes": "Not a bytes-like object.",
@@ -934,11 +935,12 @@ class Bytes(Field[bytes]):
                 case _:
                     return bytes(obj)
         except TypeError as e:
-            raise self.make_error("not_bytes")  from e
+            raise self.make_error("not_bytes") from e
         except UnicodeError as e:
-            raise self.make_error("unicode")  from e
+            raise self.make_error("unicode") from e
 
-    def _serialize(self,
+    def _serialize(
+        self,
         value: bytes,
         attr: str | None,
         obj: typing.Any,
@@ -964,7 +966,7 @@ class Bytes(Field[bytes]):
                 case _:
                     typing.assert_never(self.serialize)
         except UnicodeError as e:
-            raise self.make_error("unicode")  from e
+            raise self.make_error("unicode") from e
 
 
 class UUID(Field[uuid.UUID]):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -327,16 +327,16 @@ class TestFieldDeserialization:
         assert field.deserialize(b"foo") == b"foo"
         assert field.deserialize(bytearray(b"foo")) == b"foo"
         assert field.deserialize("foo") == b"foo"
-        assert field.deserialize(0xDEAD) == b"\xDE\xAD"
-        assert field.deserialize([0xBE, 0xEF]) == b"\xBE\xEF"
-        assert field.deserialize((0xB, 0xA, 0xB, 0xE)) == b"\x0B\x0A\x0B\x0E"
+        assert field.deserialize(0xDEAD) == b"\xde\xad"
+        assert field.deserialize([0xBE, 0xEF]) == b"\xbe\xef"
+        assert field.deserialize((0xB, 0xA, 0xB, 0xE)) == b"\x0b\x0a\x0b\x0e"
 
         with pytest.raises(ValidationError) as excinfo:
             field.deserialize({"hi": 222})
         assert excinfo.value.args[0] == "not a bytes-like object"
 
         with pytest.raises(ValidationError) as excinfo:
-            field.deserialize(['12345'])
+            field.deserialize(["12345"])
         assert excinfo.value.args[0] == "not a bytes-like object"
 
     def test_boolean_field_deserialization(self):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -322,6 +322,23 @@ class TestFieldDeserialization:
         with pytest.raises(ValidationError):
             field.deserialize({})
 
+    def test_bytes_field_deserialization(self):
+        field = fields.Bytes()
+        assert field.deserialize(b"foo") == b"foo"
+        assert field.deserialize(bytearray(b"foo")) == b"foo"
+        assert field.deserialize("foo") == b"foo"
+        assert field.deserialize(0xDEAD) == b"\xDE\xAD"
+        assert field.deserialize([0xBE, 0xEF]) == b"\xBE\xEF"
+        assert field.deserialize((0xB, 0xA, 0xB, 0xE)) == b"\x0B\x0A\x0B\x0E"
+
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize({"hi": 222})
+        assert excinfo.value.args[0] == "not a bytes-like object"
+
+        with pytest.raises(ValidationError) as excinfo:
+            field.deserialize(['12345'])
+        assert excinfo.value.args[0] == "not a bytes-like object"
+
     def test_boolean_field_deserialization(self):
         field = fields.Boolean()
         assert field.deserialize(True) is True


### PR DESCRIPTION
I would like to be able to use the native `bytes` type when deserialising. Right now the closest approximation is `marshmallow.fields.String`, but that requires it to be UTF8, which is too restrictive if I want pure binary data.

I added a new `Bytes` field, which supports deserialising from:
- `bytes`
- `bytearray`
- `str`
- `int`
- `typing.SupportsBytes`
- `typing.Iterable` (i.e. `list[int]`)