### PR TITLE
fix: return default in get_value when int key causes TypeError

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -125,7 +125,10 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            return default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):


### PR DESCRIPTION
## Problem

Fixes #2893

When an out-of-range `int` index is used with `get_value`, `obj[key]` raises `IndexError`. The fallback `getattr(obj, key, default)` then raises `TypeError` because `getattr` does not accept integer attribute names.

## Reproduction

```python
from marshmallow import utils
lst = [0, 1, 2, 3, 4, 5]
utils.get_value(lst, 999, default=3)  # TypeError: attribute name must be string
```

## Fix

Wrap the `getattr` fallback in a try/except for `TypeError` and return `default` instead. This preserves all existing behavior while correctly handling integer keys on sequence types.

## Testing

- All 20 existing tests in `tests/test_utils.py` pass
- Verified the three cases from the issue report all return the expected default value