### PR TITLE
Make Number and Mapping abstract base classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+(unreleased)
+------------
+
+Bug fixes:
+
+- Make `marshmallow.fields.Number` and `marshmallow.fields.Mapping` abstract base classes to
+  prevent using them within Schemas (:issue:`2924`). Thanks :user:`MartingaleCoda` for reporting.
+
+
 4.2.2 (2026-02-04)
 ------------------
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -781,7 +781,7 @@ class Tuple(Field[tuple]):
 
     def __init__(
         self,
-        tuple_fields: typing.Iterable[Field] | typing.Iterable[type[Field]],
+        tuple_fields: typing.Iterable[Field | type[Field]],
         **kwargs: Unpack[_BaseFieldKwargs],
     ):
         super().__init__(**kwargs)

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -907,8 +907,11 @@ class UUID(Field[uuid.UUID]):
 _NumT = typing.TypeVar("_NumT")
 
 
-class Number(Field[_NumT]):
-    """Base class for number fields. This class should not be used within schemas.
+class Number(Field[_NumT], metaclass=abc.ABCMeta):
+    """Abstract base class for number fields.
+
+    Use `Integer <marshmallow.fields.Integer>`, `Float <marshmallow.fields.Float>`,
+    or `Decimal <marshmallow.fields.Decimal>` within schemas.
 
     :param as_string: If `True`, format the serialized value as a string.
     :param kwargs: The same keyword arguments that :class:`Field` receives.
@@ -918,7 +921,9 @@ class Number(Field[_NumT]):
         Use `Integer <marshmallow.fields.Integer>`, `Float <marshmallow.fields.Float>`, or `Decimal <marshmallow.fields.Decimal>` instead.
     """
 
-    num_type: type[_NumT]
+    @property
+    @abc.abstractmethod
+    def num_type(self) -> type[_NumT]: ...
 
     #: Default error messages.
     default_error_messages = {
@@ -1544,8 +1549,10 @@ class TimeDelta(Field[dt.timedelta]):
 _MappingT = typing.TypeVar("_MappingT", bound=_Mapping)
 
 
-class Mapping(Field[_MappingT]):
-    """An abstract class for objects with key-value pairs. This class should not be used within schemas.
+class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
+    """Abstract base class for objects with key-value pairs.
+
+    Use `Dict <marshmallow.fields.Dict>` within schemas.
 
     :param keys: A field class or instance for dict keys.
     :param values: A field class or instance for dict values.
@@ -1561,7 +1568,9 @@ class Mapping(Field[_MappingT]):
         Use `Dict <marshmallow.fields.Dict>` instead.
     """
 
-    mapping_type: type[_MappingT]
+    @property
+    @abc.abstractmethod
+    def mapping_type(self) -> type[_MappingT]: ...
 
     #: Default error messages.
     default_error_messages = {"invalid": "Not a valid mapping type."}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -27,6 +27,31 @@ def test_field_aliases(alias, field):
     assert alias is field
 
 
+class TestAbstractBaseFields:
+    def test_number_cannot_be_instantiated(self):
+        with pytest.raises(TypeError, match="num_type"):
+            fields.Number()
+
+    def test_mapping_cannot_be_instantiated(self):
+        with pytest.raises(TypeError, match="mapping_type"):
+            fields.Mapping()
+
+    # Ensure that typecheckers don't error when overriding abstract properties with class attributes
+    def test_custom_number_subclass(self):
+        class MyInt(fields.Number[int]):
+            num_type = int
+
+        field = MyInt()
+        assert field.num_type is int
+
+    def test_custom_mapping_subclass(self):
+        class MyDict(fields.Mapping[dict]):
+            mapping_type = dict
+
+        field = MyDict()
+        assert field.mapping_type is dict
+
+
 class TestField:
     def test_repr(self):
         default = "œ∑´"  # noqa: RUF001

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -30,11 +30,11 @@ def test_field_aliases(alias, field):
 class TestAbstractBaseFields:
     def test_number_cannot_be_instantiated(self):
         with pytest.raises(TypeError, match="num_type"):
-            fields.Number()
+            fields.Number()  # type: ignore[abstract]
 
     def test_mapping_cannot_be_instantiated(self):
         with pytest.raises(TypeError, match="mapping_type"):
-            fields.Mapping()
+            fields.Mapping()  # type: ignore[abstract]
 
     # Ensure that typecheckers don't error when overriding abstract properties with class attributes
     def test_custom_number_subclass(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -890,7 +890,7 @@ class TestFieldSerialization:
             id = fields.Int()
 
         with pytest.raises(ValueError):
-            fields.Tuple(["string"])  # type: ignore[arg-type]
+            fields.Tuple(["string"])  # type: ignore[list-item]
         with pytest.raises(ValueError):
             fields.Tuple(fields.String)  # type: ignore[arg-type]
         expected_msg = (
@@ -898,7 +898,7 @@ class TestFieldSerialization:
             "instances of marshmallow.fields.Field."
         )
         with pytest.raises(ValueError, match=expected_msg):
-            fields.Tuple([ASchema])  # type: ignore[arg-type]
+            fields.Tuple([ASchema])  # type: ignore[list-item]
 
     def test_serialize_does_not_apply_validators(self, user):
         field = fields.Raw(validate=lambda x: False)


### PR DESCRIPTION
closes https://github.com/marshmallow-code/marshmallow/issues/2924

This was the intented behavior, according to the [v2 upgrading guide](https://marshmallow.readthedocs.io/en/latest/upgrading.html#number-and-mapping-fields-as-base-classes):

> Instantiating [Number](https://marshmallow.readthedocs.io/en/latest/marshmallow.fields.html#marshmallow.fields.Number) or [Mapping](https://marshmallow.readthedocs.io/en/latest/marshmallow.fields.html#marshmallow.fields.Mapping) will raise a warning in marshmallow>=3.24 and an error in marshmallow 4.0.

With this change, misuse of Number and Mapping can be caught at runtime and by mypy (oddly, pyright and ty don't catch it):


```python
from marshmallow import fields, Schema


class MySchema(Schema):
    # mypy catches the misusage:
    #   error: Cannot instantiate abstract class "Number" with abstract attribute "num_type"  [abstract]
    #   error: Need type annotation for "n"  [var-annotated]
    #   error: Cannot instantiate abstract class "Mapping" with abstract attribute "mapping_type"  [abstract]
    #   error: Need type annotation for "m"  [var-annotated]
    # A RuntimeError is also raised:
    #   TypeError: Can't instantiate abstract class Number without an implementation for abstract method 'num_type'
    n = fields.Number()
    m = fields.Mapping()


# Custom subclasses are OK
class MyInt(fields.Number[int]):
    num_type = int


class MyDict(fields.Mapping[dict]):
    mapping_type = dict
```