### PR TITLE
fix: return default instead of raising TypeError for out-of-range int index in get_value (#2893)

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -125,6 +125,8 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        if isinstance(key, int):
+            return default
         return getattr(obj, key, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,21 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_out_of_range_int_index_returns_default():
+    # An out-of-range integer index should return default instead of raising TypeError.
+    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/2893
+    lst = [0, 1, 2, 3, 4, 5]
+    assert utils.get_value(lst, 999, default=3) == 3
+
+    # Dict with integer keys: missing key should return default
+    d = {1: "a", 2: "b", 3: "c"}
+    assert utils.get_value(d, 4, default="z") == "z"
+
+    # List of objects: out-of-range index should return default
+    lst_empty: list = []
+    assert utils.get_value(lst_empty, 0, default=None) is None
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
## Summary

- `utils.get_value(lst, 999, default=3)` raised `TypeError: getattr(): attribute name must be string` instead of returning `3`
- Root cause: `_get_value_for_key` catches `IndexError` from an out-of-range integer index then falls back to `getattr(obj, key, default)` — `getattr` only accepts string attribute names, so integer keys cause it to raise
- Fix adds an `isinstance(key, int)` guard in the except block so integer keys return `default` directly without calling `getattr`

## Changes

- `src/marshmallow/utils.py`: return `default` immediately when `key` is an `int` and the subscript lookup fails
- `tests/test_utils.py`: added `test_get_value_out_of_range_int_index_returns_default` covering out-of-range list index, missing integer dict key, and empty list

Fixes #2893