### PR TITLE
Refactor: don't pass attr, obj, data to fields (de)serialize methods

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2019,8 +2019,8 @@ class Method(Field):
     """A field that takes the value returned by a `Schema <marshmallow.Schema>` method.
 
     :param serialize: The name of the Schema method from which
-        to retrieve the value. The method must take an argument ``obj``
-        (in addition to self) that is the object to be serialized.
+        to retrieve the value. The method must take an argument ``value``
+        (in addition to self) that is the value to be serialized.
     :param deserialize: Optional name of the Schema method for deserializing
         a value. The method must take a single argument ``value``, which is the
         value to deserialize.
@@ -2028,8 +2028,6 @@ class Method(Field):
     .. versionchanged:: 3.0.0
         Removed ``method_name`` parameter.
     """
-
-    _CHECK_ATTRIBUTE = False
 
     def __init__(
         self,
@@ -2061,7 +2059,7 @@ class Method(Field):
 
     def _serialize(self, value, attr, obj, **kwargs):
         if self._serialize_method is not None:
-            return self._serialize_method(obj)
+            return self._serialize_method(value)
         return missing_
 
     def _deserialize(self, value, attr, data, **kwargs):
@@ -2074,8 +2072,8 @@ class Function(Field):
     """A field that takes the value returned by a function.
 
     :param serialize: A callable from which to retrieve the value.
-        The function must take a single argument ``obj`` which is the object
-        to be serialized.
+        The function must take a single argument ``value`` which is the
+        value to be serialized.
         If no callable is provided then the ``load_only`` flag will be set
         to True.
     :param deserialize: A callable from which to retrieve the value.
@@ -2090,8 +2088,6 @@ class Function(Field):
     .. versionchanged:: 4.0.0
         Don't pass context to serialization and deserialization functions.
     """
-
-    _CHECK_ATTRIBUTE = False
 
     def __init__(
         self,
@@ -2115,7 +2111,7 @@ class Function(Field):
         self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
 
     def _serialize(self, value, attr, obj, **kwargs):
-        return self.serialize_func(obj)
+        return self.serialize_func(value)
 
     def _deserialize(self, value, attr, data, **kwargs):
         if self.deserialize_func:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -102,12 +102,8 @@ class _BaseFieldKwargs(typing.TypedDict, total=False):
     dump_only: bool
     error_messages: types.ErrorMessages | None
     metadata: typing.Mapping[str, typing.Any] | None
-    dump_getter: (
-        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-    )
-    load_getter: (
-        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-    )
+    dump_getter: typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+    load_getter: typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
 
 
 def _resolve_field_instance(cls_or_instance: Field | type[Field]) -> Field:
@@ -335,7 +331,6 @@ class Field(typing.Generic[_InternalT]):
 
     # If value is None, None may be returned
     @typing.overload
-
     def deserialize(self, value: None, **kwargs) -> _InternalT | None: ...
 
     # If value is not None, internal type is returned

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -320,24 +320,14 @@ class Field(typing.Generic[_InternalT]):
         if value is None and not self.allow_none:
             raise self.make_error("null")
 
-    def serialize(
-        self,
-        attr: str,
-        obj: typing.Any,
-        accessor: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-        ) = None,
-        **kwargs,
-    ):
-        """Pulls the value for the given key from the object, applies the
-        field's formatting and returns the result.
+    def serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
+        """Applies the field's formatting to ``value`` and returns the result.
 
-        :param attr: The attribute/key to get from the object.
-        :param obj: The object to access the attribute/key from.
-        :param accessor: Function used to access values from ``obj``.
+        :param value: The value to serialize.
+        :param attr: The attribute/key name (used for error context).
+        :param obj: The parent object (used by Nested fields).
         :param kwargs: Field-specific keyword arguments.
         """
-        value = self.get_value(obj, attr, accessor=accessor)
         if value is missing_:
             default = self.dump_default
             value = default() if callable(default) else default

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -102,6 +102,12 @@ class _BaseFieldKwargs(typing.TypedDict, total=False):
     dump_only: bool
     error_messages: types.ErrorMessages | None
     metadata: typing.Mapping[str, typing.Any] | None
+    dump_getter: (
+        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+    )
+    load_getter: (
+        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+    )
 
 
 def _resolve_field_instance(cls_or_instance: Field | type[Field]) -> Field:
@@ -209,12 +215,20 @@ class Field(typing.Generic[_InternalT]):
         dump_only: bool = False,
         error_messages: types.ErrorMessages | None = None,
         metadata: typing.Mapping[str, typing.Any] | None = None,
+        dump_getter: (
+            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+        ) = None,
+        load_getter: (
+            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+        ) = None,
     ) -> None:
         self.dump_default = dump_default
         self.load_default = load_default
 
         self.attribute = attribute
         self.data_key = data_key
+        self.dump_getter = dump_getter
+        self.load_getter = load_getter
         self.validate = validate
         self.validators = self._normalize_processors(validate, param="validate")
         self.pre_load = self._normalize_processors(pre_load, param="pre_load")
@@ -271,7 +285,7 @@ class Field(typing.Generic[_InternalT]):
         :param accessor: A callable used to retrieve the value of `attr` from
             the object `obj`. Defaults to `marshmallow.utils.get_value`.
         """
-        accessor_func = accessor or utils.get_value
+        accessor_func = self.dump_getter or accessor or utils.get_value
         check_key = attr if self.attribute is None else self.attribute
         return accessor_func(obj, check_key, default)
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -181,11 +181,6 @@ class Field(typing.Generic[_InternalT]):
         Add ``pre_load`` and ``post_load``.
     """
 
-    # Some fields, such as Method fields and Function fields, are not expected
-    #  to exist as attributes on the objects to serialize. Set this to False
-    #  for those fields
-    _CHECK_ATTRIBUTE = True
-
     #: Default error messages for various kinds of errors. The keys in this dictionary
     #: are passed to `Field.make_error`. The values are error messages passed to
     #: :exc:`marshmallow.exceptions.ValidationError`.
@@ -342,15 +337,12 @@ class Field(typing.Generic[_InternalT]):
         :param accessor: Function used to access values from ``obj``.
         :param kwargs: Field-specific keyword arguments.
         """
-        if self._CHECK_ATTRIBUTE:
-            value = self.get_value(obj, attr, accessor=accessor)
-            if value is missing_:
-                default = self.dump_default
-                value = default() if callable(default) else default
-            if value is missing_:
-                return value
-        else:
-            value = None
+        value = self.get_value(obj, attr, accessor=accessor)
+        if value is missing_:
+            default = self.dump_default
+            value = default() if callable(default) else default
+        if value is missing_:
+            return value
         return self._serialize(value, attr, obj, **kwargs)
 
     # If value is None, None may be returned

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -260,26 +260,6 @@ class Field(typing.Generic[_InternalT]):
     def __deepcopy__(self, memo):
         return copy.copy(self)
 
-    def get_value(
-        self,
-        obj: typing.Any,
-        attr: str,
-        accessor: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-        ) = None,
-        default: typing.Any = missing_,
-    ) -> _InternalT:
-        """Return the value for a given key from an object.
-
-        :param obj: The object to get the value from.
-        :param attr: The attribute/key in `obj` to get the value from.
-        :param accessor: A callable used to retrieve the value of `attr` from
-            the object `obj`. Defaults to `marshmallow.utils.get_value`.
-        """
-        accessor_func = self.dump_getter or accessor or utils.get_value
-        check_key = attr if self.attribute is None else self.attribute
-        return accessor_func(obj, check_key, default)
-
     def _validate(self, value: typing.Any) -> None:
         """Perform validation on ``value``. Raise a :exc:`ValidationError` if validation
         does not succeed.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -320,12 +320,10 @@ class Field(typing.Generic[_InternalT]):
         if value is None and not self.allow_none:
             raise self.make_error("null")
 
-    def serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
+    def serialize(self, value: typing.Any, **kwargs):
         """Applies the field's formatting to ``value`` and returns the result.
 
         :param value: The value to serialize.
-        :param attr: The attribute/key name (used for error context).
-        :param obj: The parent object (used by Nested fields).
         :param kwargs: Field-specific keyword arguments.
         """
         if value is missing_:
@@ -333,40 +331,21 @@ class Field(typing.Generic[_InternalT]):
             value = default() if callable(default) else default
         if value is missing_:
             return value
-        return self._serialize(value, attr, obj, **kwargs)
+        return self._serialize(value, **kwargs)
 
     # If value is None, None may be returned
     @typing.overload
-    def deserialize(
-        self,
-        value: None,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> _InternalT | None: ...
+
+    def deserialize(self, value: None, **kwargs) -> _InternalT | None: ...
 
     # If value is not None, internal type is returned
     @typing.overload
-    def deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> _InternalT: ...
+    def deserialize(self, value: typing.Any, **kwargs) -> _InternalT: ...
 
-    def deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> _InternalT | None:
+    def deserialize(self, value: typing.Any, **kwargs) -> _InternalT | None:
         """Deserialize ``value``.
 
         :param value: The value to deserialize.
-        :param attr: The attribute/key in `data` to deserialize.
-        :param data: The raw input data passed to `Schema.load <marshmallow.Schema.load>`.
         :param kwargs: Field-specific keyword arguments.
         :raise ValidationError: If an invalid value is passed or if a required value
             is missing.
@@ -385,7 +364,7 @@ class Field(typing.Generic[_InternalT]):
         if self.allow_none and value is None:
             return None
 
-        output = self._deserialize(value, attr, data, **kwargs)
+        output = self._deserialize(value, **kwargs)
         # Apply validators
         self._validate(output)
 
@@ -409,40 +388,28 @@ class Field(typing.Generic[_InternalT]):
             self.parent.root if isinstance(self.parent, Field) else self.parent
         )
 
-    def _serialize(
-        self, value: _InternalT | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> typing.Any:
+    def _serialize(self, value: _InternalT | None, **kwargs) -> typing.Any:
         """Serializes ``value`` to a basic Python datatype. Noop by default.
         Concrete :class:`Field` classes should implement this method.
 
         Example: ::
 
             class TitleCase(Field):
-                def _serialize(self, value, attr, obj, **kwargs):
+                def _serialize(self, value, **kwargs):
                     if not value:
                         return ""
                     return str(value).title()
 
         :param value: The value to be serialized.
-        :param attr: The attribute or key on the object to be serialized.
-        :param obj: The object the value was pulled from.
         :param kwargs: Field-specific keyword arguments.
         :return: The serialized value
         """
         return value
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> _InternalT:
+    def _deserialize(self, value: typing.Any, **kwargs) -> _InternalT:
         """Deserialize value. Concrete :class:`Field` classes should implement this method.
 
         :param value: The value to be deserialized.
-        :param attr: The attribute/key in `data` to be deserialized.
-        :param data: The raw input data passed to the `Schema.load <marshmallow.Schema.load>`.
         :param kwargs: Field-specific keyword arguments.
         :raise ValidationError: In case of formatting or validation failure.
         :return: The deserialized value.
@@ -616,7 +583,7 @@ class Nested(Field):
             if field.startswith(nested_field)
         ]
 
-    def _serialize(self, nested_obj, attr, obj, **kwargs):
+    def _serialize(self, nested_obj, **kwargs):
         # Load up the schema first. This allows a RegistryError to be raised
         # if an invalid schema name was passed
         schema = self.schema
@@ -646,8 +613,6 @@ class Nested(Field):
     def _deserialize(
         self,
         value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
         partial: bool | types.StrSequenceOrSet | None = None,  # noqa: FBT001
         **kwargs,
     ):
@@ -708,15 +673,15 @@ class Pluck(Nested):
         only_field = self.schema.fields[self.field_name]
         return only_field.data_key or self.field_name
 
-    def _serialize(self, nested_obj, attr, obj, **kwargs):
-        ret = super()._serialize(nested_obj, attr, obj, **kwargs)
+    def _serialize(self, nested_obj, **kwargs):
+        ret = super()._serialize(nested_obj, **kwargs)
         if ret is None:
             return None
         if self.many:
             return utils.pluck(ret, key=self._field_data_key)
         return ret[self._field_data_key]
 
-    def _deserialize(self, value, attr, data, partial=None, **kwargs):
+    def _deserialize(self, value, partial=None, **kwargs):
         self._test_collection(value)
         if self.many:
             value = [{self._field_data_key: v} for v in value]
@@ -768,12 +733,12 @@ class List(Field[list[_InternalT | None]]):
             self.inner.only = self.only
             self.inner.exclude = self.exclude
 
-    def _serialize(self, value, attr, obj, **kwargs) -> list[_InternalT] | None:
+    def _serialize(self, value, **kwargs) -> list[_InternalT] | None:
         if value is None:
             return None
-        return [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
+        return [self.inner._serialize(each, **kwargs) for each in value]
 
-    def _deserialize(self, value, attr, data, **kwargs) -> list[_InternalT | None]:
+    def _deserialize(self, value, **kwargs) -> list[_InternalT | None]:
         if not utils.is_collection(value):
             raise self.make_error("invalid")
 
@@ -848,24 +813,16 @@ class Tuple(Field[tuple]):
 
         self.tuple_fields = new_tuple_fields
 
-    def _serialize(
-        self, value: tuple | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> tuple | None:
+    def _serialize(self, value: tuple | None, **kwargs) -> tuple | None:
         if value is None:
             return None
 
         return tuple(
-            field._serialize(each, attr, obj, **kwargs)
+            field._serialize(each, **kwargs)
             for field, each in zip(self.tuple_fields, value, strict=True)
         )
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> tuple:
+    def _deserialize(self, value: typing.Any, **kwargs) -> tuple:
         if not utils.is_sequence_but_not_string(value):
             raise self.make_error("invalid")
 
@@ -899,12 +856,12 @@ class String(Field[str]):
         "invalid_utf8": "Not a valid utf-8 string.",
     }
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         return utils.ensure_text_type(value)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> str:
+    def _deserialize(self, value, **kwargs) -> str:
         if not isinstance(value, (str, bytes)):
             raise self.make_error("invalid")
         try:
@@ -930,12 +887,12 @@ class UUID(Field[uuid.UUID]):
         except (ValueError, AttributeError, TypeError) as error:
             raise self.make_error("invalid_uuid") from error
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         return str(value)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> uuid.UUID:
+    def _deserialize(self, value, **kwargs) -> uuid.UUID:
         return self._validated(value)
 
 
@@ -989,14 +946,14 @@ class Number(Field[_NumT], metaclass=abc.ABCMeta):
     def _to_string(self, value: _NumT) -> str:
         return str(value)
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | _NumT | None:
+    def _serialize(self, value, **kwargs) -> str | _NumT | None:
         """Return a string if `self.as_string=True`, otherwise return this field's `num_type`."""
         if value is None:
             return None
         ret: _NumT = self._format_num(value)
         return self._to_string(ret) if self.as_string else ret
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _NumT:
+    def _deserialize(self, value, **kwargs) -> _NumT:
         return self._validated(value)
 
 
@@ -1217,13 +1174,7 @@ class Boolean(Field[bool]):
         if falsy is not None:
             self.falsy = set(falsy)
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> bool:
+    def _deserialize(self, value: typing.Any, **kwargs) -> bool:
         if not self.truthy:
             return bool(value)
         try:
@@ -1274,7 +1225,7 @@ class _TemporalField(Field[_D], metaclass=abc.ABCMeta):
             or self.DEFAULT_FORMAT
         )
 
-    def _serialize(self, value: _D | None, attr, obj, **kwargs) -> str | float | None:
+    def _serialize(self, value: _D | None, **kwargs) -> str | float | None:
         if value is None:
             return None
         data_format = self.format or self.DEFAULT_FORMAT
@@ -1283,7 +1234,7 @@ class _TemporalField(Field[_D], metaclass=abc.ABCMeta):
             return format_func(value)
         return value.strftime(data_format)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _D:
+    def _deserialize(self, value, **kwargs) -> _D:
         internal_type: type[_D] = getattr(dt, self.OBJ_TYPE)
         if isinstance(value, internal_type):
             return value
