### PR TITLE
Fix Unreachable Warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Bug fixes:
 
 - `marshmallow.validate.URL` accepts Internationalized Domain Names (IDNs) (:issue:`2821`).
   Thanks :user:`touhidurrr` for the report.
+- Typing: Fix typing of ``netsted`` in `marshmallow.fields.Nested` (:pr:`2935`).
 
 4.2.3 (2026-03-25)
 ------------------
@@ -26,7 +27,7 @@ Bug fixes:
   Thanks :user:`bysiber` for the PR.
 - `marshmallow.fields.DateTime` with ``format="timestamp_ms"`` properly
   rejects bool values (:pr:`2904`). Thanks :user:`bysiber` for the PR.
-- Fix typing of ``error_essages`` argument to `marshmallow.fields.Field` (:pr:`1636`).
+- Fix typing of ``error_messages`` argument to `marshmallow.fields.Field` (:pr:`1636`).
   Thanks :user:`repole` for reporting and :user:`dhruvildarji` for the PR.
 
 Other changes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ ignore = [
 [tool.mypy]
 files = ["src", "tests", "examples"]
 ignore_missing_imports = true
-warn_unreachable = false
+warn_unreachable = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 no_implicit_optional = true

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -500,7 +500,7 @@ class Nested(Field):
             | SchemaMeta
             | str
             | dict[str, Field]
-            | typing.Callable[[], Schema | SchemaMeta | dict[str, Field]]
+            | typing.Callable[[], Schema | SchemaMeta | str | dict[str, Field]]
         ),
         *,
         only: types.StrSequenceOrSet | None = None,

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -529,10 +529,10 @@ class Nested(Field):
         """The nested Schema object."""
         if not self._schema:
             # defer the import of `marshmallow.schema` to avoid circular imports
-            from marshmallow.schema import Schema  # noqa: PLC0415
+            from marshmallow.schema import Schema, SchemaMeta  # noqa: PLC0415
 
             nested = self.nested
-            if callable(nested) and not isinstance(nested, type):
+            if callable(nested) and not isinstance(nested, SchemaMeta):
                 nested = nested()
 
             if isinstance(nested, dict):

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -528,12 +528,12 @@ class Nested(Field):
     def schema(self) -> Schema:
         """The nested Schema object."""
         if not self._schema:
-            if callable(self.nested) and not isinstance(self.nested, type):
-                nested = self.nested()
-            else:
-                nested = typing.cast("Schema", self.nested)
             # defer the import of `marshmallow.schema` to avoid circular imports
             from marshmallow.schema import Schema  # noqa: PLC0415
+
+            nested = self.nested
+            if callable(nested) and not isinstance(nested, type):
+                nested = nested()
 
             if isinstance(nested, dict):
                 nested = Schema.from_dict(nested)


### PR DESCRIPTION
Replace an incorrect type cast with explicit type narrowing (to work around a limitation of mypy branch inference). See https://github.com/marshmallow-code/marshmallow/issues/2879#issuecomment-4172618420

Fixes #2879