### PR TITLE
Fix schema validators after collection pre-load changes length

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -188,3 +188,4 @@ Contributors (chronological)
 - `@rstar327 <https://github.com/rstar327>`_
 - Kadir Can Ozden  `@bysiber  <https://github.com/bysiber>`_
 - Dhruvil Darji  `@dhruvildarji  <https://github.com/dhruvildarji>`_
+- `@nyxst4ck <https://github.com/nyxst4ck>`_

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -1192,9 +1192,12 @@ class Schema(metaclass=SchemaMeta):
             pass_original = validator_kwargs.get("pass_original", False)
 
             if many and not pass_collection:
-                for idx, (item, orig) in enumerate(
+                data_items = (
                     zip(data, original_data, strict=True)
-                ):
+                    if pass_original
+                    else ((item, None) for item in data)
+                )
+                for idx, (item, orig) in enumerate(data_items):
                     self._run_validator(
                         validator,
                         item,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -619,6 +619,22 @@ class TestValidatesSchemaDecorator:
         errors = schema.validate([{"foo": 4, "bar": "42"}], many=True)
         assert errors["_schema"] == ["bar cannot be a string"]
 
+    def test_collection_pre_load_can_change_length_before_item_schema_validation(self):
+        class MySchema(Schema):
+            foo = fields.Int()
+
+            @pre_load(pass_collection=True)
+            def remove_items_without_foo(self, data, **kwargs):
+                return [item for item in data if item.get("foo") != ""]
+
+            @validates_schema
+            def validate_foo(self, data, **kwargs):
+                assert "foo" in data
+
+        schema = MySchema()
+
+        assert schema.load([{"foo": 24}, {"foo": ""}], many=True) == [{"foo": 24}]
+
     def test_allow_reporting_field_errors_in_schema_validator(self):
         class NestedSchema(Schema):
             baz = fields.Int(required=True)


### PR DESCRIPTION
## Summary

- Avoid zipping deserialized `many=True` items with the original raw collection when a per-item `@validates_schema` hook did not request `pass_original`.
- Add a regression test for `@pre_load(pass_collection=True)` changing collection length before per-item schema validation.
- Add `@nyxst4ck` to `AUTHORS.rst` per the contribution guidelines.

## Root cause

For `many=True` schema validation, `_invoke_schema_validators` always used `zip(data, original_data, strict=True)` for per-item validators. If a collection-level pre-load hook filtered or otherwise changed the number of items, per-item schema validators that did not use `pass_original` still failed with `ValueError` from the strict zip, even though `original_data` is unused in that case.

## Test Plan

- `uv run pytest tests/test_decorators.py -k collection_pre_load_can_change_length_before_item_schema_validation -q`
- `uv run pytest tests/test_decorators.py -q`
- `uv run pytest -q -k "not test_from_timestamp_with_overflow_value"`
- `uv run tox -e lint`

Also ran `uv run pytest -q`; it had one unrelated Windows/Python assertion failure in `tests/test_utils.py::test_from_timestamp_with_overflow_value` because the platform error message was `Error converting value to datetime` instead of the expected regex.