@@ -1373,8 +1324,8 @@ class NaiveDateTime(DateTime):
         super().__init__(format=format, **kwargs)
         self.timezone = timezone
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.datetime:
-        ret = super()._deserialize(value, attr, data, **kwargs)
+    def _deserialize(self, value, **kwargs) -> dt.datetime:
+        ret = super()._deserialize(value, **kwargs)
         if utils.is_aware(ret):
             if self.timezone is None:
                 raise self.make_error(
@@ -1410,8 +1361,8 @@ class AwareDateTime(DateTime):
         super().__init__(format=format, **kwargs)
         self.default_timezone = default_timezone
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.datetime:
-        ret = super()._deserialize(value, attr, data, **kwargs)
+    def _deserialize(self, value, **kwargs) -> dt.datetime:
+        ret = super()._deserialize(value, **kwargs)
         if not utils.is_aware(ret):
             if self.default_timezone is None:
                 raise self.make_error(
@@ -1556,7 +1507,7 @@ class TimeDelta(Field[dt.timedelta]):
         self.precision = precision
         super().__init__(**kwargs)
 
-    def _serialize(self, value, attr, obj, **kwargs) -> float | None:
+    def _serialize(self, value, **kwargs) -> float | None:
         if value is None:
             return None
 
@@ -1565,7 +1516,7 @@ class TimeDelta(Field[dt.timedelta]):
         microseconds_per_unit: int = self._unit_to_microseconds_mapping[self.precision]
         return microseconds / microseconds_per_unit
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.timedelta:
+    def _deserialize(self, value, **kwargs) -> dt.timedelta:
         if isinstance(value, dt.timedelta):
             return value
         try:
@@ -1655,7 +1606,7 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
             self.key_field = copy.deepcopy(self.key_field)
             self.key_field._bind_to_schema(field_name, self)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if value is None:
             return None
         if not self.value_field and not self.key_field:
@@ -1665,9 +1616,7 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
         if self.key_field is None:
             keys = {k: k for k in value}
         else:
-            keys = {
-                k: self.key_field._serialize(k, None, None, **kwargs) for k in value
-            }
+            keys = {k: self.key_field._serialize(k, **kwargs) for k in value}
 
         # Serialize values
         result = self.mapping_type()
@@ -1677,11 +1626,11 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
                     result[keys[k]] = v
         else:
             for k, v in value.items():
-                result[keys[k]] = self.value_field._serialize(v, None, None, **kwargs)
+                result[keys[k]] = self.value_field._serialize(v, **kwargs)
 
         return result
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if not isinstance(value, _Mapping):
             raise self.make_error("invalid")
         if not self.value_field and not self.key_field:
@@ -1817,7 +1766,7 @@ class IP(Field[ipaddress.IPv4Address | ipaddress.IPv6Address]):
         super().__init__(**kwargs)
         self.exploded = exploded
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         if self.exploded:
@@ -1825,7 +1774,7 @@ class IP(Field[ipaddress.IPv4Address | ipaddress.IPv6Address]):
         return value.compressed
 
     def _deserialize(
-        self, value, attr, data, **kwargs
+        self, value, **kwargs
     ) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
         try:
             return (self.DESERIALIZATION_CLASS or ipaddress.ip_address)(
@@ -1879,7 +1828,7 @@ class IPInterface(Field[ipaddress.IPv4Interface | ipaddress.IPv6Interface]):
         super().__init__(**kwargs)
         self.exploded = exploded
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         if self.exploded:
@@ -1887,7 +1836,7 @@ class IPInterface(Field[ipaddress.IPv4Interface | ipaddress.IPv6Interface]):
         return value.compressed
 
     def _deserialize(
-        self, value, attr, data, **kwargs
+        self, value, **kwargs
     ) -> ipaddress.IPv4Interface | ipaddress.IPv6Interface:
         try:
             return (self.DESERIALIZATION_CLASS or ipaddress.ip_interface)(
@@ -1950,7 +1899,7 @@ class Enum(Field[_EnumT]):
         if by_value is False:
             self.field: Field = String()
             self.choices_text = ", ".join(
-                str(self.field._serialize(m, None, None)) for m in enum.__members__
+                str(self.field._serialize(m)) for m in enum.__members__
             )
         # Serialization by value
         else:
@@ -1965,26 +1914,24 @@ class Enum(Field[_EnumT]):
                         "marshmallow.fields.Field."
                     ) from error
             self.choices_text = ", ".join(
-                str(self.field._serialize(m.value, None, None)) for m in enum
+                str(self.field._serialize(m.value)) for m in enum
             )
             if "allow_none" not in kwargs and any(m.value is None for m in enum):
                 self.allow_none = True
 
-    def _serialize(
-        self, value: _EnumT | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> typing.Any | None:
+    def _serialize(self, value: _EnumT | None, **kwargs) -> typing.Any | None:
         if value is None:
             return None
         if self.by_value:
             val = value.value
         else:
             val = value.name
-        return self.field._serialize(val, attr, obj, **kwargs)
+        return self.field._serialize(val, **kwargs)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _EnumT:
+    def _deserialize(self, value, **kwargs) -> _EnumT:
         if isinstance(value, self.enum):
             return value
-        val = self.field._deserialize(value, attr, data, **kwargs)
+        val = self.field._deserialize(value, **kwargs)
         if self.by_value:
             try:
                 return self.enum(val)
@@ -2039,12 +1986,12 @@ class Method(Field):
 
         super()._bind_to_schema(field_name, parent)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if self._serialize_method is not None:
             return self._serialize_method(value)
         return missing_
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if self._deserialize_method is not None:
             return self._deserialize_method(value)
         return value
@@ -2092,10 +2039,10 @@ class Function(Field):
         self.serialize_func = serialize and utils.callable_or_raise(serialize)
         self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         return self.serialize_func(value)
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if self.deserialize_func:
             return self.deserialize_func(value)
         return value
@@ -2122,10 +2069,10 @@ class Constant(Field[_ContantT]):
         if kwargs.get("allow_none") is None and constant is None:
             self.allow_none = True
 
-    def _serialize(self, value, *args, **kwargs) -> _ContantT:
+    def _serialize(self, value, **kwargs) -> _ContantT:
         return self.constant
 
-    def _deserialize(self, value, *args, **kwargs) -> _ContantT:
+    def _deserialize(self, value, **kwargs) -> _ContantT:
         return self.constant
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2134,23 +2134,15 @@ class Constant(Field[_ContantT]):
     :param constant: The constant to return for the field attribute.
     """
 
-    _CHECK_ATTRIBUTE = False
-
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
         super().__init__(**kwargs)
         self.constant = constant
-        self.load_default = constant
-        self.dump_default = constant
+        self.dump_getter = lambda obj, attr, default: constant
+        self.load_getter = lambda data, key, default: constant
         # If allow_none was not explicitly provided and the constant is None,
         # None should be considered valid (mirrors Field.__init__ logic).
         if kwargs.get("allow_none") is None and constant is None:
             self.allow_none = True
-
-    def _validate_missing(self, value):
-        # Omit check for value is missing_
-        # Below is just a paranoid check
-        if value is None and not self.allow_none:
-            raise self.make_error("null")
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2014,8 +2014,8 @@ class Method(Field):
     """A field that takes the value returned by a `Schema <marshmallow.Schema>` method.
 
     :param serialize: The name of the Schema method from which
-        to retrieve the value. The method must take an argument ``obj``
-        (in addition to self) that is the object to be serialized.
+        to retrieve the value. The method must take an argument ``value``
+        (in addition to self) that is the value to be serialized.
     :param deserialize: Optional name of the Schema method for deserializing
         a value The method must take a single argument ``value``, which is the
         value to deserialize.
@@ -2023,8 +2023,6 @@ class Method(Field):
     .. versionchanged:: 3.0.0
         Removed ``method_name`` parameter.
     """
-
-    _CHECK_ATTRIBUTE = False
 
     def __init__(
         self,
@@ -2056,7 +2054,7 @@ class Method(Field):
 
     def _serialize(self, value, attr, obj, **kwargs):
         if self._serialize_method is not None:
-            return self._serialize_method(obj)
+            return self._serialize_method(value)
         return missing_
 
     def _deserialize(self, value, attr, data, **kwargs):
@@ -2069,8 +2067,8 @@ class Function(Field):
     """A field that takes the value returned by a function.
 
     :param serialize: A callable from which to retrieve the value.
-        The function must take a single argument ``obj`` which is the object
-        to be serialized.
+        The function must take a single argument ``value`` which is the
+        value to be serialized.
         If no callable is provided then the ```load_only``` flag will be set
         to True.
     :param deserialize: A callable from which to retrieve the value.
@@ -2085,8 +2083,6 @@ class Function(Field):
     .. versionchanged:: 4.0.0
         Don't pass context to serialization and deserialization functions.
     """
-
-    _CHECK_ATTRIBUTE = False
 
     def __init__(
         self,
@@ -2110,7 +2106,7 @@ class Function(Field):
         self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
 
     def _serialize(self, value, attr, obj, **kwargs):
-        return self.serialize_func(obj)
+        return self.serialize_func(value)
 
     def _deserialize(self, value, attr, data, **kwargs):
         if self.deserialize_func:

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -320,12 +320,10 @@ class Field(typing.Generic[_InternalT]):
         if value is None and not self.allow_none:
             raise self.make_error("null")
 
-    def serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
+    def serialize(self, value: typing.Any, **kwargs):
         """Applies the field's formatting to ``value`` and returns the result.
 
         :param value: The value to serialize.
-        :param attr: The attribute/key name (used for error context).
-        :param obj: The parent object (used by Nested fields).
         :param kwargs: Field-specific keyword arguments.
         """
         if value is missing_:
@@ -333,40 +331,20 @@ class Field(typing.Generic[_InternalT]):
             value = default() if callable(default) else default
         if value is missing_:
             return value
-        return self._serialize(value, attr, obj, **kwargs)
+        return self._serialize(value, **kwargs)
 
     # If value is None, None may be returned
     @typing.overload
-    def deserialize(
-        self,
-        value: None,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> None | _InternalT: ...
+    def deserialize(self, value: None, **kwargs) -> None | _InternalT: ...
 
     # If value is not None, internal type is returned
     @typing.overload
-    def deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> _InternalT: ...
+    def deserialize(self, value: typing.Any, **kwargs) -> _InternalT: ...
 
-    def deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None = None,
-        data: typing.Mapping[str, typing.Any] | None = None,
-        **kwargs,
-    ) -> _InternalT | None:
+    def deserialize(self, value: typing.Any, **kwargs) -> _InternalT | None:
         """Deserialize ``value``.
 
         :param value: The value to deserialize.
-        :param attr: The attribute/key in `data` to deserialize.
-        :param data: The raw input data passed to `Schema.load <marshmallow.Schema.load>`.
         :param kwargs: Field-specific keyword arguments.
         :raise ValidationError: If an invalid value is passed or if a required value
             is missing.
@@ -385,7 +363,7 @@ class Field(typing.Generic[_InternalT]):
         if self.allow_none and value is None:
             return None
 
-        output = self._deserialize(value, attr, data, **kwargs)
+        output = self._deserialize(value, **kwargs)
         # Apply validators
         self._validate(output)
 
@@ -409,40 +387,28 @@ class Field(typing.Generic[_InternalT]):
             self.parent.root if isinstance(self.parent, Field) else self.parent
         )
 
-    def _serialize(
-        self, value: _InternalT | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> typing.Any:
+    def _serialize(self, value: _InternalT | None, **kwargs) -> typing.Any:
         """Serializes ``value`` to a basic Python datatype. Noop by default.
         Concrete :class:`Field` classes should implement this method.
 
         Example: ::
 
             class TitleCase(Field):
-                def _serialize(self, value, attr, obj, **kwargs):
+                def _serialize(self, value, **kwargs):
                     if not value:
                         return ""
                     return str(value).title()
 
         :param value: The value to be serialized.
-        :param attr: The attribute or key on the object to be serialized.
-        :param obj: The object the value was pulled from.
         :param kwargs: Field-specific keyword arguments.
         :return: The serialized value
         """
         return value
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> _InternalT:
+    def _deserialize(self, value: typing.Any, **kwargs) -> _InternalT:
         """Deserialize value. Concrete :class:`Field` classes should implement this method.
 
         :param value: The value to be deserialized.
-        :param attr: The attribute/key in `data` to be deserialized.
-        :param data: The raw input data passed to the `Schema.load <marshmallow.Schema.load>`.
         :param kwargs: Field-specific keyword arguments.
         :raise ValidationError: In case of formatting or validation failure.
         :return: The deserialized value.
@@ -616,7 +582,7 @@ class Nested(Field):
             if field.startswith(nested_field)
         ]
 
-    def _serialize(self, nested_obj, attr, obj, **kwargs):
+    def _serialize(self, nested_obj, **kwargs):
         # Load up the schema first. This allows a RegistryError to be raised
         # if an invalid schema name was passed
         schema = self.schema
@@ -646,8 +612,6 @@ class Nested(Field):
     def _deserialize(
         self,
         value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
         partial: bool | types.StrSequenceOrSet | None = None,  # noqa: FBT001
         **kwargs,
     ):
@@ -708,15 +672,15 @@ class Pluck(Nested):
         only_field = self.schema.fields[self.field_name]
         return only_field.data_key or self.field_name
 
-    def _serialize(self, nested_obj, attr, obj, **kwargs):
-        ret = super()._serialize(nested_obj, attr, obj, **kwargs)
+    def _serialize(self, nested_obj, **kwargs):
+        ret = super()._serialize(nested_obj, **kwargs)
         if ret is None:
             return None
         if self.many:
             return utils.pluck(ret, key=self._field_data_key)
         return ret[self._field_data_key]
 
-    def _deserialize(self, value, attr, data, partial=None, **kwargs):
+    def _deserialize(self, value, partial=None, **kwargs):
         self._test_collection(value)
         if self.many:
             value = [{self._field_data_key: v} for v in value]
@@ -768,12 +732,12 @@ class List(Field[list[_InternalT | None]]):
             self.inner.only = self.only
             self.inner.exclude = self.exclude
 
-    def _serialize(self, value, attr, obj, **kwargs) -> list[_InternalT] | None:
+    def _serialize(self, value, **kwargs) -> list[_InternalT] | None:
         if value is None:
             return None
-        return [self.inner._serialize(each, attr, obj, **kwargs) for each in value]
+        return [self.inner._serialize(each, **kwargs) for each in value]
 
-    def _deserialize(self, value, attr, data, **kwargs) -> list[_InternalT | None]:
+    def _deserialize(self, value, **kwargs) -> list[_InternalT | None]:
         if not utils.is_collection(value):
             raise self.make_error("invalid")
 
@@ -848,24 +812,16 @@ class Tuple(Field[tuple]):
 
         self.tuple_fields = new_tuple_fields
 
-    def _serialize(
-        self, value: tuple | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> tuple | None:
+    def _serialize(self, value: tuple | None, **kwargs) -> tuple | None:
         if value is None:
             return None
 
         return tuple(
-            field._serialize(each, attr, obj, **kwargs)
+            field._serialize(each, **kwargs)
             for field, each in zip(self.tuple_fields, value, strict=True)
         )
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> tuple:
+    def _deserialize(self, value: typing.Any, **kwargs) -> tuple:
         if not utils.is_sequence_but_not_string(value):
             raise self.make_error("invalid")
 
@@ -899,12 +855,12 @@ class String(Field[str]):
         "invalid_utf8": "Not a valid utf-8 string.",
     }
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         return utils.ensure_text_type(value)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> str:
+    def _deserialize(self, value, **kwargs) -> str:
         if not isinstance(value, (str, bytes)):
             raise self.make_error("invalid")
         try:
@@ -930,12 +886,12 @@ class UUID(Field[uuid.UUID]):
         except (ValueError, AttributeError, TypeError) as error:
             raise self.make_error("invalid_uuid") from error
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         return str(value)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> uuid.UUID:
+    def _deserialize(self, value, **kwargs) -> uuid.UUID:
         return self._validated(value)
 
 
@@ -989,14 +945,14 @@ class Number(Field[_NumT], metaclass=abc.ABCMeta):
     def _to_string(self, value: _NumT) -> str:
         return str(value)
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | _NumT | None:
+    def _serialize(self, value, **kwargs) -> str | _NumT | None:
         """Return a string if `self.as_string=True`, otherwise return this field's `num_type`."""
         if value is None:
             return None
         ret: _NumT = self._format_num(value)
         return self._to_string(ret) if self.as_string else ret
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _NumT:
+    def _deserialize(self, value, **kwargs) -> _NumT:
         return self._validated(value)
 
 
@@ -1217,13 +1173,7 @@ class Boolean(Field[bool]):
         if falsy is not None:
             self.falsy = set(falsy)
 
-    def _deserialize(
-        self,
-        value: typing.Any,
-        attr: str | None,
-        data: typing.Mapping[str, typing.Any] | None,
-        **kwargs,
-    ) -> bool:
+    def _deserialize(self, value: typing.Any, **kwargs) -> bool:
         if not self.truthy:
             return bool(value)
         try:
@@ -1274,7 +1224,7 @@ class _TemporalField(Field[_D], metaclass=abc.ABCMeta):
             or self.DEFAULT_FORMAT
         )
 
-    def _serialize(self, value: _D | None, attr, obj, **kwargs) -> str | float | None:
+    def _serialize(self, value: _D | None, **kwargs) -> str | float | None:
         if value is None:
             return None
         data_format = self.format or self.DEFAULT_FORMAT
@@ -1283,7 +1233,7 @@ class _TemporalField(Field[_D], metaclass=abc.ABCMeta):
             return format_func(value)
         return value.strftime(data_format)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _D:
+    def _deserialize(self, value, **kwargs) -> _D:
         internal_type: type[_D] = getattr(dt, self.OBJ_TYPE)
         if isinstance(value, internal_type):
             return value
@@ -1373,8 +1323,8 @@ class NaiveDateTime(DateTime):
         super().__init__(format=format, **kwargs)
         self.timezone = timezone
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.datetime:
-        ret = super()._deserialize(value, attr, data, **kwargs)
+    def _deserialize(self, value, **kwargs) -> dt.datetime:
+        ret = super()._deserialize(value, **kwargs)
         if utils.is_aware(ret):
             if self.timezone is None:
                 raise self.make_error(
@@ -1410,8 +1360,8 @@ class AwareDateTime(DateTime):
         super().__init__(format=format, **kwargs)
         self.default_timezone = default_timezone
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.datetime:
-        ret = super()._deserialize(value, attr, data, **kwargs)
+    def _deserialize(self, value, **kwargs) -> dt.datetime:
+        ret = super()._deserialize(value, **kwargs)
         if not utils.is_aware(ret):
             if self.default_timezone is None:
                 raise self.make_error(
@@ -1556,7 +1506,7 @@ class TimeDelta(Field[dt.timedelta]):
         self.precision = precision
         super().__init__(**kwargs)
 
-    def _serialize(self, value, attr, obj, **kwargs) -> float | None:
+    def _serialize(self, value, **kwargs) -> float | None:
         if value is None:
             return None
 
@@ -1565,7 +1515,7 @@ class TimeDelta(Field[dt.timedelta]):
         microseconds_per_unit: int = self._unit_to_microseconds_mapping[self.precision]
         return microseconds / microseconds_per_unit
 
-    def _deserialize(self, value, attr, data, **kwargs) -> dt.timedelta:
+    def _deserialize(self, value, **kwargs) -> dt.timedelta:
         if isinstance(value, dt.timedelta):
             return value
         try:
@@ -1653,7 +1603,7 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
             self.key_field = copy.deepcopy(self.key_field)
             self.key_field._bind_to_schema(field_name, self)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if value is None:
             return None
         if not self.value_field and not self.key_field:
@@ -1663,9 +1613,7 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
         if self.key_field is None:
             keys = {k: k for k in value}
         else:
-            keys = {
-                k: self.key_field._serialize(k, None, None, **kwargs) for k in value
-            }
+            keys = {k: self.key_field._serialize(k, **kwargs) for k in value}
 
         # Serialize values
         result = self.mapping_type()
@@ -1675,11 +1623,11 @@ class Mapping(Field[_MappingT], metaclass=abc.ABCMeta):
                     result[keys[k]] = v
         else:
             for k, v in value.items():
-                result[keys[k]] = self.value_field._serialize(v, None, None, **kwargs)
+                result[keys[k]] = self.value_field._serialize(v, **kwargs)
 
         return result
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if not isinstance(value, _Mapping):
             raise self.make_error("invalid")
         if not self.value_field and not self.key_field:
@@ -1815,7 +1763,7 @@ class IP(Field[ipaddress.IPv4Address | ipaddress.IPv6Address]):
         super().__init__(**kwargs)
         self.exploded = exploded
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         if self.exploded:
@@ -1823,7 +1771,7 @@ class IP(Field[ipaddress.IPv4Address | ipaddress.IPv6Address]):
         return value.compressed
 
     def _deserialize(
-        self, value, attr, data, **kwargs
+        self, value, **kwargs
     ) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
         try:
             return (self.DESERIALIZATION_CLASS or ipaddress.ip_address)(
@@ -1877,7 +1825,7 @@ class IPInterface(Field[ipaddress.IPv4Interface | ipaddress.IPv6Interface]):
         super().__init__(**kwargs)
         self.exploded = exploded
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, **kwargs) -> str | None:
         if value is None:
             return None
         if self.exploded:
@@ -1885,7 +1833,7 @@ class IPInterface(Field[ipaddress.IPv4Interface | ipaddress.IPv6Interface]):
         return value.compressed
 
     def _deserialize(
-        self, value, attr, data, **kwargs
+        self, value, **kwargs
     ) -> ipaddress.IPv4Interface | ipaddress.IPv6Interface:
         try:
             return (self.DESERIALIZATION_CLASS or ipaddress.ip_interface)(
@@ -1947,7 +1895,7 @@ class Enum(Field[_EnumT]):
         if by_value is False:
             self.field: Field = String()
             self.choices_text = ", ".join(
-                str(self.field._serialize(m, None, None)) for m in enum.__members__
+                str(self.field._serialize(m)) for m in enum.__members__
             )
         # Serialization by value
         else:
@@ -1962,24 +1910,22 @@ class Enum(Field[_EnumT]):
                         "marshmallow.fields.Field."
                     ) from error
             self.choices_text = ", ".join(
-                str(self.field._serialize(m.value, None, None)) for m in enum
+                str(self.field._serialize(m.value)) for m in enum
             )
 
-    def _serialize(
-        self, value: _EnumT | None, attr: str | None, obj: typing.Any, **kwargs
-    ) -> typing.Any | None:
+    def _serialize(self, value: _EnumT | None, **kwargs) -> typing.Any | None:
         if value is None:
             return None
         if self.by_value:
             val = value.value
         else:
             val = value.name
-        return self.field._serialize(val, attr, obj, **kwargs)
+        return self.field._serialize(val, **kwargs)
 
-    def _deserialize(self, value, attr, data, **kwargs) -> _EnumT:
+    def _deserialize(self, value, **kwargs) -> _EnumT:
         if isinstance(value, self.enum):
             return value
-        val = self.field._deserialize(value, attr, data, **kwargs)
+        val = self.field._deserialize(value, **kwargs)
         if self.by_value:
             try:
                 return self.enum(val)
@@ -2034,12 +1980,12 @@ class Method(Field):
 
         super()._bind_to_schema(field_name, parent)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if self._serialize_method is not None:
             return self._serialize_method(value)
         return missing_
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if self._deserialize_method is not None:
             return self._deserialize_method(value)
         return value
@@ -2087,10 +2033,10 @@ class Function(Field):
         self.serialize_func = serialize and utils.callable_or_raise(serialize)
         self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         return self.serialize_func(value)
 
-    def _deserialize(self, value, attr, data, **kwargs):
+    def _deserialize(self, value, **kwargs):
         if self.deserialize_func:
             return self.deserialize_func(value)
         return value
@@ -2117,10 +2063,10 @@ class Constant(Field[_ContantT]):
         if kwargs.get("allow_none") is None and constant is None:
             self.allow_none = True
 
-    def _serialize(self, value, *args, **kwargs) -> _ContantT:
+    def _serialize(self, value, **kwargs) -> _ContantT:
         return self.constant
 
-    def _deserialize(self, value, *args, **kwargs) -> _ContantT:
+    def _deserialize(self, value, **kwargs) -> _ContantT:
         return self.constant
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -103,10 +103,10 @@ class _BaseFieldKwargs(typing.TypedDict, total=False):
     error_messages: types.ErrorMessages | None
     metadata: typing.Mapping[str, typing.Any] | None
     dump_getter: (
-        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+        str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
     )
     load_getter: (
-        typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+        str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
     )
 
 
@@ -211,10 +211,10 @@ class Field(typing.Generic[_InternalT]):
         error_messages: types.ErrorMessages | None = None,
         metadata: typing.Mapping[str, typing.Any] | None = None,
         dump_getter: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+            str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
         ) = None,
         load_getter: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+            str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
         ) = None,
     ) -> None:
         self.dump_default = dump_default
@@ -386,6 +386,14 @@ class Field(typing.Generic[_InternalT]):
         self.root = self.root or (
             self.parent.root if isinstance(self.parent, Field) else self.parent
         )
+        if isinstance(self.dump_getter, str):
+            self.dump_getter = utils.callable_or_raise(
+                getattr(parent, self.dump_getter)
+            )
+        if isinstance(self.load_getter, str):
+            self.load_getter = utils.callable_or_raise(
+                getattr(parent, self.load_getter)
+            )
 
     def _serialize(self, value: _InternalT | None, **kwargs) -> typing.Any:
         """Serializes ``value`` to a basic Python datatype. Noop by default.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -2129,23 +2129,15 @@ class Constant(Field[_ContantT]):
     :param constant: The constant to return for the field attribute.
     """
 
-    _CHECK_ATTRIBUTE = False
-
     def __init__(self, constant: _ContantT, **kwargs: Unpack[_BaseFieldKwargs]):
         super().__init__(**kwargs)
         self.constant = constant
-        self.load_default = constant
-        self.dump_default = constant
+        self.dump_getter = lambda obj, attr, default: constant
+        self.load_getter = lambda data, key, default: constant
         # If allow_none was not explicitly provided and the constant is None,
         # None should be considered valid (mirrors Field.__init__ logic).
         if kwargs.get("allow_none") is None and constant is None:
             self.allow_none = True
-
-    def _validate_missing(self, value):
-        # Omit check for value is missing_
-        # Below is just a paranoid check
-        if value is None and not self.allow_none:
-            raise self.make_error("null")
 
     def _serialize(self, value, *args, **kwargs) -> _ContantT:
         return self.constant

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -102,12 +102,8 @@ class _BaseFieldKwargs(typing.TypedDict, total=False):
     dump_only: bool
     error_messages: types.ErrorMessages | None
     metadata: typing.Mapping[str, typing.Any] | None
-    dump_getter: (
-        str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-    )
-    load_getter: (
-        str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-    )
+    dump_getter: str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
+    load_getter: str | typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
 
 
 def _resolve_field_instance(cls_or_instance: Field | type[Field]) -> Field:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -648,7 +648,12 @@ class Schema(metaclass=SchemaMeta):
                 field_name = (
                     field_obj.data_key if field_obj.data_key is not None else attr_name
                 )
-                raw_value = data.get(field_name, missing)
+                if field_obj.load_getter is not None:
+                    raw_value = field_obj.load_getter(
+                        data, field_name, missing
+                    )
+                else:
+                    raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
                     if partial is True or (

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -539,7 +539,7 @@ class Schema(metaclass=SchemaMeta):
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
             value = field_obj.get_value(obj, attr_name, accessor=self.get_attribute)
-            value = field_obj.serialize(value, attr_name, obj)
+            value = field_obj.serialize(value)
             if value is missing:
                 continue
             key = field_obj.data_key if field_obj.data_key is not None else attr_name
@@ -673,15 +673,8 @@ class Schema(metaclass=SchemaMeta):
                 elif partial is not None:
                     d_kwargs["partial"] = partial
 
-                def getter(
-                    val, field_obj=field_obj, field_name=field_name, d_kwargs=d_kwargs
-                ):
-                    return field_obj.deserialize(
-                        val,
-                        field_name,
-                        data,
-                        **d_kwargs,
-                    )
+                def getter(val, field_obj=field_obj, d_kwargs=d_kwargs):
+                    return field_obj.deserialize(val, **d_kwargs)
 
                 value = self._call_and_store(
                     getter_func=getter,

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -538,7 +538,8 @@ class Schema(metaclass=SchemaMeta):
             return [self._serialize(d, many=False) for d in obj]
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
-            value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
+            value = field_obj.get_value(obj, attr_name, accessor=self.get_attribute)
+            value = field_obj.serialize(value, attr_name, obj)
             if value is missing:
                 continue
             key = field_obj.data_key if field_obj.data_key is not None else attr_name

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -538,8 +538,9 @@ class Schema(metaclass=SchemaMeta):
             return [self._serialize(d, many=False) for d in obj]
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
-            value = field_obj.get_value(obj, attr_name, accessor=self.get_attribute)
-            value = field_obj.serialize(value)
+            accessor = field_obj.dump_getter or self.get_attribute
+            obj_value = accessor(obj, field_obj.attribute or attr_name, missing)
+            value = field_obj.serialize(obj_value)
             if value is missing:
                 continue
             key = field_obj.data_key if field_obj.data_key is not None else attr_name

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -650,9 +650,7 @@ class Schema(metaclass=SchemaMeta):
                     field_obj.data_key if field_obj.data_key is not None else attr_name
                 )
                 if field_obj.load_getter is not None:
-                    raw_value = field_obj.load_getter(
-                        data, field_name, missing
-                    )
+                    raw_value = field_obj.load_getter(data, field_name, missing)
                 else:
                     raw_value = data.get(field_name, missing)
                 if raw_value is missing:

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -649,7 +649,12 @@ class Schema(metaclass=SchemaMeta):
                 field_name = (
                     field_obj.data_key if field_obj.data_key is not None else attr_name
                 )
-                raw_value = data.get(field_name, missing)
+                if field_obj.load_getter is not None:
+                    raw_value = field_obj.load_getter(
+                        data, field_name, missing
+                    )
+                else:
+                    raw_value = data.get(field_name, missing)
                 if raw_value is missing:
                     # Ignore missing field if we're allowed to.
                     if partial is True or (

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -539,7 +539,7 @@ class Schema(metaclass=SchemaMeta):
         ret = self.dict_class()
         for attr_name, field_obj in self.dump_fields.items():
             value = field_obj.get_value(obj, attr_name, accessor=self.get_attribute)
-            value = field_obj.serialize(value, attr_name, obj)
+            value = field_obj.serialize(value)
             if value is missing:
                 continue
             key = field_obj.data_key if field_obj.data_key is not None else attr_name
@@ -674,15 +674,8 @@ class Schema(metaclass=SchemaMeta):
                 elif partial is not None:
                     d_kwargs["partial"] = partial
 
-                def getter(
-                    val, field_obj=field_obj, field_name=field_name, d_kwargs=d_kwargs
-                ):
-                    return field_obj.deserialize(
-                        val,
-                        field_name,
-                        data,
-                        **d_kwargs,
-                    )
+                def getter(val, field_obj=field_obj, d_kwargs=d_kwargs):
+                    return field_obj.deserialize(val, **d_kwargs)
 
                 value = self._call_and_store(
                     getter_func=getter,

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -651,9 +651,7 @@ class Schema(metaclass=SchemaMeta):
                     field_obj.data_key if field_obj.data_key is not None else attr_name
                 )
                 if field_obj.load_getter is not None:
-                    raw_value = field_obj.load_getter(
-                        data, field_name, missing
-                    )
+                    raw_value = field_obj.load_getter(data, field_name, missing)
                 else:
                     raw_value = data.get(field_name, missing)
                 if raw_value is missing:

--- a/tests/base.py
+++ b/tests/base.py
@@ -207,9 +207,7 @@ class UserSchema(Schema):
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
-    is_old: fields.Field = fields.Boolean(
-        dump_only=True, dump_getter=get_is_old
-    )
+    is_old: fields.Field = fields.Boolean(dump_only=True, dump_getter=get_is_old)
     lowername = fields.String(dump_only=True, dump_getter=get_lowername)
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 import simplejson
 
-from marshmallow import Schema, fields, missing, post_load, validate
+from marshmallow import Schema, fields, post_load, validate
 from marshmallow.exceptions import ValidationError
 
 central = ZoneInfo("America/Chicago")
@@ -179,12 +179,17 @@ class Uppercased(fields.String):
         return None
 
 
-def get_lowername(obj):
+def get_is_old(obj, attr, default):
     if obj is None:
-        return missing
-    if isinstance(obj, dict):
-        return obj.get("name", "").lower()
-    return obj.name.lower()
+        return default
+    age = obj.get("age", 0) if isinstance(obj, dict) else obj.age
+    return age > 80
+
+
+def get_lowername(obj, attr, default):
+    if obj is None:
+        return default
+    return (obj.get("name", "") if isinstance(obj, dict) else obj.name).lower()
 
 
 class UserSchema(Schema):
@@ -202,8 +207,10 @@ class UserSchema(Schema):
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
-    is_old: fields.Field = fields.Method("get_is_old")
-    lowername = fields.Function(get_lowername)
+    is_old: fields.Field = fields.Boolean(
+        dump_only=True, dump_getter=get_is_old
+    )
+    lowername = fields.String(dump_only=True, dump_getter=get_lowername)
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)
     sex_choices = fields.List(fields.Raw)
@@ -219,18 +226,6 @@ class UserSchema(Schema):
 
     class Meta:
         render_module = simplejson
-
-    def get_is_old(self, obj):
-        if obj is None:
-            return missing
-        if isinstance(obj, dict):
-            age = obj.get("age", 0)
-        else:
-            age = obj.age
-        try:
-            return age > 80
-        except TypeError as te:
-            raise ValidationError(str(te)) from te
 
     @post_load
     def make_user(self, data, **kwargs):

--- a/tests/base.py
+++ b/tests/base.py
@@ -173,7 +173,7 @@ class Blog:
 class Uppercased(fields.String):
     """Custom field formatting example."""
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if value:
             return value.upper()
         return None

--- a/tests/base.py
+++ b/tests/base.py
@@ -201,9 +201,7 @@ class UserSchema(Schema):
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
-    is_old: fields.Field = fields.Boolean(
-        dump_only=True, dump_getter=get_is_old
-    )
+    is_old: fields.Field = fields.Boolean(dump_only=True, dump_getter=get_is_old)
     lowername = fields.String(dump_only=True, dump_getter=get_lowername)
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)

--- a/tests/base.py
+++ b/tests/base.py
@@ -167,7 +167,7 @@ class Blog:
 class Uppercased(fields.String):
     """Custom field formatting example."""
 
-    def _serialize(self, value, attr, obj, **kwargs):
+    def _serialize(self, value, **kwargs):
         if value:
             return value.upper()
         return None

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 import simplejson
 
-from marshmallow import Schema, fields, missing, post_load, validate
+from marshmallow import Schema, fields, post_load, validate
 from marshmallow.exceptions import ValidationError
 
 central = ZoneInfo("America/Chicago")
@@ -173,12 +173,17 @@ class Uppercased(fields.String):
         return None
 
 
-def get_lowername(obj):
+def get_is_old(obj, attr, default):
     if obj is None:
-        return missing
-    if isinstance(obj, dict):
-        return obj.get("name", "").lower()
-    return obj.name.lower()
+        return default
+    age = obj.get("age", 0) if isinstance(obj, dict) else obj.age
+    return age > 80
+
+
+def get_lowername(obj, attr, default):
+    if obj is None:
+        return default
+    return obj.get("name", "").lower() if isinstance(obj, dict) else obj.name.lower()
 
 
 class UserSchema(Schema):
@@ -196,8 +201,10 @@ class UserSchema(Schema):
     homepage = fields.Url()
     email = fields.Email()
     balance = fields.Decimal()
-    is_old: fields.Field = fields.Method("get_is_old")
-    lowername = fields.Function(get_lowername)
+    is_old: fields.Field = fields.Boolean(
+        dump_only=True, dump_getter=get_is_old
+    )
+    lowername = fields.String(dump_only=True, dump_getter=get_lowername)
     registered = fields.Boolean()
     hair_colors = fields.List(fields.Raw)
     sex_choices = fields.List(fields.Raw)
@@ -213,18 +220,6 @@ class UserSchema(Schema):
 
     class Meta:
         render_module = simplejson
-
-    def get_is_old(self, obj):
-        if obj is None:
-            return missing
-        if isinstance(obj, dict):
-            age = obj.get("age", 0)
-        else:
-            age = obj.age
-        try:
-            return age > 80
-        except TypeError as te:
-            raise ValidationError(str(te)) from te
 
     @post_load
     def make_user(self, data, **kwargs):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -186,7 +186,7 @@ class TestContext:
         )
         field.parent = Parent()
         with Context({"key": "BAR"}):
-            assert field.serialize("key", user) == "MONTYBAR"
+            assert field.serialize(user.name, "key", user) == "MONTYBAR"
 
     def test_function_field_deserialization_with_context(self):
         class Parent(Schema):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -103,9 +103,7 @@ class TestContext:
         class InnerSchema(Schema):
             likes_bikes = fields.Boolean(
                 dump_only=True,
-                dump_getter=lambda obj, attr, default: (
-                    "bikes" in Context.get()["info"]
-                ),
+                dump_getter=lambda obj, attr, default: "bikes" in Context.get()["info"],
             )
 
         class CSchema(Schema):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -18,13 +18,18 @@ from tests.base import Blog, User
 
 
 class UserContextSchema(Schema):
-    is_owner = fields.Method("get_is_owner")
-    is_collab = fields.Function(
-        lambda user: user in Context[dict[str, typing.Any]].get()["blog"]
+    is_owner = fields.Boolean(
+        dump_only=True,
+        dump_getter=lambda user, attr, default: (
+            Context.get()["blog"].user.name == user.name
+        ),
     )
-
-    def get_is_owner(self, user):
-        return Context.get()["blog"].user.name == user.name
+    is_collab = fields.Boolean(
+        dump_only=True,
+        dump_getter=lambda user, attr, default: (
+            user in Context[dict[str, typing.Any]].get()["blog"]
+        ),
+    )
 
 
 class TestContext:
@@ -85,7 +90,9 @@ class TestContext:
 
         # only has a function field
         class UserFunctionContextSchema(Schema):
-            is_collab = fields.Function(serialize)
+            is_collab = fields.Function(
+                serialize, dump_getter=lambda obj, attr, default: obj.name
+            )
 
         owner = User("Joe")
         serializer = UserFunctionContextSchema()
@@ -94,7 +101,12 @@ class TestContext:
 
     def test_nested_fields_inherit_context(self):
         class InnerSchema(Schema):
-            likes_bikes = fields.Function(lambda obj: "bikes" in Context.get()["info"])
+            likes_bikes = fields.Boolean(
+                dump_only=True,
+                dump_getter=lambda obj, attr, default: (
+                    "bikes" in Context.get()["info"]
+                ),
+            )
 
         class CSchema(Schema):
             inner = fields.Nested(InnerSchema)
@@ -169,7 +181,8 @@ class TestContext:
             pass
 
         field = fields.Function(
-            serialize=lambda obj: obj.name.upper() + Context.get()["key"]
+            serialize=lambda value: value.upper() + Context.get()["key"],
+            attribute="name",
         )
         field.parent = Parent()
         with Context({"key": "BAR"}):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -35,13 +35,13 @@ class UserContextSchema(Schema):
 class TestContext:
     def test_context_load_dump(self):
         class ContextField(fields.Integer):
-            def _serialize(self, value, attr, obj, **kwargs):
+            def _serialize(self, value, **kwargs):
                 if (context := Context[dict].get(None)) is not None:
                     value *= context.get("factor", 1)
-                return super()._serialize(value, attr, obj, **kwargs)
+                return super()._serialize(value, **kwargs)
 
-            def _deserialize(self, value, attr, data, **kwargs):
-                val = super()._deserialize(value, attr, data, **kwargs)
+            def _deserialize(self, value, **kwargs):
+                val = super()._deserialize(value, **kwargs)
                 if (context := Context[dict].get(None)) is not None:
                     val *= context.get("factor", 1)
                 return val
@@ -186,7 +186,7 @@ class TestContext:
         )
         field.parent = Parent()
         with Context({"key": "BAR"}):
-            assert field.serialize(user.name, "key", user) == "MONTYBAR"
+            assert field.serialize(user.name) == "MONTYBAR"
 
     def test_function_field_deserialization_with_context(self):
         class Parent(Schema):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1296,8 +1296,8 @@ class TestFieldDeserialization:
         class MiniUserSchema(Schema):
             uppername = fields.Method("uppercase_name")
 
-            def uppercase_name(self, obj):
-                return obj.upper()
+            def uppercase_name(self, value):
+                return value.upper()
 
         s = MiniUserSchema()
         assert s.fields["uppername"].deserialize("steve") == "steve"
@@ -1306,8 +1306,8 @@ class TestFieldDeserialization:
         class MiniUserSchema(Schema):
             uppername = fields.Method("uppercase_name", deserialize="lowercase_name")
 
-            def uppercase_name(self, obj):
-                return obj.name.upper()
+            def uppercase_name(self, value):
+                return value.upper()
 
             def lowercase_name(self, value):
                 return value.lower()
@@ -2186,7 +2186,7 @@ class TestValidation:
 
     def test_function_validator(self):
         field = fields.Function(
-            lambda d: d.name.upper(), validate=validate.Length(equal=3)
+            lambda value: value.upper(), validate=validate.Length(equal=3)
         )
         assert field.deserialize("joe")
         with pytest.raises(ValidationError):
@@ -2196,20 +2196,20 @@ class TestValidation:
         "field",
         [
             fields.Function(
-                lambda d: d.name.upper(),
+                lambda value: value.upper(),
                 validate=[
                     validate.Length(equal=3),
                     predicate(lambda n: n[1].lower() == "o"),
                 ],
             ),
             fields.Function(
-                lambda d: d.name.upper(),
+                lambda value: value.upper(),
                 validate=(
                     predicate(lambda n: len(n) == 3),
                     predicate(lambda n: n[1].lower() == "o"),
                 ),
             ),
-            fields.Function(lambda d: d.name.upper(), validate=validators_gen_str),
+            fields.Function(lambda value: value.upper(), validate=validators_gen_str),
         ],
     )
     def test_function_validators(self, field):

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1289,8 +1289,8 @@ class TestFieldDeserialization:
         class MiniUserSchema(Schema):
             uppername = fields.Method("uppercase_name")
 
