### PR TITLE
fix: Pluck._serialize crashes with KeyError on missing nested field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -718,7 +718,7 @@ class Pluck(Nested):
             return None
         if self.many:
             return utils.pluck(ret, key=self._field_data_key)
-        return ret[self._field_data_key]
+        return ret.get(self._field_data_key, missing_)
 
     def _deserialize(self, value, attr, data, partial=None, **kwargs):
         self._test_collection(value)

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -88,7 +88,7 @@ def pluck(dictlist: list[dict[str, typing.Any]], key: str):
         >>> pluck(dlist, 'id')
         [1, 2]
     """
-    return [d[key] for d in dictlist]
+    return [d.get(key) for d in dictlist]
 
 
 # Various utilities for pulling keyed values from objects

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2060,6 +2060,54 @@ class TestPluckSchema:
             "collaborators": [{"name": "Mick"}, {"name": "Keith"}],
         }
 
+    def test_pluck_missing_field(self):
+        """Pluck should not crash when the plucked field is absent
+        from a nested dict.
+
+        Regression test for KeyError crash in Pluck._serialize.
+        """
+
+        class AuthorSchema(Schema):
+            id = fields.Int()
+            name = fields.Str()
+
+        class BookSchema(Schema):
+            title = fields.Str()
+            author_name = fields.Pluck(AuthorSchema, "name")
+
+        s = BookSchema()
+        # author_name nested dict is present but lacks "name"
+        data = s.dump({"title": "Test Book", "author_name": {"id": 1}})
+        assert "author_name" not in data
+
+    def test_pluck_missing_field_many(self):
+        """Pluck(many=True) should not crash when the plucked field is
+        absent from one item in the list.
+
+        Regression test for KeyError crash in Pluck._serialize.
+        """
+
+        class AuthorSchema(Schema):
+            id = fields.Int()
+            name = fields.Str()
+
+        class BookSchema(Schema):
+            title = fields.Str()
+            authors = fields.Pluck(AuthorSchema, "name", many=True)
+
+        s = BookSchema()
+        data = s.dump(
+            {
+                "title": "Test Book",
+                "authors": [
+                    {"id": 1, "name": "John"},
+                    {"id": 2},  # missing "name"
+                    {"id": 3, "name": "Jane"},
+                ],
+            }
+        )
+        assert data["authors"] == ["John", None, "Jane"]
+
 
 class TestSelfReference:
     @pytest.fixture


### PR DESCRIPTION
## Problem

`Pluck._serialize` raises a bare `KeyError` when the plucked field is absent from the nested object. This happens for both `many=False` and `many=True`.

**Reproducer:**
```python
from marshmallow import Schema, fields

class AuthorSchema(Schema):
    id = fields.Int()
    name = fields.Str()

class BookSchema(Schema):
    title = fields.Str()
    author_name = fields.Pluck(AuthorSchema, "name")

s = BookSchema()
s.dump({"title": "Test", "author_name": {"id": 1}})  # KeyError: 'name'
```

The crash occurs because both code paths use `dict[key]` instead of `dict.get(key)`:
- Non-many (fields.py:721): `ret[self._field_data_key]`
- Many (utils.py:91): `d[key]` inside `utils.pluck`

Setting `dump_default` on the Pluck field does not help, because the base
`Field.serialize` only applies it when the entire nested object is missing,
not when a specific field within it is absent.

## Fix

- `Pluck._serialize`: use `ret.get(self._field_data_key, missing_)` so the field is gracefully omitted when the key is absent.
- `utils.pluck`: use `d.get(key)` so individual items with missing keys produce `None` instead of crashing.

## Behavior after fix

- **Non-many**: field is omitted from serialized output (consistent with other missing-value behavior).
- **Many**: missing keys produce `None` in the output list.