### PR TITLE
Add IDN (Internationalized Domain Name) support to URL validator

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -195,6 +195,46 @@ class URL(Validator):
     def _format_error(self, value) -> str:
         return self.error.format(input=value)
 
+    @staticmethod
+    def _encode_idn(value: str) -> str:
+        """Encode internationalized domain names (IDN) to punycode.
+
+        Converts Unicode hostnames to their ASCII-compatible encoding
+        so that the existing ASCII-only regex can validate them.
+        """
+        try:
+            from urllib.parse import urlsplit, urlunsplit
+
+            try:
+                parsed = urlsplit(value)
+            except ValueError:
+                return value
+            if not parsed.hostname:
+                return value
+            # Only encode if hostname contains non-ASCII characters
+            try:
+                parsed.hostname.encode("ascii")
+                return value
+            except UnicodeEncodeError:
+                pass
+            encoded_hostname = parsed.hostname.encode("idna").decode("ascii")
+            # Reconstruct netloc with encoded hostname (preserve port)
+            if parsed.port:
+                netloc = f"{encoded_hostname}:{parsed.port}"
+            else:
+                netloc = encoded_hostname
+            # Preserve userinfo if present
+            if parsed.username:
+                userinfo = parsed.username
+                if parsed.password:
+                    userinfo += f":{parsed.password}"
+                netloc = f"{userinfo}@{netloc}"
+            return urlunsplit(
+                (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+            )
+        except (UnicodeError, UnicodeDecodeError):
+            return value
+
     def __call__(self, value: str) -> str:
         message = self._format_error(value)
         if not value:
@@ -211,12 +251,15 @@ class URL(Validator):
             relative=self.relative, absolute=self.absolute, require_tld=self.require_tld
         )
 
+        # Encode IDN hostnames to punycode for validation
+        validation_value = self._encode_idn(value)
+
         # Hostname is optional for file URLS. If absent it means `localhost`.
         # Fill it in for the validation if needed
-        if scheme == "file" and value.lower().startswith("file:///"):
-            matched = regex.search("file://localhost/" + value[8:])
+        if scheme == "file" and validation_value.lower().startswith("file:///"):
+            matched = regex.search("file://localhost/" + validation_value[8:])
         else:
-            matched = regex.search(value)
+            matched = regex.search(validation_value)
 
         if not matched:
             raise ValidationError(message)

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -6,6 +6,7 @@ import re
 import typing
 from abc import ABC, abstractmethod
 from operator import attrgetter
+from urllib.parse import urlsplit, urlunsplit
 
 from marshmallow.exceptions import ValidationError
 
@@ -203,37 +204,36 @@ class URL(Validator):
         so that the existing ASCII-only regex can validate them.
         """
         try:
-            from urllib.parse import urlsplit, urlunsplit
-
-            try:
-                parsed = urlsplit(value)
-            except ValueError:
-                return value
-            if not parsed.hostname:
-                return value
-            # Only encode if hostname contains non-ASCII characters
-            try:
-                parsed.hostname.encode("ascii")
-                return value
-            except UnicodeEncodeError:
-                pass
+            parsed = urlsplit(value)
+        except ValueError:
+            return value
+        if not parsed.hostname:
+            return value
+        # Only encode if hostname contains non-ASCII characters
+        try:
+            parsed.hostname.encode("ascii")
+        except UnicodeEncodeError:
+            pass
+        else:
+            return value
+        try:
             encoded_hostname = parsed.hostname.encode("idna").decode("ascii")
-            # Reconstruct netloc with encoded hostname (preserve port)
-            if parsed.port:
-                netloc = f"{encoded_hostname}:{parsed.port}"
-            else:
-                netloc = encoded_hostname
-            # Preserve userinfo if present
-            if parsed.username:
-                userinfo = parsed.username
-                if parsed.password:
-                    userinfo += f":{parsed.password}"
-                netloc = f"{userinfo}@{netloc}"
-            return urlunsplit(
-                (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
-            )
         except (UnicodeError, UnicodeDecodeError):
             return value
+        # Reconstruct netloc with encoded hostname (preserve port)
+        if parsed.port:
+            netloc = f"{encoded_hostname}:{parsed.port}"
+        else:
+            netloc = encoded_hostname
+        # Preserve userinfo if present
+        if parsed.username:
+            userinfo = parsed.username
+            if parsed.password:
+                userinfo += f":{parsed.password}"
+            netloc = f"{userinfo}@{netloc}"
+        return urlunsplit(
+            (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+        )
 
     def __call__(self, value: str) -> str:
         message = self._format_error(value)


### PR DESCRIPTION
Add support for Internationalized Domain Names (IDN) in the `URL` validator.

URLs with Unicode hostnames like `https://তৌহিদুর.বাংলা` and `https://münchen.de` are currently always rejected because the hostname regex only accepts ASCII characters.

The fix converts Unicode hostnames to punycode (IDNA encoding) before regex validation using Python's built-in `str.encode('idna')`. The original URL value is preserved and returned — only the validation step uses the encoded form.

All 1149 existing tests pass.

Fixes #2821