-            def uppercase_name(self, obj):
-                return obj.upper()
+            def uppercase_name(self, value):
+                return value.upper()
 
         s = MiniUserSchema()
         assert s.fields["uppername"].deserialize("steve") == "steve"
@@ -1299,8 +1299,8 @@ class TestFieldDeserialization:
         class MiniUserSchema(Schema):
             uppername = fields.Method("uppercase_name", deserialize="lowercase_name")
 
-            def uppercase_name(self, obj):
-                return obj.name.upper()
+            def uppercase_name(self, value):
+                return value.upper()
 
             def lowercase_name(self, value):
                 return value.lower()
@@ -2179,7 +2179,7 @@ class TestValidation:
 
     def test_function_validator(self):
         field = fields.Function(
-            lambda d: d.name.upper(), validate=validate.Length(equal=3)
+            lambda value: value.upper(), validate=validate.Length(equal=3)
         )
         assert field.deserialize("joe")
         with pytest.raises(ValidationError):
@@ -2189,20 +2189,20 @@ class TestValidation:
         "field",
         [
             fields.Function(
-                lambda d: d.name.upper(),
+                lambda value: value.upper(),
                 validate=[
                     validate.Length(equal=3),
                     predicate(lambda n: n[1].lower() == "o"),
                 ],
             ),
             fields.Function(
-                lambda d: d.name.upper(),
+                lambda value: value.upper(),
                 validate=(
                     predicate(lambda n: len(n) == 3),
                     predicate(lambda n: n[1].lower() == "o"),
                 ),
             ),
-            fields.Function(lambda d: d.name.upper(), validate=validators_gen_str),
+            fields.Function(lambda value: value.upper(), validate=validators_gen_str),
         ],
     )
     def test_function_validators(self, field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -76,11 +76,9 @@ class TestField:
         ):
             fields.Raw(required=True, load_default=42)
 
-    def test_custom_field_receives_attr_and_obj(self):
+    def test_custom_field_deserialize(self):
         class MyField(fields.Field[str]):
-            def _deserialize(self, value, attr, data, **kwargs) -> str:
-                assert attr == "name"
-                assert data["foo"] == 42
+            def _deserialize(self, value, **kwargs) -> str:
                 return str(value)
 
         class MySchema(Schema):
@@ -89,11 +87,9 @@ class TestField:
         result = MySchema(unknown=EXCLUDE).load({"name": "Monty", "foo": 42})
         assert result == {"name": "Monty"}
 
-    def test_custom_field_receives_data_key_if_set(self):
+    def test_custom_field_deserialize_with_data_key(self):
         class MyField(fields.Field[str]):
-            def _deserialize(self, value, attr, data, **kwargs):
-                assert attr == "name"
-                assert data["foo"] == 42
+            def _deserialize(self, value, **kwargs):
                 return str(value)
 
         class MySchema(Schema):
@@ -104,9 +100,7 @@ class TestField:
 
     def test_custom_field_follows_data_key_if_set(self):
         class MyField(fields.Field[str]):
-            def _serialize(self, value, attr, obj, **kwargs) -> str:
-                assert attr == "name"
-                assert obj["foo"] == 42
+            def _serialize(self, value, **kwargs) -> str:
                 return str(value)
 
         class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -115,6 +115,56 @@ class TestField:
         result = MySchema().dump({"name": "Monty", "foo": 42})
         assert result == {"_NaMe": "Monty"}
 
+    def test_dump_getter_overrides_default_access(self):
+        field = fields.String(
+            dump_getter=lambda obj, attr, default: obj[attr].upper()
+        )
+        assert field.get_value({"name": "monty"}, "name") == "MONTY"
+
+    def test_dump_getter_takes_priority_over_accessor(self):
+        field = fields.String(
+            dump_getter=lambda obj, attr, default: "from_getter"
+        )
+        accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
+        assert field.get_value({}, "name", accessor=accessor) == "from_getter"
+
+    def test_dump_getter_used_in_schema_dump(self):
+        class MySchema(Schema):
+            name = fields.String(
+                dump_getter=lambda obj, attr, default: obj[attr].upper()
+            )
+
+        result = MySchema().dump({"name": "monty"})
+        assert result == {"name": "MONTY"}
+
+    def test_load_getter_overrides_default_access(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_getter=lambda data, key, default: data[key].upper()
+            )
+
+        result = MySchema().load({"name": "monty"})
+        assert result == {"name": "MONTY"}
+
+    def test_load_getter_takes_priority_over_data_get(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_getter=lambda data, key, default: "from_getter"
+            )
+
+        result = MySchema().load({"name": "monty"})
+        assert result == {"name": "from_getter"}
+
+    def test_load_getter_missing_value_uses_load_default(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_default="default_name",
+                load_getter=lambda data, key, default: default,
+            )
+
+        result = MySchema().load({})
+        assert result == {"name": "default_name"}
+
 
 class TestParentAndName:
     class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -110,13 +110,21 @@ class TestField:
         assert result == {"_NaMe": "Monty"}
 
     def test_dump_getter_overrides_default_access(self):
-        field = fields.String(dump_getter=lambda obj, attr, default: obj[attr].upper())
-        assert field.get_value({"name": "monty"}, "name") == "MONTY"
+        class MySchema(Schema):
+            name = fields.String(
+                dump_getter=lambda obj, attr, default: obj[attr].upper()
+            )
+
+        assert MySchema().dump({"name": "monty"}) == {"name": "MONTY"}
 
     def test_dump_getter_takes_priority_over_accessor(self):
