### PR TITLE
Materialize single-use iterables in OneOf/NoneOf validators

### DIFF
--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -566,7 +566,11 @@ class NoneOf(Validator):
     default_message = "Invalid input."
 
     def __init__(self, iterable: typing.Iterable, *, error: str | None = None):
-        self.iterable = iterable
+        # Materialise single-use iterators (e.g. generators) so they are not
+        # exhausted while building ``values_text`` and can be reused in
+        # ``__call__``. Sequences and strings are kept as-is to preserve their
+        # membership semantics (e.g. substring checks for ``str``).
+        self.iterable = list(iterable) if iter(iterable) is iterable else iterable
         self.values_text = ", ".join(str(each) for each in self.iterable)
         self.error: str = error or self.default_message
 
@@ -604,7 +608,11 @@ class OneOf(Validator):
         *,
         error: str | None = None,
     ):
-        self.choices = choices
+        # Materialise single-use iterators (e.g. generators) so they are not
+        # exhausted while building ``choices_text`` and can be reused in
+        # ``__call__``. Sequences and strings are kept as-is to preserve their
+        # membership semantics (e.g. substring checks for ``str``).
+        self.choices = list(choices) if iter(choices) is choices else choices
         self.choices_text = ", ".join(str(choice) for choice in self.choices)
         self.labels = labels if labels is not None else []
         self.labels_text = ", ".join(str(label) for label in self.labels)

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -566,10 +566,7 @@ class NoneOf(Validator):
     default_message = "Invalid input."
 
     def __init__(self, iterable: typing.Iterable, *, error: str | None = None):
-        # Materialise single-use iterators (e.g. generators) so they are not
-        # exhausted while building ``values_text`` and can be reused in
-        # ``__call__``. Sequences and strings are kept as-is to preserve their
-        # membership semantics (e.g. substring checks for ``str``).
+        # Materialise one-shot iterators (e.g. generators); keep str/sequences as-is.
         self.iterable = list(iterable) if iter(iterable) is iterable else iterable
         self.values_text = ", ".join(str(each) for each in self.iterable)
         self.error: str = error or self.default_message
@@ -608,10 +605,7 @@ class OneOf(Validator):
         *,
         error: str | None = None,
     ):
-        # Materialise single-use iterators (e.g. generators) so they are not
-        # exhausted while building ``choices_text`` and can be reused in
-        # ``__call__``. Sequences and strings are kept as-is to preserve their
-        # membership semantics (e.g. substring checks for ``str``).
+        # Materialise one-shot iterators (e.g. generators); keep str/sequences as-is.
         self.choices = list(choices) if iter(choices) is choices else choices
         self.choices_text = ", ".join(str(choice) for choice in self.choices)
         self.labels = labels if labels is not None else []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -841,6 +841,25 @@ def test_oneof_repr():
     )
 
 
+def test_oneof_accepts_single_use_iterable():
+    # ``choices`` is typed as ``Iterable``; a generator must validate the same
+    # as a list rather than being silently exhausted while building the error
+    # text (which previously made the validator reject every value).
+    validator = validate.OneOf(iter([1, 2, 3]))
+    assert validator(2) == 2
+    with pytest.raises(ValidationError):
+        validator(5)
+
+
+def test_noneof_accepts_single_use_iterable():
+    # Same single-use-iterable problem for ``NoneOf.iterable``: a generator was
+    # exhausted while building the error text, so nothing was ever rejected.
+    validator = validate.NoneOf(iter([1, 2, 3]))
+    assert validator(5) == 5
+    with pytest.raises(ValidationError):
+        validator(1)
+
+
 def test_containsonly_in_list():
     assert validate.ContainsOnly([])([]) == []
     assert validate.ContainsOnly([1, 2, 3])([1]) == [1]


### PR DESCRIPTION
`OneOf` and `NoneOf` are annotated to accept any `typing.Iterable`, but they store the argument directly and consume it once while building the error text (`choices_text` / `values_text`), then re-iterate it in `__call__`:

```python
def __init__(self, choices: typing.Iterable, ...):
    self.choices = choices
    self.choices_text = ", ".join(str(c) for c in self.choices)  # consumes a generator
...
def __call__(self, value):
    if value not in self.choices:  # re-iterates -- empty if a generator was passed
        raise ValidationError(...)
```

So passing a generator silently breaks validation:

```python
>>> OneOf(iter([1, 2, 3]))(2)          # rejects a valid value
ValidationError: ['Must be one of: 1, 2, 3.']
>>> NoneOf(iter([1, 2, 3]))(1)         # accepts an invalid value (returns it)
1
```

`OneOf` rejects everything; `NoneOf` accepts everything.

## Fix

Materialize only true single-use iterators (detected via `iter(x) is x`) into a list, leaving sequences and strings untouched so their membership semantics are preserved — e.g. `OneOf("abc")` keeps treating `"abc"` as a string (`"b" in "abc"`) rather than `["a", "b", "c"]`. Regression tests added for both validators.

Full test suite passes (1180 passed); `ruff check`/`format` clean.