### PR TITLE
Security: Thread-unsafe global mutable class registry

### DIFF
--- a/src/marshmallow/class_registry.py
+++ b/src/marshmallow/class_registry.py
@@ -11,6 +11,7 @@ class:`fields.Nested <marshmallow.fields.Nested>`.
 
 from __future__ import annotations
 
+import threading
 import typing
 
 from marshmallow.exceptions import RegistryError
@@ -25,6 +26,7 @@ if typing.TYPE_CHECKING:
 #   <module_path_to_class>: <list of class objects>
 # }
 _registry = {}  # type: dict[str, list[SchemaType]]
+_registry_lock = threading.Lock()
 
 
 def register(classname: str, cls: SchemaType) -> None:
@@ -51,22 +53,23 @@ def register(classname: str, cls: SchemaType) -> None:
     # Full module path to the class
     # e.g. user.schemas.UserSchema
     fullpath = f"{module}.{classname}"
-    # If the class is already registered; need to check if the entries are
-    # in the same module as cls to avoid having multiple instances of the same
-    # class in the registry
-    if classname in _registry and not any(
-        each.__module__ == module for each in _registry[classname]
-    ):
-        _registry[classname].append(cls)
-    elif classname not in _registry:
-        _registry[classname] = [cls]
+    with _registry_lock:
+        # If the class is already registered; need to check if the entries are
+        # in the same module as cls to avoid having multiple instances of the same
+        # class in the registry
+        if classname in _registry and not any(
+            each.__module__ == module for each in _registry[classname]
+        ):
+            _registry[classname].append(cls)
+        elif classname not in _registry:
+            _registry[classname] = [cls]
 
-    # Also register the full path
-    if fullpath not in _registry:
-        _registry.setdefault(fullpath, []).append(cls)
-    else:
-        # If fullpath does exist, replace existing entry
-        _registry[fullpath] = [cls]
+        # Also register the full path
+        if fullpath not in _registry:
+            _registry.setdefault(fullpath, []).append(cls)
+        else:
+            # If fullpath does exist, replace existing entry
+            _registry[fullpath] = [cls]
 
 
 @typing.overload
@@ -85,19 +88,20 @@ def get_class(classname: str, *, all: bool = False) -> list[SchemaType] | Schema
     :raises: `marshmallow.exceptions.RegistryError` if the class cannot be found
         or if there are multiple entries for the given class name.
     """
-    try:
-        classes = _registry[classname]
-    except KeyError as error:
-        raise RegistryError(
-            f"Class with name {classname!r} was not found. You may need "
-            "to import the class."
-        ) from error
-    if len(classes) > 1:
-        if all:
-            return _registry[classname]
-        raise RegistryError(
-            f"Multiple classes with name {classname!r} "
-            "were found. Please use the full, "
-            "module-qualified path."
-        )
-    return _registry[classname][0]
+    with _registry_lock:
+        try:
+            classes = _registry[classname]
+        except KeyError as error:
+            raise RegistryError(
+                f"Class with name {classname!r} was not found. You may need "
+                "to import the class."
+            ) from error
+        if len(classes) > 1:
+            if all:
+                return _registry[classname]
+            raise RegistryError(
+                f"Multiple classes with name {classname!r} "
+                "were found. Please use the full, "
+                "module-qualified path."
+            )
+        return _registry[classname][0]


### PR DESCRIPTION
## Problem

The `_registry` module-level dictionary in `class_registry.py` is modified by the `register()` function without any thread synchronization (e.g., locks). The `register()` function performs check-then-act operations (e.g., `if classname in _registry ... _registry[classname].append(cls)`) that are not atomic. In multi-threaded applications where schemas are defined dynamically, this can lead to race conditions, lost registry entries, or inconsistent state.

**Severity**: `low`
**File**: `src/marshmallow/class_registry.py`

## Solution

Add a threading.Lock to protect read-modify-write operations on `_registry`, or document that schema class registration must happen at import time before spawning threads.

## Changes

- `src/marshmallow/class_registry.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