-        field = fields.String(dump_getter=lambda obj, attr, default: "from_getter")
-        accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
-        assert field.get_value({}, "name", accessor=accessor) == "from_getter"
+        class MySchema(Schema):
+            def get_attribute(self, obj, attr, default):
+                return "from_accessor"
+
+            name = fields.String(dump_getter=lambda obj, attr, default: "from_getter")
+
+        assert MySchema().dump({}) == {"name": "from_getter"}
 
     def test_dump_getter_used_in_schema_dump(self):
         class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -110,15 +110,11 @@ class TestField:
         assert result == {"_NaMe": "Monty"}
 
     def test_dump_getter_overrides_default_access(self):
-        field = fields.String(
-            dump_getter=lambda obj, attr, default: obj[attr].upper()
-        )
+        field = fields.String(dump_getter=lambda obj, attr, default: obj[attr].upper())
         assert field.get_value({"name": "monty"}, "name") == "MONTY"
 
     def test_dump_getter_takes_priority_over_accessor(self):
-        field = fields.String(
-            dump_getter=lambda obj, attr, default: "from_getter"
-        )
+        field = fields.String(dump_getter=lambda obj, attr, default: "from_getter")
         accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
         assert field.get_value({}, "name", accessor=accessor) == "from_getter"
 
@@ -142,9 +138,7 @@ class TestField:
 
     def test_load_getter_takes_priority_over_data_get(self):
         class MySchema(Schema):
-            name = fields.String(
-                load_getter=lambda data, key, default: "from_getter"
-            )
+            name = fields.String(load_getter=lambda data, key, default: "from_getter")
 
         result = MySchema().load({"name": "monty"})
         assert result == {"name": "from_getter"}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -115,6 +115,96 @@ class TestField:
         result = MySchema().dump({"name": "Monty", "foo": 42})
         assert result == {"_NaMe": "Monty"}
 
+    def test_dump_getter_overrides_default_access(self):
+        field = fields.String(
+            dump_getter=lambda obj, attr, default: obj[attr].upper()
+        )
+        assert field.get_value({"name": "monty"}, "name") == "MONTY"
+
+    def test_dump_getter_takes_priority_over_accessor(self):
+        field = fields.String(
+            dump_getter=lambda obj, attr, default: "from_getter"
+        )
+        accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
+        assert field.get_value({}, "name", accessor=accessor) == "from_getter"
+
+    def test_dump_getter_used_in_schema_dump(self):
+        class MySchema(Schema):
+            name = fields.String(
+                dump_getter=lambda obj, attr, default: obj[attr].upper()
+            )
+
+        result = MySchema().dump({"name": "monty"})
+        assert result == {"name": "MONTY"}
+
+    def test_dump_getter_receives_default(self):
+        received = []
+
+        def getter(obj, attr, default):
+            received.append(default)
+            return default
+
+        field = fields.String(dump_default="fallback", dump_getter=getter)
+        field.get_value({}, "missing")
+        assert received[0] is missing
+
+    def test_no_dump_getter_falls_back_to_accessor(self):
+        field = fields.String()
+        accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
+        assert field.get_value({}, "name", accessor=accessor) == "from_accessor"
+
+    def test_no_dump_getter_falls_back_to_utils_get_value(self):
+        field = fields.String()
+        assert field.get_value({"name": "monty"}, "name") == "monty"
+
+    def test_load_getter_overrides_default_access(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_getter=lambda data, key, default: data[key].upper()
+            )
+
+        result = MySchema().load({"name": "monty"})
+        assert result == {"name": "MONTY"}
+
+    def test_load_getter_takes_priority_over_data_get(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_getter=lambda data, key, default: "from_getter"
+            )
+
+        result = MySchema().load({"name": "monty"})
+        assert result == {"name": "from_getter"}
+
+    def test_load_getter_receives_default(self):
+        received = []
+
+        def getter(data, key, default):
+            received.append(default)
+            return default
+
+        class MySchema(Schema):
+            name = fields.String(load_default="fallback", load_getter=getter)
+
+        MySchema().load({})
+        assert received[0] is missing
+
+    def test_load_getter_missing_value_uses_load_default(self):
+        class MySchema(Schema):
+            name = fields.String(
+                load_default="default_name",
+                load_getter=lambda data, key, default: default,
+            )
+
+        result = MySchema().load({})
+        assert result == {"name": "default_name"}
+
+    def test_no_load_getter_falls_back_to_data_get(self):
+        class MySchema(Schema):
+            name = fields.String()
+
+        result = MySchema().load({"name": "monty"})
+        assert result == {"name": "monty"}
+
 
 class TestParentAndName:
     class MySchema(Schema):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -151,6 +151,24 @@ class TestField:
         field = fields.String()
         assert field.get_value({"name": "monty"}, "name") == "monty"
 
+    def test_dump_getter_as_function(self):
+        def get_upper(obj, attr, default):
+            return obj[attr].upper()
+
+        class MySchema(Schema):
+            name = fields.String(dump_getter=get_upper)
+
+        assert MySchema().dump({"name": "monty"}) == {"name": "MONTY"}
+
+    def test_dump_getter_as_schema_method(self):
+        class MySchema(Schema):
+            def get_upper(self, obj, attr, default):
+                return obj[attr].upper()
+
+            name = fields.String(dump_getter="get_upper")
+
+        assert MySchema().dump({"name": "monty"}) == {"name": "MONTY"}
+
     def test_load_getter_overrides_default_access(self):
         class MySchema(Schema):
             name = fields.String(
@@ -198,6 +216,24 @@ class TestField:
 
         result = MySchema().load({"name": "monty"})
         assert result == {"name": "monty"}
+
+    def test_load_getter_as_function(self):
+        def get_upper(data, key, default):
+            return data[key].upper()
+
+        class MySchema(Schema):
+            name = fields.String(load_getter=get_upper)
+
+        assert MySchema().load({"name": "monty"}) == {"name": "MONTY"}
+
+    def test_load_getter_as_schema_method(self):
+        class MySchema(Schema):
+            def get_upper(self, data, key, default):
+                return data[key].upper()
+
+            name = fields.String(load_getter="get_upper")
+
+        assert MySchema().load({"name": "monty"}) == {"name": "MONTY"}
 
 
 class TestParentAndName:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -110,15 +110,11 @@ class TestField:
         assert result == {"_NaMe": "Monty"}
 
     def test_dump_getter_overrides_default_access(self):
-        field = fields.String(
-            dump_getter=lambda obj, attr, default: obj[attr].upper()
-        )
+        field = fields.String(dump_getter=lambda obj, attr, default: obj[attr].upper())
         assert field.get_value({"name": "monty"}, "name") == "MONTY"
 
     def test_dump_getter_takes_priority_over_accessor(self):
-        field = fields.String(
-            dump_getter=lambda obj, attr, default: "from_getter"
-        )
+        field = fields.String(dump_getter=lambda obj, attr, default: "from_getter")
         accessor = lambda obj, attr, default: "from_accessor"  # noqa: E731
         assert field.get_value({}, "name", accessor=accessor) == "from_getter"
 
@@ -180,9 +176,7 @@ class TestField:
 
     def test_load_getter_takes_priority_over_data_get(self):
         class MySchema(Schema):
-            name = fields.String(
-                load_getter=lambda data, key, default: "from_getter"
-            )
+            name = fields.String(load_getter=lambda data, key, default: "from_getter")
 
         result = MySchema().load({"name": "monty"})
         assert result == {"name": "from_getter"}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -118,7 +118,7 @@ def test_load_resets_error_fields():
 def test_errored_fields_do_not_appear_in_output():
     class MyField(fields.Field[int]):
         # Make sure validation fails during serialization
-        def _serialize(self, value, attr, obj, **kwargs):
+        def _serialize(self, value, **kwargs):
             raise ValidationError("oops")
 
     def validator(val):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -43,7 +43,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_func(self, user):
         field = fields.Function(lambda value: value.upper())
-        assert field.serialize("name", user) == "FOO"
+        assert field.serialize(user.name, "name", user) == "FOO"
 
     def test_function_field_passed_serialize_only_is_dump_only(self, user):
         field = fields.Function(serialize=lambda value: value.upper())
@@ -57,7 +57,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_serialize(self, user):
         field = fields.Function(serialize=lambda value: value.upper())
-        assert field.serialize("name", user) == "FOO"
+        assert field.serialize(user.name, "name", user) == "FOO"
 
     # https://github.com/marshmallow-code/marshmallow/issues/395
     def test_function_field_does_not_swallow_attribute_error(self, user):
@@ -66,7 +66,7 @@ class TestFieldSerialization:
 
         field = fields.Function(serialize=raise_error)
         with pytest.raises(AttributeError):
-            field.serialize("name", user)
+            field.serialize(user.name, "name", user)
 
     def test_serialize_with_load_only_param(self):
         class AliasingUserSerializer(Schema):
@@ -97,32 +97,35 @@ class TestFieldSerialization:
 
     def test_integer_field(self, user):
         field = fields.Integer()
-        assert field.serialize("age", user) == 42
+        assert field.serialize(user.age, "age", user) == 42
 
     def test_integer_as_string_field(self, user):
         field = fields.Integer(as_string=True)
-        assert field.serialize("age", user) == "42"
+        assert field.serialize(user.age, "age", user) == "42"
 
     def test_integer_field_default(self, user):
         user.age = None
         field = fields.Integer(dump_default=0)
-        assert field.serialize("age", user) is None
+        assert field.serialize(user.age, "age", user) is None
         # missing
-        assert field.serialize("age", {}) == 0
+        assert field.serialize(0, "age", {}) == 0
 
     def test_integer_field_default_set_to_none(self, user):
         user.age = None
         field = fields.Integer(dump_default=None)
-        assert field.serialize("age", user) is None
+        assert field.serialize(user.age, "age", user) is None
 
     def test_uuid_field(self, user):
         user.uuid1 = uuid.UUID("12345678123456781234567812345678")
         user.uuid2 = None
 
         field = fields.UUID()
-        assert isinstance(field.serialize("uuid1", user), str)
-        assert field.serialize("uuid1", user) == "12345678-1234-5678-1234-567812345678"
-        assert field.serialize("uuid2", user) is None
+        assert isinstance(field.serialize(user.uuid1, "uuid1", user), str)
+        assert (
+            field.serialize(user.uuid1, "uuid1", user)
+            == "12345678-1234-5678-1234-567812345678"
+        )
+        assert field.serialize(user.uuid2, "uuid2", user) is None
 
     def test_ip_address_field(self, user):
         ipv4_string = "192.168.0.1"
@@ -134,15 +137,15 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field_compressed = fields.IP()
-        assert isinstance(field_compressed.serialize("ipv4", user), str)
-        assert field_compressed.serialize("ipv4", user) == ipv4_string
-        assert isinstance(field_compressed.serialize("ipv6", user), str)
-        assert field_compressed.serialize("ipv6", user) == ipv6_string
-        assert field_compressed.serialize("empty_ip", user) is None
+        assert isinstance(field_compressed.serialize(user.ipv4, "ipv4", user), str)
+        assert field_compressed.serialize(user.ipv4, "ipv4", user) == ipv4_string
+        assert isinstance(field_compressed.serialize(user.ipv6, "ipv6", user), str)
+        assert field_compressed.serialize(user.ipv6, "ipv6", user) == ipv6_string
+        assert field_compressed.serialize(user.empty_ip, "empty_ip", user) is None
 
         field_exploded = fields.IP(exploded=True)
-        assert isinstance(field_exploded.serialize("ipv6", user), str)
-        assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(user.ipv6, "ipv6", user), str)
+        assert field_exploded.serialize(user.ipv6, "ipv6", user) == ipv6_exploded_string
 
     def test_ipv4_address_field(self, user):
         ipv4_string = "192.168.0.1"
@@ -151,9 +154,9 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field = fields.IPv4()
-        assert isinstance(field.serialize("ipv4", user), str)
-        assert field.serialize("ipv4", user) == ipv4_string
-        assert field.serialize("empty_ip", user) is None
+        assert isinstance(field.serialize(user.ipv4, "ipv4", user), str)
+        assert field.serialize(user.ipv4, "ipv4", user) == ipv4_string
+        assert field.serialize(user.empty_ip, "empty_ip", user) is None
 
     def test_ipv6_address_field(self, user):
         ipv6_string = "ffff::ffff"
@@ -163,13 +166,13 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field_compressed = fields.IPv6()
-        assert isinstance(field_compressed.serialize("ipv6", user), str)
-        assert field_compressed.serialize("ipv6", user) == ipv6_string
-        assert field_compressed.serialize("empty_ip", user) is None
+        assert isinstance(field_compressed.serialize(user.ipv6, "ipv6", user), str)
+        assert field_compressed.serialize(user.ipv6, "ipv6", user) == ipv6_string
+        assert field_compressed.serialize(user.empty_ip, "empty_ip", user) is None
 
         field_exploded = fields.IPv6(exploded=True)
-        assert isinstance(field_exploded.serialize("ipv6", user), str)
-        assert field_exploded.serialize("ipv6", user) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(user.ipv6, "ipv6", user), str)
+        assert field_exploded.serialize(user.ipv6, "ipv6", user) == ipv6_exploded_string
 
     def test_ip_interface_field(self, user):
         ipv4interface_string = "192.168.0.1/24"
@@ -183,16 +186,33 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field_compressed = fields.IPInterface()
-        assert isinstance(field_compressed.serialize("ipv4interface", user), str)
-        assert field_compressed.serialize("ipv4interface", user) == ipv4interface_string
-        assert isinstance(field_compressed.serialize("ipv6interface", user), str)
-        assert field_compressed.serialize("ipv6interface", user) == ipv6interface_string
-        assert field_compressed.serialize("empty_ipinterface", user) is None
+        assert isinstance(
+            field_compressed.serialize(user.ipv4interface, "ipv4interface", user), str
+        )
+        assert (
+            field_compressed.serialize(user.ipv4interface, "ipv4interface", user)
+            == ipv4interface_string
+        )
+        assert isinstance(
+            field_compressed.serialize(user.ipv6interface, "ipv6interface", user), str
+        )
+        assert (
+            field_compressed.serialize(user.ipv6interface, "ipv6interface", user)
+            == ipv6interface_string
+        )
+        assert (
+            field_compressed.serialize(
+                user.empty_ipinterface, "empty_ipinterface", user
+            )
+            is None
+        )
 
         field_exploded = fields.IPInterface(exploded=True)
-        assert isinstance(field_exploded.serialize("ipv6interface", user), str)
+        assert isinstance(
+            field_exploded.serialize(user.ipv6interface, "ipv6interface", user), str
+        )
         assert (
-            field_exploded.serialize("ipv6interface", user)
+            field_exploded.serialize(user.ipv6interface, "ipv6interface", user)
             == ipv6interface_exploded_string
         )
 
@@ -203,9 +223,16 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field = fields.IPv4Interface()
-        assert isinstance(field.serialize("ipv4interface", user), str)
-        assert field.serialize("ipv4interface", user) == ipv4interface_string
-        assert field.serialize("empty_ipinterface", user) is None
+        assert isinstance(
+            field.serialize(user.ipv4interface, "ipv4interface", user), str
+        )
+        assert (
+            field.serialize(user.ipv4interface, "ipv4interface", user)
+            == ipv4interface_string
+        )
+        assert (
+            field.serialize(user.empty_ipinterface, "empty_ipinterface", user) is None
+        )
 
     def test_ipv6_interface_field(self, user):
         ipv6interface_string = "ffff::ffff/128"
@@ -217,41 +244,53 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field_compressed = fields.IPv6Interface()
-        assert isinstance(field_compressed.serialize("ipv6interface", user), str)
-        assert field_compressed.serialize("ipv6interface", user) == ipv6interface_string
-        assert field_compressed.serialize("empty_ipinterface", user) is None
+        assert isinstance(
+            field_compressed.serialize(user.ipv6interface, "ipv6interface", user), str
+        )
+        assert (
+            field_compressed.serialize(user.ipv6interface, "ipv6interface", user)
+            == ipv6interface_string
+        )
+        assert (
+            field_compressed.serialize(
+                user.empty_ipinterface, "empty_ipinterface", user
+            )
+            is None
+        )
 
         field_exploded = fields.IPv6Interface(exploded=True)
-        assert isinstance(field_exploded.serialize("ipv6interface", user), str)
+        assert isinstance(
+            field_exploded.serialize(user.ipv6interface, "ipv6interface", user), str
+        )
         assert (
-            field_exploded.serialize("ipv6interface", user)
+            field_exploded.serialize(user.ipv6interface, "ipv6interface", user)
             == ipv6interface_exploded_string
         )
 
     def test_enum_field_by_symbol_serialization(self, user):
         user.sex = GenderEnum.male
         field = fields.Enum(GenderEnum)
-        assert field.serialize("sex", user) == "male"
+        assert field.serialize(user.sex, "sex", user) == "male"
 
     def test_enum_field_by_value_true_serialization(self, user):
         user.hair_color = HairColorEnum.black
         field = fields.Enum(HairColorEnum, by_value=True)
-        assert field.serialize("hair_color", user) == "black hair"
+        assert field.serialize(user.hair_color, "hair_color", user) == "black hair"
         user.sex = GenderEnum.male
         field2 = fields.Enum(GenderEnum, by_value=True)
-        assert field2.serialize("sex", user) == 1
+        assert field2.serialize(user.sex, "sex", user) == 1
         user.some_date = DateEnum.date_1
 
     def test_enum_field_by_value_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
         field = fields.Enum(HairColorEnum, by_value=fields.String)
-        assert field.serialize("hair_color", user) == "black hair"
+        assert field.serialize(user.hair_color, "hair_color", user) == "black hair"
         user.sex = GenderEnum.male
         field2 = fields.Enum(GenderEnum, by_value=fields.Integer)
-        assert field2.serialize("sex", user) == 1
+        assert field2.serialize(user.sex, "sex", user) == 1
         user.some_date = DateEnum.date_1
         field3 = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
-        assert field3.serialize("some_date", user) == "29/02/2004"
+        assert field3.serialize(user.some_date, "some_date", user) == "29/02/2004"
 
     def test_decimal_field(self, user):
         user.m1 = 12
@@ -260,31 +299,31 @@ class TestFieldSerialization:
         user.m4 = None
 
         field = fields.Decimal()
-        assert isinstance(field.serialize("m1", user), decimal.Decimal)
-        assert field.serialize("m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize("m2", user), decimal.Decimal)
-        assert field.serialize("m2", user) == decimal.Decimal("12.355")
-        assert isinstance(field.serialize("m3", user), decimal.Decimal)
-        assert field.serialize("m3", user) == decimal.Decimal(1)
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
+        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
+        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.355")
+        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
+        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
+        assert field.serialize(user.m4, "m4", user) is None
 
         field = fields.Decimal(1)
-        assert isinstance(field.serialize("m1", user), decimal.Decimal)
-        assert field.serialize("m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize("m2", user), decimal.Decimal)
-        assert field.serialize("m2", user) == decimal.Decimal("12.4")
-        assert isinstance(field.serialize("m3", user), decimal.Decimal)
-        assert field.serialize("m3", user) == decimal.Decimal(1)
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
+        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
+        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.4")
+        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
+        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
+        assert field.serialize(user.m4, "m4", user) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN)
-        assert isinstance(field.serialize("m1", user), decimal.Decimal)
-        assert field.serialize("m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize("m2", user), decimal.Decimal)
-        assert field.serialize("m2", user) == decimal.Decimal("12.3")
-        assert isinstance(field.serialize("m3", user), decimal.Decimal)
-        assert field.serialize("m3", user) == decimal.Decimal(1)
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
+        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
+        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.3")
+        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
+        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
+        assert field.serialize(user.m4, "m4", user) is None
 
     def test_decimal_field_string(self, user):
         user.m1 = 12
@@ -293,31 +332,31 @@ class TestFieldSerialization:
         user.m4 = None
 
         field = fields.Decimal(as_string=True)
-        assert isinstance(field.serialize("m1", user), str)
-        assert field.serialize("m1", user) == "12"
-        assert isinstance(field.serialize("m2", user), str)
-        assert field.serialize("m2", user) == "12.355"
-        assert isinstance(field.serialize("m3", user), str)
-        assert field.serialize("m3", user) == "1"
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), str)
+        assert field.serialize(user.m1, "m1", user) == "12"
+        assert isinstance(field.serialize(user.m2, "m2", user), str)
+        assert field.serialize(user.m2, "m2", user) == "12.355"
+        assert isinstance(field.serialize(user.m3, "m3", user), str)
+        assert field.serialize(user.m3, "m3", user) == "1"
+        assert field.serialize(user.m4, "m4", user) is None
 
         field = fields.Decimal(1, as_string=True)
-        assert isinstance(field.serialize("m1", user), str)
-        assert field.serialize("m1", user) == "12.0"
-        assert isinstance(field.serialize("m2", user), str)
-        assert field.serialize("m2", user) == "12.4"
-        assert isinstance(field.serialize("m3", user), str)
-        assert field.serialize("m3", user) == "1.0"
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), str)
+        assert field.serialize(user.m1, "m1", user) == "12.0"
+        assert isinstance(field.serialize(user.m2, "m2", user), str)
+        assert field.serialize(user.m2, "m2", user) == "12.4"
+        assert isinstance(field.serialize(user.m3, "m3", user), str)
+        assert field.serialize(user.m3, "m3", user) == "1.0"
+        assert field.serialize(user.m4, "m4", user) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN, as_string=True)
-        assert isinstance(field.serialize("m1", user), str)
-        assert field.serialize("m1", user) == "12.0"
-        assert isinstance(field.serialize("m2", user), str)
-        assert field.serialize("m2", user) == "12.3"
-        assert isinstance(field.serialize("m3", user), str)
-        assert field.serialize("m3", user) == "1.0"
-        assert field.serialize("m4", user) is None
+        assert isinstance(field.serialize(user.m1, "m1", user), str)
+        assert field.serialize(user.m1, "m1", user) == "12.0"
+        assert isinstance(field.serialize(user.m2, "m2", user), str)
+        assert field.serialize(user.m2, "m2", user) == "12.3"
+        assert isinstance(field.serialize(user.m3, "m3", user), str)
+        assert field.serialize(user.m3, "m3", user) == "1.0"
+        assert field.serialize(user.m4, "m4", user) is None
 
     def test_decimal_field_special_values(self, user):
         user.m1 = "-NaN"
