### PR TITLE
Add support for IDNs to validate.URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+(unreleased)
+------------
+
+Bug fixes:
+
+- `marshmallow.validate.URL` accepts Internationalized Domain Names (IDNs) (:issue:`2821`).
+  Thanks :user:`touhidurrr` for the report.
+
 4.2.3 (2026-03-25)
 ------------------
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -103,12 +103,24 @@ class URL(Validator):
         def _regex_generator(
             self, *, relative: bool, absolute: bool, require_tld: bool
         ) -> typing.Pattern:
+            unicode_letters = "\u00a1-\uffff"
             hostname_variants = [
-                # a normal domain name, expressed in [A-Z0-9] chars with hyphens allowed only in the middle
+                # a normal domain name, expressed in [A-Z0-9] chars (plus unicode letters)
+                # with hyphens allowed only in the middle
                 # note that the regex will be compiled with IGNORECASE, so these are upper and lowercase chars
                 (
-                    r"(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+"
-                    r"(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)"
+                    r"(?:[A-Z0-9"
+                    + unicode_letters
+                    + r"](?:[A-Z0-9"
+                    + unicode_letters
+                    + r"-]{0,61}[A-Z0-9"
+                    + unicode_letters
+                    + r"])?\.)+"
+                    r"(?:[A-Z"
+                    + unicode_letters
+                    + r"]{2,6}\.?|[A-Z0-9"
+                    + unicode_letters
+                    + r"-]{2,}\.?)"
                 ),
                 # or the special string 'localhost'
                 r"localhost",
@@ -119,7 +131,15 @@ class URL(Validator):
             ]
             if not require_tld:
                 # allow dotless hostnames
-                hostname_variants.append(r"(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)")
+                hostname_variants.append(
+                    r"(?:[A-Z0-9"
+                    + unicode_letters
+                    + r"](?:[A-Z0-9"
+                    + unicode_letters
+                    + r"-]{0,61}[A-Z0-9"
+                    + unicode_letters
+                    + r"])?\.?)"
+                )
 
             absolute_part = "".join(
                 (

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -293,6 +293,35 @@ def test_url_rejects_invalid_relative_usage():
 
 
 @pytest.mark.parametrize(
+    "valid_url",
+    [
+        "https://তৌহিদুর.বাংলা",
+        "https://münchen.de",
+        "https://例え.jp/path",
+        "http://مثال.إختبار",
+        "https://üñîçödé.com/path?q=1#frag",
+        "http://www.اختبار.com:8080/path",
+    ],
+)
+def test_url_idn_valid(valid_url):
+    validator = validate.URL()
+    assert validator(valid_url) == valid_url
+
+
+@pytest.mark.parametrize(
+    "invalid_url",
+    [
+        "münchen.de",
+        "তৌহিদুর.বাংলা",
+    ],
+)
+def test_url_idn_invalid(invalid_url):
+    validator = validate.URL()
+    with pytest.raises(ValidationError):
+        validator(invalid_url)
+
+
+@pytest.mark.parametrize(
     "valid_email",
     [
         "niceandsimple@example.com",


### PR DESCRIPTION
closes https://github.com/marshmallow-code/marshmallow/issues/2821
alternative to https://github.com/marshmallow-code/marshmallow/pull/2927

this adapts [Django's approach](https://github.com/django/django/blob/f6167b8bc881babd19b67c004e8f37954afc192e/django/core/validators.py#L71-L85) of accepting unicode chars in its regex 