### PR TITLE
Fix get_value default for missing int keys

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -188,3 +188,4 @@ Contributors (chronological)
 - `@rstar327 <https://github.com/rstar327>`_
 - Kadir Can Ozden  `@bysiber  <https://github.com/bysiber>`_
 - Dhruvil Darji  `@dhruvildarji  <https://github.com/dhruvildarji>`_
+- `@hansu650 <https://github.com/hansu650>`_

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -125,6 +125,8 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,11 +72,17 @@ def test_get_value_from_dict():
 def test_get_value():
     lst = [1, 2, 3]
     assert utils.get_value(lst, 1) == 2
+    assert utils.get_value(lst, 999, default=3) == 3
 
     class MyInt(int):
         pass
 
     assert utils.get_value(lst, MyInt(1)) == 2
+    assert utils.get_value(lst, MyInt(999), default=3) == 3
+
+
+def test_get_value_from_dict_with_missing_int_key():
+    assert utils.get_value({1: "a", 2: "b"}, 3, default="c") == "c"
 
 
 def test_set_value():


### PR DESCRIPTION
Fixes #2893.

This fixes `utils.get_value` so missing non-string keys return the supplied default instead of raising from the attribute fallback.

Previously, an out-of-range integer list index raised `IndexError`, then `get_value` fell back to `getattr(obj, key, default)`. Since `getattr` requires a string attribute name, this raised `TypeError` instead of returning the default.

This keeps the existing string-key fallback behavior and only returns the default when indexed lookup fails for a non-string key.

Tests added:
- out-of-range integer list index returns the default
- out-of-range `int` subclass list index returns the default
- missing integer dictionary key returns the default

Validation:
- `python -m pytest tests/test_utils.py -k get_value -q`
- `python -m pytest tests -q -k "not from_timestamp_with_overflow_value"`
- `python -m ruff check src/marshmallow/utils.py tests/test_utils.py`
- `python -m py_compile src/marshmallow/utils.py`
- `git diff --check`

Note: running all of `tests/test_utils.py` on Windows exposed an existing unrelated timestamp overflow message mismatch in `test_from_timestamp_with_overflow_value`, so I excluded that test from the broader local run.

AI assistance:
I used ChatGPT/Codex to help identify this issue, inspect the existing implementation and tests, and prepare the local patch. I reviewed the final diff and validation results before submitting.