@@ -330,52 +369,52 @@ class TestFieldSerialization:
 
         field = fields.Decimal(places=2, allow_nan=True)
 
-        m1s = field.serialize("m1", user)
+        m1s = field.serialize(user.m1, "m1", user)
         assert isinstance(m1s, decimal.Decimal)
         assert m1s.is_qnan()
         assert not m1s.is_signed()
 
-        m2s = field.serialize("m2", user)
+        m2s = field.serialize(user.m2, "m2", user)
         assert isinstance(m2s, decimal.Decimal)
         assert m2s.is_qnan()
         assert not m2s.is_signed()
 
-        m3s = field.serialize("m3", user)
+        m3s = field.serialize(user.m3, "m3", user)
         assert isinstance(m3s, decimal.Decimal)
         assert m3s.is_qnan()
         assert not m3s.is_signed()
 
-        m4s = field.serialize("m4", user)
+        m4s = field.serialize(user.m4, "m4", user)
         assert isinstance(m4s, decimal.Decimal)
         assert m4s.is_qnan()
         assert not m4s.is_signed()
 
-        m5s = field.serialize("m5", user)
+        m5s = field.serialize(user.m5, "m5", user)
         assert isinstance(m5s, decimal.Decimal)
         assert m5s.is_infinite()
         assert m5s.is_signed()
 
-        m6s = field.serialize("m6", user)
+        m6s = field.serialize(user.m6, "m6", user)
         assert isinstance(m6s, decimal.Decimal)
         assert m6s.is_infinite()
         assert not m6s.is_signed()
 
-        m7s = field.serialize("m7", user)
+        m7s = field.serialize(user.m7, "m7", user)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
 
         field = fields.Decimal(as_string=True, allow_nan=True)
 
-        m2s = field.serialize("m2", user)
+        m2s = field.serialize(user.m2, "m2", user)
         assert isinstance(m2s, str)
         assert m2s == user.m2
 
-        m5s = field.serialize("m5", user)
+        m5s = field.serialize(user.m5, "m5", user)
         assert isinstance(m5s, str)
         assert m5s == user.m5
 
-        m6s = field.serialize("m6", user)
+        m6s = field.serialize(user.m6, "m6", user)
         assert isinstance(m6s, str)
         assert m6s == user.m6
 
@@ -384,7 +423,7 @@ class TestFieldSerialization:
 
         field = fields.Decimal(places=2)
 
-        m7s = field.serialize("m7", user)
+        m7s = field.serialize(user.m7, "m7", user)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
@@ -397,34 +436,34 @@ class TestFieldSerialization:
         user.m1 = "0.00000000100000000"
 
         field = fields.Decimal()
-        s = field.serialize("m1", user)
+        s = field.serialize(user.m1, "m1", user)
         assert isinstance(s, decimal.Decimal)
         assert s == decimal.Decimal("1.00000000E-9")
 
         field = fields.Decimal(as_string=True)
-        s = field.serialize("m1", user)
+        s = field.serialize(user.m1, "m1", user)
         assert isinstance(s, str)
         assert s == user.m1
 
         field = fields.Decimal(as_string=True, places=2)
-        s = field.serialize("m1", user)
+        s = field.serialize(user.m1, "m1", user)
         assert isinstance(s, str)
         assert s == "0.00"
 
     def test_email_field_serialize_none(self, user):
         user.email = None
         field = fields.Email()
-        assert field.serialize("email", user) is None
+        assert field.serialize(user.email, "email", user) is None
 
     def test_dict_field_serialize_none(self, user):
         user.various_data = None
         field = fields.Dict()
-        assert field.serialize("various_data", user) is None
+        assert field.serialize(user.various_data, "various_data", user) is None
 
     def test_dict_field_serialize(self, user):
         user.various_data = {"foo": "bar"}
         field = fields.Dict()
-        dump = field.serialize("various_data", user)
+        dump = field.serialize(user.various_data, "various_data", user)
         assert dump == {"foo": "bar"}
         # Check dump is a distinct object
         dump["foo"] = "baz"
@@ -433,29 +472,29 @@ class TestFieldSerialization:
     def test_dict_field_serialize_ordereddict(self, user):
         user.various_data = OrderedDict([("foo", "bar"), ("bar", "baz")])
         field = fields.Dict()
-        assert field.serialize("various_data", user) == OrderedDict(
+        assert field.serialize(user.various_data, "various_data", user) == OrderedDict(
             [("foo", "bar"), ("bar", "baz")]
         )
 
     def test_structured_dict_value_serialize(self, user):
         user.various_data = {"foo": decimal.Decimal(1)}
         field = fields.Dict(values=fields.Decimal)
-        assert field.serialize("various_data", user) == {"foo": 1}
+        assert field.serialize(user.various_data, "various_data", user) == {"foo": 1}
 
     def test_structured_dict_key_serialize(self, user):
         user.various_data = {1: "bar"}
         field = fields.Dict(keys=fields.Str)
-        assert field.serialize("various_data", user) == {"1": "bar"}
+        assert field.serialize(user.various_data, "various_data", user) == {"1": "bar"}
 
     def test_structured_dict_key_value_serialize(self, user):
         user.various_data = {1: decimal.Decimal(1)}
         field = fields.Dict(keys=fields.Str, values=fields.Decimal)
-        assert field.serialize("various_data", user) == {"1": 1}
+        assert field.serialize(user.various_data, "various_data", user) == {"1": 1}
 
     def test_url_field_serialize_none(self, user):
         user.homepage = None
         field = fields.Url()
-        assert field.serialize("homepage", user) is None
+        assert field.serialize(user.homepage, "homepage", user) is None
 
     def test_method_field_with_method_missing(self):
         class BadSerializer(Schema):
@@ -497,7 +536,7 @@ class TestFieldSerialization:
         m = fields.Method()
         m.parent = Schema()
 
-        assert m.serialize("", "", None) is missing_
+        assert m.serialize(missing_, "", None) is missing_
 
     def test_serialize_with_data_key_param(self):
         class DumpToSchema(Schema):
@@ -547,7 +586,7 @@ class TestFieldSerialization:
     )
     def test_datetime_field_rfc822(self, fmt, value, expected):
         field = fields.DateTime(format=fmt)
-        assert field.serialize("d", {"d": value}) == expected
+        assert field.serialize(value, "d", {"d": value}) == expected
 
     @pytest.mark.parametrize(
         ("fmt", "value", "expected"),
@@ -579,7 +618,7 @@ class TestFieldSerialization:
     )
     def test_datetime_field_timestamp(self, fmt, value, expected):
         field = fields.DateTime(format=fmt)
-        assert field.serialize("d", {"d": value}) == expected
+        assert field.serialize(value, "d", {"d": value}) == expected
 
     @pytest.mark.parametrize("fmt", ["iso", "iso8601", None])
     @pytest.mark.parametrize(
@@ -606,32 +645,36 @@ class TestFieldSerialization:
             field = fields.DateTime()
         else:
             field = fields.DateTime(format=fmt)
-        assert field.serialize("d", {"d": value}) == expected
+        assert field.serialize(value, "d", {"d": value}) == expected
 
     def test_datetime_field_format(self, user):
         datetimeformat = "%Y-%m-%d"
         field = fields.DateTime(format=datetimeformat)
-        assert field.serialize("created", user) == user.created.strftime(datetimeformat)
+        assert field.serialize(user.created, "created", user) == user.created.strftime(
+            datetimeformat
+        )
 
     def test_string_field(self):
         field = fields.String()
         user = User(name=b"foo")
-        assert field.serialize("name", user) == "foo"
+        assert field.serialize(user.name, "name", user) == "foo"
         field = fields.String(allow_none=True)
         user.name = None
-        assert field.serialize("name", user) is None
+        assert field.serialize(user.name, "name", user) is None
 
     def test_string_field_default_to_empty_string(self, user):
         field = fields.String(dump_default="")
-        assert field.serialize("notfound", {}) == ""
+        assert field.serialize("", "notfound", {}) == ""
 
     def test_time_field(self, user):
         field = fields.Time()
         expected = user.time_registered.isoformat()[:15]
-        assert field.serialize("time_registered", user) == expected
+        assert (
+            field.serialize(user.time_registered, "time_registered", user) == expected
+        )
 
         user.time_registered = None
-        assert field.serialize("time_registered", user) is None
+        assert field.serialize(user.time_registered, "time_registered", user) is None
 
     @pytest.mark.parametrize("fmt", ["iso", "iso8601", None])
     @pytest.mark.parametrize(
@@ -648,19 +691,24 @@ class TestFieldSerialization:
             field = fields.Time()
         else:
             field = fields.Time(format=fmt)
-        assert field.serialize("d", {"d": value}) == expected
+        assert field.serialize(value, "d", {"d": value}) == expected
 
     def test_time_field_format(self, user):
         fmt = "%H:%M:%S"
         field = fields.Time(format=fmt)
-        assert field.serialize("birthtime", user) == user.birthtime.strftime(fmt)
+        assert field.serialize(
+            user.birthtime, "birthtime", user
+        ) == user.birthtime.strftime(fmt)
 
     def test_date_field(self, user):
         field = fields.Date()
-        assert field.serialize("birthdate", user) == user.birthdate.isoformat()
+        assert (
+            field.serialize(user.birthdate, "birthdate", user)
+            == user.birthdate.isoformat()
+        )
 
         user.birthdate = None
-        assert field.serialize("birthdate", user) is None
+        assert field.serialize(user.birthdate, "birthdate", user) is None
 
     def test_timedelta_field(self, user):
         user.d1 = dt.timedelta(days=1, seconds=1, microseconds=1)
@@ -679,67 +727,67 @@ class TestFieldSerialization:
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d1", user) == 1.0000115740856481
+        assert field.serialize(user.d1, "d1", user) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d1", user) == 86401.000001
+        assert field.serialize(user.d1, "d1", user) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d1", user) == 86401000001
+        assert field.serialize(user.d1, "d1", user) == 86401000001
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize("d1", user) == 24.000277778055555
+        assert field.serialize(user.d1, "d1", user) == 24.000277778055555
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d2", user) == 1.0000115740856481
+        assert field.serialize(user.d2, "d2", user) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d2", user) == 86401.000001
+        assert field.serialize(user.d2, "d2", user) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d2", user) == 86401000001
+        assert field.serialize(user.d2, "d2", user) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d3", user) == 1.0000115740856481
+        assert field.serialize(user.d3, "d3", user) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d3", user) == 86401.000001
+        assert field.serialize(user.d3, "d3", user) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d3", user) == 86401000001
+        assert field.serialize(user.d3, "d3", user) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d4", user) == 0
+        assert field.serialize(user.d4, "d4", user) == 0
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d4", user) == 0
+        assert field.serialize(user.d4, "d4", user) == 0
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d4", user) == 0
+        assert field.serialize(user.d4, "d4", user) == 0
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d5", user) == -1
+        assert field.serialize(user.d5, "d5", user) == -1
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d5", user) == -86400
+        assert field.serialize(user.d5, "d5", user) == -86400
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d5", user) == -86400000000
+        assert field.serialize(user.d5, "d5", user) == -86400000000
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
-        assert field.serialize("d6", user) == 1.1489103852529763
+        assert field.serialize(user.d6, "d6", user) == 1.1489103852529763
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize("d6", user) == 8.042372696770833
+        assert field.serialize(user.d6, "d6", user) == 8.042372696770833
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize("d6", user) == 193.0169447225
+        assert field.serialize(user.d6, "d6", user) == 193.0169447225
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
-        assert field.serialize("d6", user) == 11581.01668335
+        assert field.serialize(user.d6, "d6", user) == 11581.01668335
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d6", user) == 694861.001001
+        assert field.serialize(user.d6, "d6", user) == 694861.001001
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize("d6", user) == 694861001.001
+        assert field.serialize(user.d6, "d6", user) == 694861001.001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize("d6", user) == 694861001001
+        assert field.serialize(user.d6, "d6", user) == 694861001001
 
         user.d7 = None
-        assert field.serialize("d7", user) is None
+        assert field.serialize(user.d7, "d7", user) is None
 
         user.d8 = dt.timedelta(milliseconds=345)
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize("d8", user) == 345
+        assert field.serialize(user.d8, "d8", user) == 345
 
         user.d9 = dt.timedelta(milliseconds=1999)
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize("d9", user) == 1.999
+        assert field.serialize(user.d9, "d9", user) == 1.999
 
         user.d10 = dt.timedelta(
             weeks=1,
@@ -754,52 +802,60 @@ class TestFieldSerialization:
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         unit_value = dt.timedelta(microseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
         unit_value = dt.timedelta(milliseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert math.isclose(field.serialize("d10", user), user.d10.total_seconds())
+        assert math.isclose(
+            field.serialize(user.d10, "d10", user), user.d10.total_seconds()
+        )
 
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
         unit_value = dt.timedelta(minutes=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
         unit_value = dt.timedelta(hours=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         unit_value = dt.timedelta(days=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
         unit_value = dt.timedelta(weeks=1).total_seconds()
         assert math.isclose(
-            field.serialize("d10", user), user.d10.total_seconds() / unit_value
+            field.serialize(user.d10, "d10", user),
+            user.d10.total_seconds() / unit_value,
         )
 
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.now(dt.timezone.utc), dt.datetime.now()])
         field = fields.List(fields.DateTime)
-        result = field.serialize("dtimes", obj)
+        result = field.serialize(obj.dtimes, "dtimes", obj)
         assert all(type(each) is str for each in result)
 
     def test_list_field_serialize_none_returns_none(self):
         obj = DateTimeList(None)
         field = fields.List(fields.DateTime)
-        assert field.serialize("dtimes", obj) is None
+        assert field.serialize(obj.dtimes, "dtimes", obj) is None
 
     def test_list_field_work_with_generator_single_value(self):
         def custom_generator():
@@ -807,7 +863,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime)
-        result = field.serialize("dtimes", obj)
+        result = field.serialize(obj.dtimes, "dtimes", obj)
         assert len(result) == 1
 
     def test_list_field_work_with_generators_multiple_values(self):
@@ -816,7 +872,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime)
-        result = field.serialize("dtimes", obj)
+        result = field.serialize(obj.dtimes, "dtimes", obj)
         assert len(result) == 2
 
     def test_list_field_work_with_generators_empty_generator_returns_none_for_every_non_returning_yield_statement(
@@ -828,7 +884,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime, allow_none=True)
-        result = field.serialize("dtimes", obj)
+        result = field.serialize(obj.dtimes, "dtimes", obj)
         assert len(result) == 2
         assert result[0] is None
         assert result[1] is None
@@ -837,7 +893,7 @@ class TestFieldSerialization:
         custom_set = {1, 2, 3}
         obj = IntegerList(custom_set)
         field = fields.List(fields.Int)
-        result = field.serialize("ints", obj)
+        result = field.serialize(obj.ints, "ints", obj)
         assert len(result) == 3
         assert 1 in result
         assert 2 in result
@@ -854,7 +910,7 @@ class TestFieldSerialization:
         ints = IteratorSupportingClass([1, 2, 3])
         obj = IntegerList(ints)
         field = fields.List(fields.Int)
-        result = field.serialize("ints", obj)
+        result = field.serialize(obj.ints, "ints", obj)
         assert len(result) == 3
         assert result[0] == 1
         assert result[1] == 2
@@ -876,14 +932,14 @@ class TestFieldSerialization:
     def test_datetime_integer_tuple_field(self):
         obj = DateTimeIntegerTuple((dt.datetime.now(dt.timezone.utc), 42))
         field = fields.Tuple([fields.DateTime, fields.Integer])
-        result = field.serialize("dtime_int", obj)
+        result = field.serialize(obj.dtime_int, "dtime_int", obj)
         assert type(result[0]) is str
         assert type(result[1]) is int
 
     def test_tuple_field_serialize_none_returns_none(self):
         obj = DateTimeIntegerTuple(None)
         field = fields.Tuple([fields.DateTime, fields.Integer])
-        assert field.serialize("dtime_int", obj) is None
+        assert field.serialize(obj.dtime_int, "dtime_int", obj) is None
 
     def test_bad_tuple_field(self):
         class ASchema(Schema):
@@ -903,11 +959,11 @@ class TestFieldSerialization:
     def test_serialize_does_not_apply_validators(self, user):
         field = fields.Raw(validate=lambda x: False)
         # No validation error raised
-        assert field.serialize("age", user) == user.age
+        assert field.serialize(user.age, "age", user) == user.age
 
     def test_constant_field_serialization(self, user):
         field = fields.Constant("something")
-        assert field.serialize("whatever", user) == "something"
+        assert field.serialize("whatever", "whatever", user) == "something"
 
     def test_constant_is_always_included_in_serialized_data(self):
         class MySchema(Schema):
@@ -927,7 +983,7 @@ class TestFieldSerialization:
     @pytest.mark.parametrize("FieldClass", ALL_FIELDS)
     def test_all_fields_serialize_none_to_none(self, FieldClass):
         field = FieldClass(allow_none=True)
-        res = field.serialize("foo", {"foo": None})
+        res = field.serialize(None, "foo", {"foo": None})
         assert res is None
 
 
@@ -958,7 +1014,7 @@ def test_serializing_named_tuple():
 
     p = Point(x=4, y=2)
 
-    assert field.serialize("x", p) == 4
+    assert field.serialize(p.x, "x", p) == 4
 
 
 def test_serializing_named_tuple_with_meta():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -42,11 +42,11 @@ class TestFieldSerialization:
         return User("Foo", email="foo@bar.com", age=42)
 
     def test_function_field_passed_func(self, user):
-        field = fields.Function(lambda obj: obj.name.upper())
-        assert field.serialize("key", user) == "FOO"
+        field = fields.Function(lambda value: value.upper())
+        assert field.serialize("name", user) == "FOO"
 
     def test_function_field_passed_serialize_only_is_dump_only(self, user):
-        field = fields.Function(serialize=lambda obj: obj.name.upper())
+        field = fields.Function(serialize=lambda value: value.upper())
         assert field.dump_only is True
 
     def test_function_field_passed_deserialize_and_serialize_is_not_dump_only(self):
@@ -56,17 +56,17 @@ class TestFieldSerialization:
         assert field.dump_only is False
 
     def test_function_field_passed_serialize(self, user):
-        field = fields.Function(serialize=lambda obj: obj.name.upper())
-        assert field.serialize("key", user) == "FOO"
+        field = fields.Function(serialize=lambda value: value.upper())
+        assert field.serialize("name", user) == "FOO"
 
     # https://github.com/marshmallow-code/marshmallow/issues/395
     def test_function_field_does_not_swallow_attribute_error(self, user):
-        def raise_error(obj):
+        def raise_error(value):
             raise AttributeError
 
         field = fields.Function(serialize=raise_error)
         with pytest.raises(AttributeError):
-            field.serialize("key", user)
+            field.serialize("name", user)
 
     def test_serialize_with_load_only_param(self):
         class AliasingUserSerializer(Schema):
@@ -487,11 +487,11 @@ class TestFieldSerialization:
         class MySchema(Schema):
             mfield = fields.Method("raise_error")
 
-            def raise_error(self, obj):
+            def raise_error(self, value):
                 raise AttributeError
 
         with pytest.raises(AttributeError):
-            MySchema().dump({})
+            MySchema().dump({"mfield": "something"})
 
     def test_method_with_no_serialize_is_missing(self):
         m = fields.Method()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -13,7 +13,7 @@ import pytest
 
 from marshmallow import Schema, fields
 from marshmallow import missing as missing_
-from tests.base import ALL_FIELDS, DateEnum, GenderEnum, HairColorEnum, User, central
+from tests.base import ALL_FIELDS, DateEnum, GenderEnum, HairColorEnum, central
 
 
 class Point(NamedTuple):
@@ -37,15 +37,11 @@ class DateTimeIntegerTuple:
 
 
 class TestFieldSerialization:
-    @pytest.fixture
-    def user(self):
-        return User("Foo", email="foo@bar.com", age=42)
-
-    def test_function_field_passed_func(self, user):
+    def test_function_field_passed_func(self):
         field = fields.Function(lambda value: value.upper())
-        assert field.serialize(user.name) == "FOO"
+        assert field.serialize("Foo") == "FOO"
 
-    def test_function_field_passed_serialize_only_is_dump_only(self, user):
+    def test_function_field_passed_serialize_only_is_dump_only(self):
         field = fields.Function(serialize=lambda value: value.upper())
         assert field.dump_only is True
 
@@ -55,18 +51,18 @@ class TestFieldSerialization:
         )
         assert field.dump_only is False
 
-    def test_function_field_passed_serialize(self, user):
+    def test_function_field_passed_serialize(self):
         field = fields.Function(serialize=lambda value: value.upper())
-        assert field.serialize(user.name) == "FOO"
+        assert field.serialize("Foo") == "FOO"
 
     # https://github.com/marshmallow-code/marshmallow/issues/395
-    def test_function_field_does_not_swallow_attribute_error(self, user):
+    def test_function_field_does_not_swallow_attribute_error(self):
         def raise_error(value):
             raise AttributeError
 
         field = fields.Function(serialize=raise_error)
         with pytest.raises(AttributeError):
-            field.serialize(user.name)
+            field.serialize("Foo")
 
     def test_serialize_with_load_only_param(self):
         class AliasingUserSerializer(Schema):
@@ -95,367 +91,336 @@ class TestFieldSerialization:
         with pytest.raises(TypeError):
             fields.Function("uncallable")  # type: ignore[arg-type]
 
-    def test_integer_field(self, user):
+    def test_integer_field(self):
         field = fields.Integer()
-        assert field.serialize(user.age) == 42
+        assert field.serialize(42) == 42
 
-    def test_integer_as_string_field(self, user):
+    def test_integer_as_string_field(self):
         field = fields.Integer(as_string=True)
-        assert field.serialize(user.age) == "42"
+        assert field.serialize(42) == "42"
 
-    def test_integer_field_default(self, user):
-        user.age = None
+    def test_integer_field_default(self):
         field = fields.Integer(dump_default=0)
-        assert field.serialize(user.age) is None
+        assert field.serialize(None) is None
         # missing
         assert field.serialize(0) == 0
 
-    def test_integer_field_default_set_to_none(self, user):
-        user.age = None
+    def test_integer_field_default_set_to_none(self):
         field = fields.Integer(dump_default=None)
-        assert field.serialize(user.age) is None
+        assert field.serialize(None) is None
 
-    def test_uuid_field(self, user):
-        user.uuid1 = uuid.UUID("12345678123456781234567812345678")
-        user.uuid2 = None
+    def test_uuid_field(self):
+        uuid1 = uuid.UUID("12345678123456781234567812345678")
 
         field = fields.UUID()
-        assert isinstance(field.serialize(user.uuid1), str)
-        assert field.serialize(user.uuid1) == "12345678-1234-5678-1234-567812345678"
-        assert field.serialize(user.uuid2) is None
+        assert isinstance(field.serialize(uuid1), str)
+        assert field.serialize(uuid1) == "12345678-1234-5678-1234-567812345678"
+        assert field.serialize(None) is None
 
-    def test_ip_address_field(self, user):
+    def test_ip_address_field(self):
         ipv4_string = "192.168.0.1"
         ipv6_string = "ffff::ffff"
         ipv6_exploded_string = ipaddress.ip_address("ffff::ffff").exploded
 
-        user.ipv4 = ipaddress.ip_address(ipv4_string)
-        user.ipv6 = ipaddress.ip_address(ipv6_string)
-        user.empty_ip = None
+        ipv4 = ipaddress.ip_address(ipv4_string)
+        ipv6 = ipaddress.ip_address(ipv6_string)
 
         field_compressed = fields.IP()
-        assert isinstance(field_compressed.serialize(user.ipv4), str)
-        assert field_compressed.serialize(user.ipv4) == ipv4_string
-        assert isinstance(field_compressed.serialize(user.ipv6), str)
-        assert field_compressed.serialize(user.ipv6) == ipv6_string
-        assert field_compressed.serialize(user.empty_ip) is None
+        assert isinstance(field_compressed.serialize(ipv4), str)
+        assert field_compressed.serialize(ipv4) == ipv4_string
+        assert isinstance(field_compressed.serialize(ipv6), str)
+        assert field_compressed.serialize(ipv6) == ipv6_string
+        assert field_compressed.serialize(None) is None
 
         field_exploded = fields.IP(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6), str)
-        assert field_exploded.serialize(user.ipv6) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(ipv6), str)
+        assert field_exploded.serialize(ipv6) == ipv6_exploded_string
 
-    def test_ipv4_address_field(self, user):
+    def test_ipv4_address_field(self):
         ipv4_string = "192.168.0.1"
 
-        user.ipv4 = ipaddress.ip_address(ipv4_string)
-        user.empty_ip = None
+        ipv4 = ipaddress.ip_address(ipv4_string)
 
         field = fields.IPv4()
-        assert isinstance(field.serialize(user.ipv4), str)
-        assert field.serialize(user.ipv4) == ipv4_string
-        assert field.serialize(user.empty_ip) is None
+        assert isinstance(field.serialize(ipv4), str)
+        assert field.serialize(ipv4) == ipv4_string
+        assert field.serialize(None) is None
 
-    def test_ipv6_address_field(self, user):
+    def test_ipv6_address_field(self):
         ipv6_string = "ffff::ffff"
         ipv6_exploded_string = ipaddress.ip_address("ffff::ffff").exploded
 
-        user.ipv6 = ipaddress.ip_address(ipv6_string)
-        user.empty_ip = None
+        ipv6 = ipaddress.ip_address(ipv6_string)
 
         field_compressed = fields.IPv6()
-        assert isinstance(field_compressed.serialize(user.ipv6), str)
-        assert field_compressed.serialize(user.ipv6) == ipv6_string
-        assert field_compressed.serialize(user.empty_ip) is None
+        assert isinstance(field_compressed.serialize(ipv6), str)
+        assert field_compressed.serialize(ipv6) == ipv6_string
+        assert field_compressed.serialize(None) is None
 
         field_exploded = fields.IPv6(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6), str)
