### PR TITLE
Fix _get_value_for_key raising TypeError on out-of-range int index

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -124,7 +124,9 @@ def _get_value_for_key(obj, key, default):
 
     try:
         return obj[key]
-    except (KeyError, IndexError, TypeError, AttributeError):
+    except IndexError:
+        return default
+    except (KeyError, TypeError, AttributeError):
         return getattr(obj, key, default)
 
 


### PR DESCRIPTION
## Problem

`utils.get_value` with an out-of-range integer index raises `TypeError` instead of returning `default`:
```python
get_value([1, 2, 3], 5)  # TypeError, expected: missing
```

## Root cause

When `obj[key]` raises `IndexError`, the handler falls through to `getattr(obj, key, default)`. Since `key` is an integer, `getattr` raises `TypeError`.

## Fix

Separate `IndexError` handling from the other exception types. For out-of-range indices, return `default` immediately.

Closes #2893