### PR TITLE
Fix: ensure metadata is defensively copied in Field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -230,7 +230,7 @@ class Field(typing.Generic[_InternalT]):
         self.required = required
 
         metadata = metadata or {}
-        self.metadata = metadata
+        self.metadata = dict(metadata)
         # Collect default error message from self and parent classes
         messages: types.ErrorMessages = {}
         for cls in reversed(self.__class__.__mro__):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -245,7 +245,37 @@ class TestMetadata:
             metadata={"description": "foo", "widget": "select"},
         )
         assert field.metadata == {"description": "foo", "widget": "select"}
+    def test_metadata_is_defensively_copied(self):
+        original_meta = {"key1": "value1", "key2": "value2"}
+        field = fields.Field(metadata=original_meta)
 
+        original_meta["key1"] = "modified_value"
+        original_meta["key3"] = "new_key"
+
+        assert field.metadata.get("key1") == "value1"
+        assert "key3" not in field.metadata
+
+    def test_empty_metadata_is_defensively_copied(self):
+        empty_meta = {}
+        field = fields.Field(metadata=empty_meta)
+
+        empty_meta["injected"] = "value"
+
+        assert "injected" not in field.metadata
+
+    def test_metadata_defensive_copy_with_other_params(self):
+        original_meta = {"description": "test field"}
+        field = fields.Field(
+            metadata=original_meta,
+            required=True,
+            data_key="test_key",
+        )
+
+        original_meta["description"] = "modified"
+        original_meta["extra"] = "added"
+
+        assert field.metadata.get("description") == "test field"
+        assert "extra" not in field.metadata
 
 class TestErrorMessages:
     class MyField(fields.Field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -245,6 +245,7 @@ class TestMetadata:
             metadata={"description": "foo", "widget": "select"},
         )
         assert field.metadata == {"description": "foo", "widget": "select"}
+
     def test_metadata_is_defensively_copied(self):
         original_meta = {"key1": "value1", "key2": "value2"}
         field = fields.Field(metadata=original_meta)
@@ -276,6 +277,7 @@ class TestMetadata:
 
         assert field.metadata.get("description") == "test field"
         assert "extra" not in field.metadata
+
 
 class TestErrorMessages:
     class MyField(fields.Field):


### PR DESCRIPTION
Description: This PR ensures that metadata passed to a Field is defensively copied. Previously, it was assigned by reference, causing external mutations to the original dictionary to affect the field's metadata (a regression from #2701).

Fixes #2949