-        assert field_exploded.serialize(user.ipv6) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(ipv6), str)
+        assert field_exploded.serialize(ipv6) == ipv6_exploded_string
 
-    def test_ip_interface_field(self, user):
+    def test_ip_interface_field(self):
         ipv4interface_string = "192.168.0.1/24"
         ipv6interface_string = "ffff::ffff/128"
         ipv6interface_exploded_string = ipaddress.ip_interface(
             "ffff::ffff/128"
         ).exploded
 
-        user.ipv4interface = ipaddress.ip_interface(ipv4interface_string)
-        user.ipv6interface = ipaddress.ip_interface(ipv6interface_string)
-        user.empty_ipinterface = None
+        ipv4interface = ipaddress.ip_interface(ipv4interface_string)
+        ipv6interface = ipaddress.ip_interface(ipv6interface_string)
 
         field_compressed = fields.IPInterface()
-        assert isinstance(field_compressed.serialize(user.ipv4interface), str)
-        assert field_compressed.serialize(user.ipv4interface) == ipv4interface_string
-        assert isinstance(field_compressed.serialize(user.ipv6interface), str)
-        assert field_compressed.serialize(user.ipv6interface) == ipv6interface_string
-        assert field_compressed.serialize(user.empty_ipinterface) is None
+        assert isinstance(field_compressed.serialize(ipv4interface), str)
+        assert field_compressed.serialize(ipv4interface) == ipv4interface_string
+        assert isinstance(field_compressed.serialize(ipv6interface), str)
+        assert field_compressed.serialize(ipv6interface) == ipv6interface_string
+        assert field_compressed.serialize(None) is None
 
         field_exploded = fields.IPInterface(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6interface), str)
-        assert (
-            field_exploded.serialize(user.ipv6interface)
-            == ipv6interface_exploded_string
-        )
+        assert isinstance(field_exploded.serialize(ipv6interface), str)
+        assert field_exploded.serialize(ipv6interface) == ipv6interface_exploded_string
 
-    def test_ipv4_interface_field(self, user):
+    def test_ipv4_interface_field(self):
         ipv4interface_string = "192.168.0.1/24"
 
-        user.ipv4interface = ipaddress.ip_interface(ipv4interface_string)
-        user.empty_ipinterface = None
+        ipv4interface = ipaddress.ip_interface(ipv4interface_string)
 
         field = fields.IPv4Interface()
-        assert isinstance(field.serialize(user.ipv4interface), str)
-        assert field.serialize(user.ipv4interface) == ipv4interface_string
-        assert field.serialize(user.empty_ipinterface) is None
+        assert isinstance(field.serialize(ipv4interface), str)
+        assert field.serialize(ipv4interface) == ipv4interface_string
+        assert field.serialize(None) is None
 
-    def test_ipv6_interface_field(self, user):
+    def test_ipv6_interface_field(self):
         ipv6interface_string = "ffff::ffff/128"
         ipv6interface_exploded_string = ipaddress.ip_interface(
             "ffff::ffff/128"
         ).exploded
 
-        user.ipv6interface = ipaddress.ip_interface(ipv6interface_string)
-        user.empty_ipinterface = None
+        ipv6interface = ipaddress.ip_interface(ipv6interface_string)
 
         field_compressed = fields.IPv6Interface()
-        assert isinstance(field_compressed.serialize(user.ipv6interface), str)
-        assert field_compressed.serialize(user.ipv6interface) == ipv6interface_string
-        assert field_compressed.serialize(user.empty_ipinterface) is None
+        assert isinstance(field_compressed.serialize(ipv6interface), str)
+        assert field_compressed.serialize(ipv6interface) == ipv6interface_string
+        assert field_compressed.serialize(None) is None
 
         field_exploded = fields.IPv6Interface(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6interface), str)
-        assert (
-            field_exploded.serialize(user.ipv6interface)
-            == ipv6interface_exploded_string
-        )
+        assert isinstance(field_exploded.serialize(ipv6interface), str)
+        assert field_exploded.serialize(ipv6interface) == ipv6interface_exploded_string
 
-    def test_enum_field_by_symbol_serialization(self, user):
-        user.sex = GenderEnum.male
+    def test_enum_field_by_symbol_serialization(self):
         field = fields.Enum(GenderEnum)
-        assert field.serialize(user.sex) == "male"
+        assert field.serialize(GenderEnum.male) == "male"
 
-    def test_enum_field_by_value_true_serialization(self, user):
-        user.hair_color = HairColorEnum.black
+    def test_enum_field_by_value_true_serialization(self):
         field = fields.Enum(HairColorEnum, by_value=True)
-        assert field.serialize(user.hair_color) == "black hair"
-        user.sex = GenderEnum.male
+        assert field.serialize(HairColorEnum.black) == "black hair"
         field2 = fields.Enum(GenderEnum, by_value=True)
-        assert field2.serialize(user.sex) == 1
-        user.some_date = DateEnum.date_1
+        assert field2.serialize(GenderEnum.male) == 1
 
-    def test_enum_field_by_value_field_serialization(self, user):
-        user.hair_color = HairColorEnum.black
+    def test_enum_field_by_value_field_serialization(self):
         field = fields.Enum(HairColorEnum, by_value=fields.String)
-        assert field.serialize(user.hair_color) == "black hair"
-        user.sex = GenderEnum.male
+        assert field.serialize(HairColorEnum.black) == "black hair"
         field2 = fields.Enum(GenderEnum, by_value=fields.Integer)
-        assert field2.serialize(user.sex) == 1
-        user.some_date = DateEnum.date_1
+        assert field2.serialize(GenderEnum.male) == 1
         field3 = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
-        assert field3.serialize(user.some_date) == "29/02/2004"
+        assert field3.serialize(DateEnum.date_1) == "29/02/2004"
 
-    def test_decimal_field(self, user):
-        user.m1 = 12
-        user.m2 = "12.355"
-        user.m3 = decimal.Decimal(1)
-        user.m4 = None
+    def test_decimal_field(self):
+        m1 = 12
+        m2 = "12.355"
+        m3 = decimal.Decimal(1)
+        m4 = None
 
         field = fields.Decimal()
-        assert isinstance(field.serialize(user.m1), decimal.Decimal)
-        assert field.serialize(user.m1) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2), decimal.Decimal)
-        assert field.serialize(user.m2) == decimal.Decimal("12.355")
-        assert isinstance(field.serialize(user.m3), decimal.Decimal)
-        assert field.serialize(user.m3) == decimal.Decimal(1)
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), decimal.Decimal)
+        assert field.serialize(m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(m2), decimal.Decimal)
+        assert field.serialize(m2) == decimal.Decimal("12.355")
+        assert isinstance(field.serialize(m3), decimal.Decimal)
+        assert field.serialize(m3) == decimal.Decimal(1)
+        assert field.serialize(m4) is None
 
         field = fields.Decimal(1)
-        assert isinstance(field.serialize(user.m1), decimal.Decimal)
-        assert field.serialize(user.m1) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2), decimal.Decimal)
-        assert field.serialize(user.m2) == decimal.Decimal("12.4")
-        assert isinstance(field.serialize(user.m3), decimal.Decimal)
-        assert field.serialize(user.m3) == decimal.Decimal(1)
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), decimal.Decimal)
+        assert field.serialize(m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(m2), decimal.Decimal)
+        assert field.serialize(m2) == decimal.Decimal("12.4")
+        assert isinstance(field.serialize(m3), decimal.Decimal)
+        assert field.serialize(m3) == decimal.Decimal(1)
+        assert field.serialize(m4) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN)
-        assert isinstance(field.serialize(user.m1), decimal.Decimal)
-        assert field.serialize(user.m1) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2), decimal.Decimal)
-        assert field.serialize(user.m2) == decimal.Decimal("12.3")
-        assert isinstance(field.serialize(user.m3), decimal.Decimal)
-        assert field.serialize(user.m3) == decimal.Decimal(1)
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), decimal.Decimal)
+        assert field.serialize(m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(m2), decimal.Decimal)
+        assert field.serialize(m2) == decimal.Decimal("12.3")
+        assert isinstance(field.serialize(m3), decimal.Decimal)
+        assert field.serialize(m3) == decimal.Decimal(1)
+        assert field.serialize(m4) is None
 
-    def test_decimal_field_string(self, user):
-        user.m1 = 12
-        user.m2 = "12.355"
-        user.m3 = decimal.Decimal(1)
-        user.m4 = None
+    def test_decimal_field_string(self):
+        m1 = 12
+        m2 = "12.355"
+        m3 = decimal.Decimal(1)
+        m4 = None
 
         field = fields.Decimal(as_string=True)
-        assert isinstance(field.serialize(user.m1), str)
-        assert field.serialize(user.m1) == "12"
-        assert isinstance(field.serialize(user.m2), str)
-        assert field.serialize(user.m2) == "12.355"
-        assert isinstance(field.serialize(user.m3), str)
-        assert field.serialize(user.m3) == "1"
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), str)
+        assert field.serialize(m1) == "12"
+        assert isinstance(field.serialize(m2), str)
+        assert field.serialize(m2) == "12.355"
+        assert isinstance(field.serialize(m3), str)
+        assert field.serialize(m3) == "1"
+        assert field.serialize(m4) is None
 
         field = fields.Decimal(1, as_string=True)
-        assert isinstance(field.serialize(user.m1), str)
-        assert field.serialize(user.m1) == "12.0"
-        assert isinstance(field.serialize(user.m2), str)
-        assert field.serialize(user.m2) == "12.4"
-        assert isinstance(field.serialize(user.m3), str)
-        assert field.serialize(user.m3) == "1.0"
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), str)
+        assert field.serialize(m1) == "12.0"
+        assert isinstance(field.serialize(m2), str)
+        assert field.serialize(m2) == "12.4"
+        assert isinstance(field.serialize(m3), str)
+        assert field.serialize(m3) == "1.0"
+        assert field.serialize(m4) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN, as_string=True)
-        assert isinstance(field.serialize(user.m1), str)
-        assert field.serialize(user.m1) == "12.0"
-        assert isinstance(field.serialize(user.m2), str)
-        assert field.serialize(user.m2) == "12.3"
-        assert isinstance(field.serialize(user.m3), str)
-        assert field.serialize(user.m3) == "1.0"
-        assert field.serialize(user.m4) is None
+        assert isinstance(field.serialize(m1), str)
+        assert field.serialize(m1) == "12.0"
+        assert isinstance(field.serialize(m2), str)
+        assert field.serialize(m2) == "12.3"
+        assert isinstance(field.serialize(m3), str)
+        assert field.serialize(m3) == "1.0"
+        assert field.serialize(m4) is None
 
-    def test_decimal_field_special_values(self, user):
-        user.m1 = "-NaN"
-        user.m2 = "NaN"
-        user.m3 = "-sNaN"
-        user.m4 = "sNaN"
-        user.m5 = "-Infinity"
-        user.m6 = "Infinity"
-        user.m7 = "-0"
+    def test_decimal_field_special_values(self):
+        m1 = "-NaN"
+        m2 = "NaN"
+        m3 = "-sNaN"
+        m4 = "sNaN"
+        m5 = "-Infinity"
+        m6 = "Infinity"
+        m7 = "-0"
 
         field = fields.Decimal(places=2, allow_nan=True)
 
-        m1s = field.serialize(user.m1)
+        m1s = field.serialize(m1)
         assert isinstance(m1s, decimal.Decimal)
         assert m1s.is_qnan()
         assert not m1s.is_signed()
 
-        m2s = field.serialize(user.m2)
+        m2s = field.serialize(m2)
         assert isinstance(m2s, decimal.Decimal)
         assert m2s.is_qnan()
         assert not m2s.is_signed()
 
-        m3s = field.serialize(user.m3)
+        m3s = field.serialize(m3)
         assert isinstance(m3s, decimal.Decimal)
         assert m3s.is_qnan()
         assert not m3s.is_signed()
 
-        m4s = field.serialize(user.m4)
+        m4s = field.serialize(m4)
         assert isinstance(m4s, decimal.Decimal)
         assert m4s.is_qnan()
         assert not m4s.is_signed()
 
-        m5s = field.serialize(user.m5)
+        m5s = field.serialize(m5)
         assert isinstance(m5s, decimal.Decimal)
         assert m5s.is_infinite()
         assert m5s.is_signed()
 
-        m6s = field.serialize(user.m6)
+        m6s = field.serialize(m6)
         assert isinstance(m6s, decimal.Decimal)
         assert m6s.is_infinite()
         assert not m6s.is_signed()
 
-        m7s = field.serialize(user.m7)
+        m7s = field.serialize(m7)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
 
         field = fields.Decimal(as_string=True, allow_nan=True)
 
-        m2s = field.serialize(user.m2)
+        m2s = field.serialize(m2)
         assert isinstance(m2s, str)
-        assert m2s == user.m2
+        assert m2s == m2
 
-        m5s = field.serialize(user.m5)
+        m5s = field.serialize(m5)
         assert isinstance(m5s, str)
-        assert m5s == user.m5
+        assert m5s == m5
 
-        m6s = field.serialize(user.m6)
+        m6s = field.serialize(m6)
         assert isinstance(m6s, str)
-        assert m6s == user.m6
+        assert m6s == m6
 
-    def test_decimal_field_special_values_not_permitted(self, user):
-        user.m7 = "-0"
-
+    def test_decimal_field_special_values_not_permitted(self):
         field = fields.Decimal(places=2)
 
-        m7s = field.serialize(user.m7)
+        m7s = field.serialize("-0")
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
 
-    def test_decimal_field_fixed_point_representation(self, user):
+    def test_decimal_field_fixed_point_representation(self):
         """
         Test we get fixed-point string representation for a Decimal number that would normally
         output in engineering notation.
         """
-        user.m1 = "0.00000000100000000"
+        m1 = "0.00000000100000000"
 
         field = fields.Decimal()
-        s = field.serialize(user.m1)
+        s = field.serialize(m1)
         assert isinstance(s, decimal.Decimal)
         assert s == decimal.Decimal("1.00000000E-9")
 
         field = fields.Decimal(as_string=True)
-        s = field.serialize(user.m1)
+        s = field.serialize(m1)
         assert isinstance(s, str)
-        assert s == user.m1
+        assert s == m1
 
         field = fields.Decimal(as_string=True, places=2)
-        s = field.serialize(user.m1)
+        s = field.serialize(m1)
         assert isinstance(s, str)
         assert s == "0.00"
 
-    def test_email_field_serialize_none(self, user):
-        user.email = None
+    def test_email_field_serialize_none(self):
         field = fields.Email()
-        assert field.serialize(user.email) is None
+        assert field.serialize(None) is None
 
-    def test_dict_field_serialize_none(self, user):
-        user.various_data = None
+    def test_dict_field_serialize_none(self):
         field = fields.Dict()
-        assert field.serialize(user.various_data) is None
+        assert field.serialize(None) is None
 
-    def test_dict_field_serialize(self, user):
-        user.various_data = {"foo": "bar"}
+    def test_dict_field_serialize(self):
+        data = {"foo": "bar"}
         field = fields.Dict()
-        dump = field.serialize(user.various_data)
+        dump = field.serialize(data)
         assert dump == {"foo": "bar"}
         # Check dump is a distinct object
         dump["foo"] = "baz"
-        assert user.various_data["foo"] == "bar"
+        assert data["foo"] == "bar"
 
-    def test_dict_field_serialize_ordereddict(self, user):
-        user.various_data = OrderedDict([("foo", "bar"), ("bar", "baz")])
+    def test_dict_field_serialize_ordereddict(self):
         field = fields.Dict()
-        assert field.serialize(user.various_data) == OrderedDict(
-            [("foo", "bar"), ("bar", "baz")]
-        )
+        assert field.serialize(
+            OrderedDict([("foo", "bar"), ("bar", "baz")])
+        ) == OrderedDict([("foo", "bar"), ("bar", "baz")])
 
-    def test_structured_dict_value_serialize(self, user):
-        user.various_data = {"foo": decimal.Decimal(1)}
+    def test_structured_dict_value_serialize(self):
         field = fields.Dict(values=fields.Decimal)
-        assert field.serialize(user.various_data) == {"foo": 1}
+        assert field.serialize({"foo": decimal.Decimal(1)}) == {"foo": 1}
 
-    def test_structured_dict_key_serialize(self, user):
-        user.various_data = {1: "bar"}
+    def test_structured_dict_key_serialize(self):
         field = fields.Dict(keys=fields.Str)
