### PR TITLE
Avoid infinite recursion in nesting docs

### DIFF
--- a/docs/nesting.rst
+++ b/docs/nesting.rst
@@ -274,8 +274,8 @@ If the object to be marshalled has a relationship to an object of the same type,
         name = fields.String()
         email = fields.Email()
         # Use the 'exclude' argument to avoid infinite recursion
-        employer = fields.Nested(lambda: UserSchema(exclude=("employer",)))
-        friends = fields.List(fields.Nested(lambda: UserSchema()))
+        employer = fields.Nested(lambda: UserSchema(exclude=("employer", "friends")))
+        friends = fields.List(fields.Nested(lambda: UserSchema("employer", "friends")))
 
 
     user = User("Steve", "steve@example.com")


### PR DESCRIPTION
Fixes #2851 

Exclude both `employer` and `friends` relationships to avoid infinite recursion