### PR TITLE
fix(utils): handle TypeError from getattr in get_value for non-string keys

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -125,7 +125,10 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            return default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):


### PR DESCRIPTION
Fixes #2893

When `obj[key]` raises `IndexError` or `TypeError` for an out-of-range int key, the fallback to `getattr(obj, key, default)` also raises `TypeError` because attribute names must be strings. Wrap the `getattr` call in a try/except to catch this and return the default value instead.