-        assert field.serialize(user.various_data) == {"1": "bar"}
+        assert field.serialize({1: "bar"}) == {"1": "bar"}
 
-    def test_structured_dict_key_value_serialize(self, user):
-        user.various_data = {1: decimal.Decimal(1)}
+    def test_structured_dict_key_value_serialize(self):
         field = fields.Dict(keys=fields.Str, values=fields.Decimal)
-        assert field.serialize(user.various_data) == {"1": 1}
+        assert field.serialize({1: decimal.Decimal(1)}) == {"1": 1}
 
-    def test_url_field_serialize_none(self, user):
-        user.homepage = None
+    def test_url_field_serialize_none(self):
         field = fields.Url()
-        assert field.serialize(user.homepage) is None
+        assert field.serialize(None) is None
 
     def test_method_field_with_method_missing(self):
         class BadSerializer(Schema):
@@ -464,7 +429,7 @@ class TestFieldSerialization:
         with pytest.raises(AttributeError):
             BadSerializer()
 
-    def test_method_field_passed_serialize_only_is_dump_only(self, user):
+    def test_method_field_passed_serialize_only_is_dump_only(self):
         field = fields.Method(serialize="method")
         assert field.dump_only is True
         assert field.load_only is False
@@ -608,30 +573,29 @@ class TestFieldSerialization:
             field = fields.DateTime(format=fmt)
         assert field.serialize(value) == expected
 
-    def test_datetime_field_format(self, user):
+    def test_datetime_field_format(self):
         datetimeformat = "%Y-%m-%d"
+        created = dt.datetime(2013, 11, 10, 14, 20, 58)
         field = fields.DateTime(format=datetimeformat)
-        assert field.serialize(user.created) == user.created.strftime(datetimeformat)
+        assert field.serialize(created) == created.strftime(datetimeformat)
 
     def test_string_field(self):
         field = fields.String()
-        user = User(name=b"foo")
-        assert field.serialize(user.name) == "foo"
+        assert field.serialize(b"foo") == "foo"
         field = fields.String(allow_none=True)
-        user.name = None
-        assert field.serialize(user.name) is None
+        assert field.serialize(None) is None
 
-    def test_string_field_default_to_empty_string(self, user):
+    def test_string_field_default_to_empty_string(self):
         field = fields.String(dump_default="")
         assert field.serialize("") == ""
 
-    def test_time_field(self, user):
+    def test_time_field(self):
+        time_registered = dt.time(1, 23, 45, 6789)
         field = fields.Time()
-        expected = user.time_registered.isoformat()[:15]
-        assert field.serialize(user.time_registered) == expected
+        expected = time_registered.isoformat()[:15]
+        assert field.serialize(time_registered) == expected
 
-        user.time_registered = None
-        assert field.serialize(user.time_registered) is None
+        assert field.serialize(None) is None
 
     @pytest.mark.parametrize("fmt", ["iso", "iso8601", None])
     @pytest.mark.parametrize(
@@ -650,25 +614,26 @@ class TestFieldSerialization:
             field = fields.Time(format=fmt)
         assert field.serialize(value) == expected
 
-    def test_time_field_format(self, user):
+    def test_time_field_format(self):
         fmt = "%H:%M:%S"
+        birthtime = dt.time(0, 1, 2, 3333)
         field = fields.Time(format=fmt)
-        assert field.serialize(user.birthtime) == user.birthtime.strftime(fmt)
+        assert field.serialize(birthtime) == birthtime.strftime(fmt)
 
-    def test_date_field(self, user):
+    def test_date_field(self):
+        birthdate = dt.date(2013, 1, 23)
         field = fields.Date()
-        assert field.serialize(user.birthdate) == user.birthdate.isoformat()
+        assert field.serialize(birthdate) == birthdate.isoformat()
 
-        user.birthdate = None
-        assert field.serialize(user.birthdate) is None
+        assert field.serialize(None) is None
 
-    def test_timedelta_field(self, user):
-        user.d1 = dt.timedelta(days=1, seconds=1, microseconds=1)
-        user.d2 = dt.timedelta(days=0, seconds=86401, microseconds=1)
-        user.d3 = dt.timedelta(days=0, seconds=0, microseconds=86401000001)
-        user.d4 = dt.timedelta(days=0, seconds=0, microseconds=0)
-        user.d5 = dt.timedelta(days=-1, seconds=0, microseconds=0)
-        user.d6 = dt.timedelta(
+    def test_timedelta_field(self):
+        d1 = dt.timedelta(days=1, seconds=1, microseconds=1)
+        d2 = dt.timedelta(days=0, seconds=86401, microseconds=1)
+        d3 = dt.timedelta(days=0, seconds=0, microseconds=86401000001)
+        d4 = dt.timedelta(days=0, seconds=0, microseconds=0)
+        d5 = dt.timedelta(days=-1, seconds=0, microseconds=0)
+        d6 = dt.timedelta(
             days=1,
             seconds=1,
             microseconds=1,
@@ -679,69 +644,68 @@ class TestFieldSerialization:
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d1) == 1.0000115740856481
+        assert field.serialize(d1) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d1) == 86401.000001
+        assert field.serialize(d1) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d1) == 86401000001
+        assert field.serialize(d1) == 86401000001
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize(user.d1) == 24.000277778055555
+        assert field.serialize(d1) == 24.000277778055555
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d2) == 1.0000115740856481
+        assert field.serialize(d2) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d2) == 86401.000001
+        assert field.serialize(d2) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d2) == 86401000001
+        assert field.serialize(d2) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d3) == 1.0000115740856481
+        assert field.serialize(d3) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d3) == 86401.000001
+        assert field.serialize(d3) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d3) == 86401000001
+        assert field.serialize(d3) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d4) == 0
+        assert field.serialize(d4) == 0
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d4) == 0
+        assert field.serialize(d4) == 0
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d4) == 0
+        assert field.serialize(d4) == 0
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d5) == -1
+        assert field.serialize(d5) == -1
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d5) == -86400
+        assert field.serialize(d5) == -86400
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d5) == -86400000000
+        assert field.serialize(d5) == -86400000000
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
-        assert field.serialize(user.d6) == 1.1489103852529763
+        assert field.serialize(d6) == 1.1489103852529763
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d6) == 8.042372696770833
+        assert field.serialize(d6) == 8.042372696770833
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize(user.d6) == 193.0169447225
+        assert field.serialize(d6) == 193.0169447225
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
-        assert field.serialize(user.d6) == 11581.01668335
+        assert field.serialize(d6) == 11581.01668335
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d6) == 694861.001001
+        assert field.serialize(d6) == 694861.001001
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize(user.d6) == 694861001.001
+        assert field.serialize(d6) == 694861001.001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d6) == 694861001001
+        assert field.serialize(d6) == 694861001001
 
-        user.d7 = None
-        assert field.serialize(user.d7) is None
+        assert field.serialize(None) is None
 
-        user.d8 = dt.timedelta(milliseconds=345)
+        d8 = dt.timedelta(milliseconds=345)
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize(user.d8) == 345
+        assert field.serialize(d8) == 345
 
-        user.d9 = dt.timedelta(milliseconds=1999)
+        d9 = dt.timedelta(milliseconds=1999)
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d9) == 1.999
+        assert field.serialize(d9) == 1.999
 
-        user.d10 = dt.timedelta(
+        d10 = dt.timedelta(
             weeks=1,
             days=6,
             hours=2,
@@ -754,46 +718,46 @@ class TestFieldSerialization:
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         unit_value = dt.timedelta(microseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
         unit_value = dt.timedelta(milliseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert math.isclose(field.serialize(user.d10), user.d10.total_seconds())
+        assert math.isclose(field.serialize(d10), d10.total_seconds())
 
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
         unit_value = dt.timedelta(minutes=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
         unit_value = dt.timedelta(hours=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         unit_value = dt.timedelta(days=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
         unit_value = dt.timedelta(weeks=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10),
-            user.d10.total_seconds() / unit_value,
+            field.serialize(d10),
+            d10.total_seconds() / unit_value,
         )
 
     def test_datetime_list_field(self):
@@ -906,12 +870,12 @@ class TestFieldSerialization:
         with pytest.raises(ValueError, match=expected_msg):
             fields.Tuple([ASchema])  # type: ignore[list-item]
 
-    def test_serialize_does_not_apply_validators(self, user):
+    def test_serialize_does_not_apply_validators(self):
         field = fields.Raw(validate=lambda x: False)
         # No validation error raised
-        assert field.serialize(user.age) == user.age
+        assert field.serialize(42) == 42
 
-    def test_constant_field_serialization(self, user):
+    def test_constant_field_serialization(self):
         field = fields.Constant("something")
         assert field.serialize("whatever") == "something"
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -43,7 +43,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_func(self, user):
         field = fields.Function(lambda value: value.upper())
-        assert field.serialize(user.name, "name", user) == "FOO"
+        assert field.serialize(user.name) == "FOO"
 
     def test_function_field_passed_serialize_only_is_dump_only(self, user):
         field = fields.Function(serialize=lambda value: value.upper())
@@ -57,7 +57,7 @@ class TestFieldSerialization:
 
     def test_function_field_passed_serialize(self, user):
         field = fields.Function(serialize=lambda value: value.upper())
-        assert field.serialize(user.name, "name", user) == "FOO"
+        assert field.serialize(user.name) == "FOO"
 
     # https://github.com/marshmallow-code/marshmallow/issues/395
     def test_function_field_does_not_swallow_attribute_error(self, user):
@@ -66,7 +66,7 @@ class TestFieldSerialization:
 
         field = fields.Function(serialize=raise_error)
         with pytest.raises(AttributeError):
-            field.serialize(user.name, "name", user)
+            field.serialize(user.name)
 
     def test_serialize_with_load_only_param(self):
         class AliasingUserSerializer(Schema):
@@ -97,35 +97,32 @@ class TestFieldSerialization:
 
     def test_integer_field(self, user):
         field = fields.Integer()
-        assert field.serialize(user.age, "age", user) == 42
+        assert field.serialize(user.age) == 42
 
     def test_integer_as_string_field(self, user):
         field = fields.Integer(as_string=True)
-        assert field.serialize(user.age, "age", user) == "42"
+        assert field.serialize(user.age) == "42"
 
     def test_integer_field_default(self, user):
         user.age = None
         field = fields.Integer(dump_default=0)
-        assert field.serialize(user.age, "age", user) is None
+        assert field.serialize(user.age) is None
         # missing
-        assert field.serialize(0, "age", {}) == 0
+        assert field.serialize(0) == 0
 
     def test_integer_field_default_set_to_none(self, user):
         user.age = None
         field = fields.Integer(dump_default=None)
-        assert field.serialize(user.age, "age", user) is None
+        assert field.serialize(user.age) is None
 
     def test_uuid_field(self, user):
         user.uuid1 = uuid.UUID("12345678123456781234567812345678")
         user.uuid2 = None
 
         field = fields.UUID()
-        assert isinstance(field.serialize(user.uuid1, "uuid1", user), str)
-        assert (
-            field.serialize(user.uuid1, "uuid1", user)
-            == "12345678-1234-5678-1234-567812345678"
-        )
-        assert field.serialize(user.uuid2, "uuid2", user) is None
+        assert isinstance(field.serialize(user.uuid1), str)
+        assert field.serialize(user.uuid1) == "12345678-1234-5678-1234-567812345678"
+        assert field.serialize(user.uuid2) is None
 
     def test_ip_address_field(self, user):
         ipv4_string = "192.168.0.1"
@@ -137,15 +134,15 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field_compressed = fields.IP()
-        assert isinstance(field_compressed.serialize(user.ipv4, "ipv4", user), str)
-        assert field_compressed.serialize(user.ipv4, "ipv4", user) == ipv4_string
-        assert isinstance(field_compressed.serialize(user.ipv6, "ipv6", user), str)
-        assert field_compressed.serialize(user.ipv6, "ipv6", user) == ipv6_string
-        assert field_compressed.serialize(user.empty_ip, "empty_ip", user) is None
+        assert isinstance(field_compressed.serialize(user.ipv4), str)
+        assert field_compressed.serialize(user.ipv4) == ipv4_string
+        assert isinstance(field_compressed.serialize(user.ipv6), str)
+        assert field_compressed.serialize(user.ipv6) == ipv6_string
+        assert field_compressed.serialize(user.empty_ip) is None
 
         field_exploded = fields.IP(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6, "ipv6", user), str)
-        assert field_exploded.serialize(user.ipv6, "ipv6", user) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(user.ipv6), str)
+        assert field_exploded.serialize(user.ipv6) == ipv6_exploded_string
 
     def test_ipv4_address_field(self, user):
         ipv4_string = "192.168.0.1"
@@ -154,9 +151,9 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field = fields.IPv4()
-        assert isinstance(field.serialize(user.ipv4, "ipv4", user), str)
-        assert field.serialize(user.ipv4, "ipv4", user) == ipv4_string
-        assert field.serialize(user.empty_ip, "empty_ip", user) is None
+        assert isinstance(field.serialize(user.ipv4), str)
+        assert field.serialize(user.ipv4) == ipv4_string
+        assert field.serialize(user.empty_ip) is None
 
     def test_ipv6_address_field(self, user):
         ipv6_string = "ffff::ffff"
@@ -166,13 +163,13 @@ class TestFieldSerialization:
         user.empty_ip = None
 
         field_compressed = fields.IPv6()
-        assert isinstance(field_compressed.serialize(user.ipv6, "ipv6", user), str)
-        assert field_compressed.serialize(user.ipv6, "ipv6", user) == ipv6_string
-        assert field_compressed.serialize(user.empty_ip, "empty_ip", user) is None
+        assert isinstance(field_compressed.serialize(user.ipv6), str)
+        assert field_compressed.serialize(user.ipv6) == ipv6_string
+        assert field_compressed.serialize(user.empty_ip) is None
 
         field_exploded = fields.IPv6(exploded=True)
-        assert isinstance(field_exploded.serialize(user.ipv6, "ipv6", user), str)
-        assert field_exploded.serialize(user.ipv6, "ipv6", user) == ipv6_exploded_string
+        assert isinstance(field_exploded.serialize(user.ipv6), str)
+        assert field_exploded.serialize(user.ipv6) == ipv6_exploded_string
 
     def test_ip_interface_field(self, user):
         ipv4interface_string = "192.168.0.1/24"
@@ -186,33 +183,16 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field_compressed = fields.IPInterface()
-        assert isinstance(
-            field_compressed.serialize(user.ipv4interface, "ipv4interface", user), str
-        )
-        assert (
-            field_compressed.serialize(user.ipv4interface, "ipv4interface", user)
-            == ipv4interface_string
-        )
-        assert isinstance(
-            field_compressed.serialize(user.ipv6interface, "ipv6interface", user), str
-        )
-        assert (
-            field_compressed.serialize(user.ipv6interface, "ipv6interface", user)
-            == ipv6interface_string
-        )
-        assert (
-            field_compressed.serialize(
-                user.empty_ipinterface, "empty_ipinterface", user
-            )
-            is None
-        )
+        assert isinstance(field_compressed.serialize(user.ipv4interface), str)
+        assert field_compressed.serialize(user.ipv4interface) == ipv4interface_string
+        assert isinstance(field_compressed.serialize(user.ipv6interface), str)
+        assert field_compressed.serialize(user.ipv6interface) == ipv6interface_string
+        assert field_compressed.serialize(user.empty_ipinterface) is None
 
         field_exploded = fields.IPInterface(exploded=True)
-        assert isinstance(
-            field_exploded.serialize(user.ipv6interface, "ipv6interface", user), str
-        )
+        assert isinstance(field_exploded.serialize(user.ipv6interface), str)
         assert (
-            field_exploded.serialize(user.ipv6interface, "ipv6interface", user)
+            field_exploded.serialize(user.ipv6interface)
             == ipv6interface_exploded_string
         )
 
@@ -223,16 +203,9 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field = fields.IPv4Interface()
-        assert isinstance(
-            field.serialize(user.ipv4interface, "ipv4interface", user), str
-        )
-        assert (
-            field.serialize(user.ipv4interface, "ipv4interface", user)
-            == ipv4interface_string
-        )
-        assert (
-            field.serialize(user.empty_ipinterface, "empty_ipinterface", user) is None
-        )
+        assert isinstance(field.serialize(user.ipv4interface), str)
+        assert field.serialize(user.ipv4interface) == ipv4interface_string
+        assert field.serialize(user.empty_ipinterface) is None
 
     def test_ipv6_interface_field(self, user):
         ipv6interface_string = "ffff::ffff/128"
@@ -244,53 +217,41 @@ class TestFieldSerialization:
         user.empty_ipinterface = None
 
         field_compressed = fields.IPv6Interface()
-        assert isinstance(
-            field_compressed.serialize(user.ipv6interface, "ipv6interface", user), str
-        )
-        assert (
-            field_compressed.serialize(user.ipv6interface, "ipv6interface", user)
-            == ipv6interface_string
-        )
-        assert (
-            field_compressed.serialize(
-                user.empty_ipinterface, "empty_ipinterface", user
-            )
-            is None
-        )
+        assert isinstance(field_compressed.serialize(user.ipv6interface), str)
+        assert field_compressed.serialize(user.ipv6interface) == ipv6interface_string
+        assert field_compressed.serialize(user.empty_ipinterface) is None
 
         field_exploded = fields.IPv6Interface(exploded=True)
-        assert isinstance(
-            field_exploded.serialize(user.ipv6interface, "ipv6interface", user), str
-        )
+        assert isinstance(field_exploded.serialize(user.ipv6interface), str)
         assert (
-            field_exploded.serialize(user.ipv6interface, "ipv6interface", user)
+            field_exploded.serialize(user.ipv6interface)
             == ipv6interface_exploded_string
         )
 
     def test_enum_field_by_symbol_serialization(self, user):
         user.sex = GenderEnum.male
         field = fields.Enum(GenderEnum)
-        assert field.serialize(user.sex, "sex", user) == "male"
+        assert field.serialize(user.sex) == "male"
 
     def test_enum_field_by_value_true_serialization(self, user):
         user.hair_color = HairColorEnum.black
         field = fields.Enum(HairColorEnum, by_value=True)
-        assert field.serialize(user.hair_color, "hair_color", user) == "black hair"
+        assert field.serialize(user.hair_color) == "black hair"
         user.sex = GenderEnum.male
         field2 = fields.Enum(GenderEnum, by_value=True)
-        assert field2.serialize(user.sex, "sex", user) == 1
+        assert field2.serialize(user.sex) == 1
         user.some_date = DateEnum.date_1
 
     def test_enum_field_by_value_field_serialization(self, user):
         user.hair_color = HairColorEnum.black
         field = fields.Enum(HairColorEnum, by_value=fields.String)
-        assert field.serialize(user.hair_color, "hair_color", user) == "black hair"
+        assert field.serialize(user.hair_color) == "black hair"
         user.sex = GenderEnum.male
         field2 = fields.Enum(GenderEnum, by_value=fields.Integer)
-        assert field2.serialize(user.sex, "sex", user) == 1
+        assert field2.serialize(user.sex) == 1
         user.some_date = DateEnum.date_1
         field3 = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
-        assert field3.serialize(user.some_date, "some_date", user) == "29/02/2004"
+        assert field3.serialize(user.some_date) == "29/02/2004"
 
     def test_decimal_field(self, user):
         user.m1 = 12
@@ -299,31 +260,31 @@ class TestFieldSerialization:
         user.m4 = None
 
         field = fields.Decimal()
-        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
-        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
-        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.355")
-        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
-        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), decimal.Decimal)
+        assert field.serialize(user.m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2), decimal.Decimal)
+        assert field.serialize(user.m2) == decimal.Decimal("12.355")
+        assert isinstance(field.serialize(user.m3), decimal.Decimal)
+        assert field.serialize(user.m3) == decimal.Decimal(1)
+        assert field.serialize(user.m4) is None
 
         field = fields.Decimal(1)
-        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
-        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
-        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.4")
-        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
-        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), decimal.Decimal)
+        assert field.serialize(user.m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2), decimal.Decimal)
+        assert field.serialize(user.m2) == decimal.Decimal("12.4")
+        assert isinstance(field.serialize(user.m3), decimal.Decimal)
+        assert field.serialize(user.m3) == decimal.Decimal(1)
+        assert field.serialize(user.m4) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN)
-        assert isinstance(field.serialize(user.m1, "m1", user), decimal.Decimal)
-        assert field.serialize(user.m1, "m1", user) == decimal.Decimal(12)
-        assert isinstance(field.serialize(user.m2, "m2", user), decimal.Decimal)
-        assert field.serialize(user.m2, "m2", user) == decimal.Decimal("12.3")
-        assert isinstance(field.serialize(user.m3, "m3", user), decimal.Decimal)
-        assert field.serialize(user.m3, "m3", user) == decimal.Decimal(1)
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), decimal.Decimal)
+        assert field.serialize(user.m1) == decimal.Decimal(12)
+        assert isinstance(field.serialize(user.m2), decimal.Decimal)
+        assert field.serialize(user.m2) == decimal.Decimal("12.3")
+        assert isinstance(field.serialize(user.m3), decimal.Decimal)
+        assert field.serialize(user.m3) == decimal.Decimal(1)
+        assert field.serialize(user.m4) is None
 
     def test_decimal_field_string(self, user):
         user.m1 = 12
@@ -332,31 +293,31 @@ class TestFieldSerialization:
         user.m4 = None
 
         field = fields.Decimal(as_string=True)
