### PR TITLE
fix: return default for out-of-range int key in get_value

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,11 +120,15 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,19 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_out_of_range_int_returns_default():
+    # Out-of-range integer index on a list should return default, not raise TypeError
+    lst = [0, 1, 2, 3]
+    assert utils.get_value(lst, 999, default=42) == 42
+
+    # Missing integer key in a dict with integer keys should return default
+    d = {1: "a", 2: "b"}
+    assert utils.get_value(d, 99, default="z") == "z"
+
+    # Nested list with out-of-range index
+    assert utils.get_value([[1, 2], [3, 4]], 5, default=None) is None
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893.

## Problem

When an integer `key` is passed to `utils.get_value` and `obj[key]`
raises an exception (e.g. `IndexError` for a list, `KeyError` for a
dict with integer keys), the code falls back to
`getattr(obj, key, default)`. However, `getattr()` requires the
attribute name to be a string, so it raises:

```
TypeError: getattr(): attribute name must be string
```

## Fix

In `_get_value_for_key`, guard the `getattr` fallback with
`isinstance(key, str)`. When the key is not a string, return `default`
directly instead of calling `getattr`.

## Examples (now work correctly)

```python
# Out-of-range integer index → returns default
utils.get_value([0, 1, 2], 999, default=42)   # 42

# Missing integer key in dict → returns default
utils.get_value({1: "a"}, 99, default="z")     # "z"
```

Made with [Cursor](https://cursor.com)