### PR TITLE
fix: utils.get_value return default for out-of-range int keys

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -124,7 +124,15 @@ def _get_value_for_key(obj, key, default):
 
     try:
         return obj[key]
-    except (KeyError, IndexError, TypeError, AttributeError):
+    except (KeyError, IndexError):
+        try:
+            return getattr(obj, key, default)
+        except TypeError:
+            # getattr(obj, int_key, default) fails when key is int and
+            # obj has no such attribute, because attribute name must be string.
+            return default
+    except TypeError:
+        # e.g. obj doesn't support indexing at all, or key type is invalid
         return getattr(obj, key, default)
 
 


### PR DESCRIPTION
Fixes marshmallow-code/marshmallow#2893

Handle TypeError from getattr when key is an int and obj has no such attribute (e.g., list with out-of-range index, dict with missing int key).