-        assert isinstance(field.serialize(user.m1, "m1", user), str)
-        assert field.serialize(user.m1, "m1", user) == "12"
-        assert isinstance(field.serialize(user.m2, "m2", user), str)
-        assert field.serialize(user.m2, "m2", user) == "12.355"
-        assert isinstance(field.serialize(user.m3, "m3", user), str)
-        assert field.serialize(user.m3, "m3", user) == "1"
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), str)
+        assert field.serialize(user.m1) == "12"
+        assert isinstance(field.serialize(user.m2), str)
+        assert field.serialize(user.m2) == "12.355"
+        assert isinstance(field.serialize(user.m3), str)
+        assert field.serialize(user.m3) == "1"
+        assert field.serialize(user.m4) is None
 
         field = fields.Decimal(1, as_string=True)
-        assert isinstance(field.serialize(user.m1, "m1", user), str)
-        assert field.serialize(user.m1, "m1", user) == "12.0"
-        assert isinstance(field.serialize(user.m2, "m2", user), str)
-        assert field.serialize(user.m2, "m2", user) == "12.4"
-        assert isinstance(field.serialize(user.m3, "m3", user), str)
-        assert field.serialize(user.m3, "m3", user) == "1.0"
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), str)
+        assert field.serialize(user.m1) == "12.0"
+        assert isinstance(field.serialize(user.m2), str)
+        assert field.serialize(user.m2) == "12.4"
+        assert isinstance(field.serialize(user.m3), str)
+        assert field.serialize(user.m3) == "1.0"
+        assert field.serialize(user.m4) is None
 
         field = fields.Decimal(1, decimal.ROUND_DOWN, as_string=True)
-        assert isinstance(field.serialize(user.m1, "m1", user), str)
-        assert field.serialize(user.m1, "m1", user) == "12.0"
-        assert isinstance(field.serialize(user.m2, "m2", user), str)
-        assert field.serialize(user.m2, "m2", user) == "12.3"
-        assert isinstance(field.serialize(user.m3, "m3", user), str)
-        assert field.serialize(user.m3, "m3", user) == "1.0"
-        assert field.serialize(user.m4, "m4", user) is None
+        assert isinstance(field.serialize(user.m1), str)
+        assert field.serialize(user.m1) == "12.0"
+        assert isinstance(field.serialize(user.m2), str)
+        assert field.serialize(user.m2) == "12.3"
+        assert isinstance(field.serialize(user.m3), str)
+        assert field.serialize(user.m3) == "1.0"
+        assert field.serialize(user.m4) is None
 
     def test_decimal_field_special_values(self, user):
         user.m1 = "-NaN"
@@ -369,52 +330,52 @@ class TestFieldSerialization:
 
         field = fields.Decimal(places=2, allow_nan=True)
 
-        m1s = field.serialize(user.m1, "m1", user)
+        m1s = field.serialize(user.m1)
         assert isinstance(m1s, decimal.Decimal)
         assert m1s.is_qnan()
         assert not m1s.is_signed()
 
-        m2s = field.serialize(user.m2, "m2", user)
+        m2s = field.serialize(user.m2)
         assert isinstance(m2s, decimal.Decimal)
         assert m2s.is_qnan()
         assert not m2s.is_signed()
 
-        m3s = field.serialize(user.m3, "m3", user)
+        m3s = field.serialize(user.m3)
         assert isinstance(m3s, decimal.Decimal)
         assert m3s.is_qnan()
         assert not m3s.is_signed()
 
-        m4s = field.serialize(user.m4, "m4", user)
+        m4s = field.serialize(user.m4)
         assert isinstance(m4s, decimal.Decimal)
         assert m4s.is_qnan()
         assert not m4s.is_signed()
 
-        m5s = field.serialize(user.m5, "m5", user)
+        m5s = field.serialize(user.m5)
         assert isinstance(m5s, decimal.Decimal)
         assert m5s.is_infinite()
         assert m5s.is_signed()
 
-        m6s = field.serialize(user.m6, "m6", user)
+        m6s = field.serialize(user.m6)
         assert isinstance(m6s, decimal.Decimal)
         assert m6s.is_infinite()
         assert not m6s.is_signed()
 
-        m7s = field.serialize(user.m7, "m7", user)
+        m7s = field.serialize(user.m7)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
 
         field = fields.Decimal(as_string=True, allow_nan=True)
 
-        m2s = field.serialize(user.m2, "m2", user)
+        m2s = field.serialize(user.m2)
         assert isinstance(m2s, str)
         assert m2s == user.m2
 
-        m5s = field.serialize(user.m5, "m5", user)
+        m5s = field.serialize(user.m5)
         assert isinstance(m5s, str)
         assert m5s == user.m5
 
-        m6s = field.serialize(user.m6, "m6", user)
+        m6s = field.serialize(user.m6)
         assert isinstance(m6s, str)
         assert m6s == user.m6
 
@@ -423,7 +384,7 @@ class TestFieldSerialization:
 
         field = fields.Decimal(places=2)
 
-        m7s = field.serialize(user.m7, "m7", user)
+        m7s = field.serialize(user.m7)
         assert isinstance(m7s, decimal.Decimal)
         assert m7s.is_zero()
         assert m7s.is_signed()
@@ -436,34 +397,34 @@ class TestFieldSerialization:
         user.m1 = "0.00000000100000000"
 
         field = fields.Decimal()
-        s = field.serialize(user.m1, "m1", user)
+        s = field.serialize(user.m1)
         assert isinstance(s, decimal.Decimal)
         assert s == decimal.Decimal("1.00000000E-9")
 
         field = fields.Decimal(as_string=True)
-        s = field.serialize(user.m1, "m1", user)
+        s = field.serialize(user.m1)
         assert isinstance(s, str)
         assert s == user.m1
 
         field = fields.Decimal(as_string=True, places=2)
-        s = field.serialize(user.m1, "m1", user)
+        s = field.serialize(user.m1)
         assert isinstance(s, str)
         assert s == "0.00"
 
     def test_email_field_serialize_none(self, user):
         user.email = None
         field = fields.Email()
-        assert field.serialize(user.email, "email", user) is None
+        assert field.serialize(user.email) is None
 
     def test_dict_field_serialize_none(self, user):
         user.various_data = None
         field = fields.Dict()
-        assert field.serialize(user.various_data, "various_data", user) is None
+        assert field.serialize(user.various_data) is None
 
     def test_dict_field_serialize(self, user):
         user.various_data = {"foo": "bar"}
         field = fields.Dict()
-        dump = field.serialize(user.various_data, "various_data", user)
+        dump = field.serialize(user.various_data)
         assert dump == {"foo": "bar"}
         # Check dump is a distinct object
         dump["foo"] = "baz"
@@ -472,29 +433,29 @@ class TestFieldSerialization:
     def test_dict_field_serialize_ordereddict(self, user):
         user.various_data = OrderedDict([("foo", "bar"), ("bar", "baz")])
         field = fields.Dict()
-        assert field.serialize(user.various_data, "various_data", user) == OrderedDict(
+        assert field.serialize(user.various_data) == OrderedDict(
             [("foo", "bar"), ("bar", "baz")]
         )
 
     def test_structured_dict_value_serialize(self, user):
         user.various_data = {"foo": decimal.Decimal(1)}
         field = fields.Dict(values=fields.Decimal)
-        assert field.serialize(user.various_data, "various_data", user) == {"foo": 1}
+        assert field.serialize(user.various_data) == {"foo": 1}
 
     def test_structured_dict_key_serialize(self, user):
         user.various_data = {1: "bar"}
         field = fields.Dict(keys=fields.Str)
-        assert field.serialize(user.various_data, "various_data", user) == {"1": "bar"}
+        assert field.serialize(user.various_data) == {"1": "bar"}
 
     def test_structured_dict_key_value_serialize(self, user):
         user.various_data = {1: decimal.Decimal(1)}
         field = fields.Dict(keys=fields.Str, values=fields.Decimal)
-        assert field.serialize(user.various_data, "various_data", user) == {"1": 1}
+        assert field.serialize(user.various_data) == {"1": 1}
 
     def test_url_field_serialize_none(self, user):
         user.homepage = None
         field = fields.Url()
-        assert field.serialize(user.homepage, "homepage", user) is None
+        assert field.serialize(user.homepage) is None
 
     def test_method_field_with_method_missing(self):
         class BadSerializer(Schema):
@@ -536,7 +497,7 @@ class TestFieldSerialization:
         m = fields.Method()
         m.parent = Schema()
 
-        assert m.serialize(missing_, "", None) is missing_
+        assert m.serialize(missing_) is missing_
 
     def test_serialize_with_data_key_param(self):
         class DumpToSchema(Schema):
@@ -586,7 +547,7 @@ class TestFieldSerialization:
     )
     def test_datetime_field_rfc822(self, fmt, value, expected):
         field = fields.DateTime(format=fmt)
-        assert field.serialize(value, "d", {"d": value}) == expected
+        assert field.serialize(value) == expected
 
     @pytest.mark.parametrize(
         ("fmt", "value", "expected"),
@@ -618,7 +579,7 @@ class TestFieldSerialization:
     )
     def test_datetime_field_timestamp(self, fmt, value, expected):
         field = fields.DateTime(format=fmt)
-        assert field.serialize(value, "d", {"d": value}) == expected
+        assert field.serialize(value) == expected
 
     @pytest.mark.parametrize("fmt", ["iso", "iso8601", None])
     @pytest.mark.parametrize(
@@ -645,36 +606,32 @@ class TestFieldSerialization:
             field = fields.DateTime()
         else:
             field = fields.DateTime(format=fmt)
-        assert field.serialize(value, "d", {"d": value}) == expected
+        assert field.serialize(value) == expected
 
     def test_datetime_field_format(self, user):
         datetimeformat = "%Y-%m-%d"
         field = fields.DateTime(format=datetimeformat)
-        assert field.serialize(user.created, "created", user) == user.created.strftime(
-            datetimeformat
-        )
+        assert field.serialize(user.created) == user.created.strftime(datetimeformat)
 
     def test_string_field(self):
         field = fields.String()
         user = User(name=b"foo")
-        assert field.serialize(user.name, "name", user) == "foo"
+        assert field.serialize(user.name) == "foo"
         field = fields.String(allow_none=True)
         user.name = None
-        assert field.serialize(user.name, "name", user) is None
+        assert field.serialize(user.name) is None
 
     def test_string_field_default_to_empty_string(self, user):
         field = fields.String(dump_default="")
-        assert field.serialize("", "notfound", {}) == ""
+        assert field.serialize("") == ""
 
     def test_time_field(self, user):
         field = fields.Time()
         expected = user.time_registered.isoformat()[:15]
-        assert (
-            field.serialize(user.time_registered, "time_registered", user) == expected
-        )
+        assert field.serialize(user.time_registered) == expected
 
         user.time_registered = None
-        assert field.serialize(user.time_registered, "time_registered", user) is None
+        assert field.serialize(user.time_registered) is None
 
     @pytest.mark.parametrize("fmt", ["iso", "iso8601", None])
     @pytest.mark.parametrize(
@@ -691,24 +648,19 @@ class TestFieldSerialization:
             field = fields.Time()
         else:
             field = fields.Time(format=fmt)
-        assert field.serialize(value, "d", {"d": value}) == expected
+        assert field.serialize(value) == expected
 
     def test_time_field_format(self, user):
         fmt = "%H:%M:%S"
         field = fields.Time(format=fmt)
-        assert field.serialize(
-            user.birthtime, "birthtime", user
-        ) == user.birthtime.strftime(fmt)
+        assert field.serialize(user.birthtime) == user.birthtime.strftime(fmt)
 
     def test_date_field(self, user):
         field = fields.Date()
-        assert (
-            field.serialize(user.birthdate, "birthdate", user)
-            == user.birthdate.isoformat()
-        )
+        assert field.serialize(user.birthdate) == user.birthdate.isoformat()
 
         user.birthdate = None
-        assert field.serialize(user.birthdate, "birthdate", user) is None
+        assert field.serialize(user.birthdate) is None
 
     def test_timedelta_field(self, user):
         user.d1 = dt.timedelta(days=1, seconds=1, microseconds=1)
@@ -727,67 +679,67 @@ class TestFieldSerialization:
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d1, "d1", user) == 1.0000115740856481
+        assert field.serialize(user.d1) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d1, "d1", user) == 86401.000001
+        assert field.serialize(user.d1) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d1, "d1", user) == 86401000001
+        assert field.serialize(user.d1) == 86401000001
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize(user.d1, "d1", user) == 24.000277778055555
+        assert field.serialize(user.d1) == 24.000277778055555
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d2, "d2", user) == 1.0000115740856481
+        assert field.serialize(user.d2) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d2, "d2", user) == 86401.000001
+        assert field.serialize(user.d2) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d2, "d2", user) == 86401000001
+        assert field.serialize(user.d2) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d3, "d3", user) == 1.0000115740856481
+        assert field.serialize(user.d3) == 1.0000115740856481
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d3, "d3", user) == 86401.000001
+        assert field.serialize(user.d3) == 86401.000001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d3, "d3", user) == 86401000001
+        assert field.serialize(user.d3) == 86401000001
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d4, "d4", user) == 0
+        assert field.serialize(user.d4) == 0
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d4, "d4", user) == 0
+        assert field.serialize(user.d4) == 0
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d4, "d4", user) == 0
+        assert field.serialize(user.d4) == 0
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d5, "d5", user) == -1
+        assert field.serialize(user.d5) == -1
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d5, "d5", user) == -86400
+        assert field.serialize(user.d5) == -86400
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d5, "d5", user) == -86400000000
+        assert field.serialize(user.d5) == -86400000000
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
-        assert field.serialize(user.d6, "d6", user) == 1.1489103852529763
+        assert field.serialize(user.d6) == 1.1489103852529763
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
-        assert field.serialize(user.d6, "d6", user) == 8.042372696770833
+        assert field.serialize(user.d6) == 8.042372696770833
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
-        assert field.serialize(user.d6, "d6", user) == 193.0169447225
+        assert field.serialize(user.d6) == 193.0169447225
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
-        assert field.serialize(user.d6, "d6", user) == 11581.01668335
+        assert field.serialize(user.d6) == 11581.01668335
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d6, "d6", user) == 694861.001001
+        assert field.serialize(user.d6) == 694861.001001
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize(user.d6, "d6", user) == 694861001.001
+        assert field.serialize(user.d6) == 694861001.001
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
-        assert field.serialize(user.d6, "d6", user) == 694861001001
+        assert field.serialize(user.d6) == 694861001001
 
         user.d7 = None
-        assert field.serialize(user.d7, "d7", user) is None
+        assert field.serialize(user.d7) is None
 
         user.d8 = dt.timedelta(milliseconds=345)
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
-        assert field.serialize(user.d8, "d8", user) == 345
+        assert field.serialize(user.d8) == 345
 
         user.d9 = dt.timedelta(milliseconds=1999)
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert field.serialize(user.d9, "d9", user) == 1.999
+        assert field.serialize(user.d9) == 1.999
 
         user.d10 = dt.timedelta(
             weeks=1,
@@ -802,60 +754,58 @@ class TestFieldSerialization:
         field = fields.TimeDelta(fields.TimeDelta.MICROSECONDS)
         unit_value = dt.timedelta(microseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.MILLISECONDS)
         unit_value = dt.timedelta(milliseconds=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.SECONDS)
-        assert math.isclose(
-            field.serialize(user.d10, "d10", user), user.d10.total_seconds()
-        )
+        assert math.isclose(field.serialize(user.d10), user.d10.total_seconds())
 
         field = fields.TimeDelta(fields.TimeDelta.MINUTES)
         unit_value = dt.timedelta(minutes=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.HOURS)
         unit_value = dt.timedelta(hours=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         unit_value = dt.timedelta(days=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
         field = fields.TimeDelta(fields.TimeDelta.WEEKS)
         unit_value = dt.timedelta(weeks=1).total_seconds()
         assert math.isclose(
-            field.serialize(user.d10, "d10", user),
+            field.serialize(user.d10),
             user.d10.total_seconds() / unit_value,
         )
 
     def test_datetime_list_field(self):
         obj = DateTimeList([dt.datetime.now(dt.timezone.utc), dt.datetime.now()])
         field = fields.List(fields.DateTime)
-        result = field.serialize(obj.dtimes, "dtimes", obj)
+        result = field.serialize(obj.dtimes)
         assert all(type(each) is str for each in result)
 
     def test_list_field_serialize_none_returns_none(self):
         obj = DateTimeList(None)
         field = fields.List(fields.DateTime)
-        assert field.serialize(obj.dtimes, "dtimes", obj) is None
+        assert field.serialize(obj.dtimes) is None
 
     def test_list_field_work_with_generator_single_value(self):
         def custom_generator():
@@ -863,7 +813,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime)
-        result = field.serialize(obj.dtimes, "dtimes", obj)
+        result = field.serialize(obj.dtimes)
         assert len(result) == 1
 
     def test_list_field_work_with_generators_multiple_values(self):
@@ -872,7 +822,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime)
-        result = field.serialize(obj.dtimes, "dtimes", obj)
+        result = field.serialize(obj.dtimes)
         assert len(result) == 2
 
     def test_list_field_work_with_generators_empty_generator_returns_none_for_every_non_returning_yield_statement(
@@ -884,7 +834,7 @@ class TestFieldSerialization:
 
         obj = DateTimeList(custom_generator())
         field = fields.List(fields.DateTime, allow_none=True)
-        result = field.serialize(obj.dtimes, "dtimes", obj)
+        result = field.serialize(obj.dtimes)
         assert len(result) == 2
         assert result[0] is None
         assert result[1] is None
@@ -893,7 +843,7 @@ class TestFieldSerialization:
         custom_set = {1, 2, 3}
         obj = IntegerList(custom_set)
         field = fields.List(fields.Int)
-        result = field.serialize(obj.ints, "ints", obj)
+        result = field.serialize(obj.ints)
         assert len(result) == 3
         assert 1 in result
         assert 2 in result
@@ -910,7 +860,7 @@ class TestFieldSerialization:
         ints = IteratorSupportingClass([1, 2, 3])
         obj = IntegerList(ints)
         field = fields.List(fields.Int)
-        result = field.serialize(obj.ints, "ints", obj)
+        result = field.serialize(obj.ints)
         assert len(result) == 3
         assert result[0] == 1
         assert result[1] == 2
@@ -932,14 +882,14 @@ class TestFieldSerialization:
     def test_datetime_integer_tuple_field(self):
         obj = DateTimeIntegerTuple((dt.datetime.now(dt.timezone.utc), 42))
         field = fields.Tuple([fields.DateTime, fields.Integer])
-        result = field.serialize(obj.dtime_int, "dtime_int", obj)
+        result = field.serialize(obj.dtime_int)
         assert type(result[0]) is str
         assert type(result[1]) is int
 
     def test_tuple_field_serialize_none_returns_none(self):
         obj = DateTimeIntegerTuple(None)
         field = fields.Tuple([fields.DateTime, fields.Integer])
-        assert field.serialize(obj.dtime_int, "dtime_int", obj) is None
+        assert field.serialize(obj.dtime_int) is None
 
     def test_bad_tuple_field(self):
         class ASchema(Schema):
@@ -959,11 +909,11 @@ class TestFieldSerialization:
     def test_serialize_does_not_apply_validators(self, user):
         field = fields.Raw(validate=lambda x: False)
         # No validation error raised
-        assert field.serialize(user.age, "age", user) == user.age
+        assert field.serialize(user.age) == user.age
 
     def test_constant_field_serialization(self, user):
         field = fields.Constant("something")
-        assert field.serialize("whatever", "whatever", user) == "something"
+        assert field.serialize("whatever") == "something"
 
     def test_constant_is_always_included_in_serialized_data(self):
         class MySchema(Schema):
@@ -983,7 +933,7 @@ class TestFieldSerialization:
     @pytest.mark.parametrize("FieldClass", ALL_FIELDS)
     def test_all_fields_serialize_none_to_none(self, FieldClass):
         field = FieldClass(allow_none=True)
-        res = field.serialize(None, "foo", {"foo": None})
+        res = field.serialize(None)
         assert res is None
 
 
@@ -1014,7 +964,7 @@ def test_serializing_named_tuple():
 
     p = Point(x=4, y=2)
 
-    assert field.serialize(p.x, "x", p) == 4
+    assert field.serialize(p.x) == 4
 
 
 def test_serializing_named_tuple_with_meta():


### PR DESCRIPTION
#2039 is a long standing issue I've been wanting to address for a while but it implies a lot of changes that can hardly be done incrementally so I never got down to it.

[Disclaimer: The company I work for wants us to leverage AI power because everyone does it (FOMO) so we asked for Claude tokens and I tried agent coding on our projects to give management feedback about it and I figured why not try it on this issue as well. Obviously, it is not as simple as telling the tool to fix #2039. It took me a few tries to get the steps in the right order. And although I was supervising, there may be a few hallucinations I haven't spotted yet. The tool was not always clever at guessing what I didn't tell, but it helped me facing the fear of rewriting all calls to serialization functions in lib and tests.]

I'm sharing this as it is a nice POC. It still needs to be polished around the edges and there may be possibilities for further improvements, but some of them could be done later. Changes certainly need to be double-checked (but this would also be true if I had done all this manually, TBH). Consider it an illustration of what I have in mind.

The [de|]serialization_getter arguments added to `Field` could be added in MA4 while deprecating the use of `Function`/`Method` to do fancy accessing. The rest is breaking changes that would have to wait until 5.0.

Happy to get feedback before doing any more work on this.