### PR TITLE
Handle TypeError in _get_value_for_key when key is non-string

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -118,12 +118,18 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            return default
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            return default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,14 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_int_key_out_of_range():
+    lst = [0, 1, 2]
+    assert utils.get_value(lst, 999, default="missing") == "missing"
+
+    d = {1: "a", 2: "b"}
+    assert utils.get_value(d, 4, default="z") == "z"
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893

When get_value receives an out-of-range int index for a list, the IndexError fallback calls getattr(obj, key, default) which raises TypeError because getattr requires a string attribute name. The same happens with dict int keys that don't exist.

Wrapped the getattr fallback in a try/except TypeError so it returns the default value instead of crashing. Added tests for the list and dict cases from the issue.