### PR TITLE
Enum Allow None Default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+(unreleased)
+------------
+
+Features:
+
+- If `by_value` is enabled on an enum with a `None` value `allow_none` now defaults to `True`.
+  Thanks :user:`GeraldineGalindo` for the suggestion (:issue:`2985`).
+
 4.3.0 (2026-04-03)
 ------------------
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1928,6 +1928,7 @@ class Enum(Field[_EnumT]):
     If `by_value` is `False` (default), enum members are (de)serialized by symbol (name).
     If it is `True`, they are (de)serialized by value using `marshmallow.fields.Raw`.
     If it is a field instance or class, they are (de)serialized by value using this field.
+    If `by_value` is enabled on an enum with a `None` value, `allow_none` defaults to `True`.
 
     .. versionadded:: 3.18.0
     """
@@ -1968,6 +1969,8 @@ class Enum(Field[_EnumT]):
             self.choices_text = ", ".join(
                 str(self.field._serialize(m.value, None, None)) for m in enum
             )
+            if "allow_none" not in kwargs and any(m.value is None for m in enum):
+                self.allow_none = True
 
     def _serialize(
         self, value: _EnumT | None, attr: str | None, obj: typing.Any, **kwargs

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,6 +28,11 @@ class HairColorEnum(Enum):
     red = "red hair"
 
 
+class UltimatumEnum(Enum):
+    all = float("inf")
+    nothing = None
+
+
 class DateEnum(Enum):
     date_1 = dt.date(2004, 2, 29)
     date_2 = dt.date(2008, 2, 29)
@@ -57,6 +62,7 @@ ALL_FIELDS = [
     functools.partial(fields.Enum, GenderEnum),
     functools.partial(fields.Enum, HairColorEnum, by_value=fields.String),
     functools.partial(fields.Enum, GenderEnum, by_value=fields.Integer),
+    functools.partial(fields.Enum, UltimatumEnum, allow_none=False),
 ]
 
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -24,6 +24,7 @@ from tests.base import (
     DateEnum,
     GenderEnum,
     HairColorEnum,
+    UltimatumEnum,
     assert_date_equal,
     assert_time_equal,
     central,
@@ -1280,6 +1281,10 @@ class TestFieldDeserialization:
         field = fields.Enum(DateEnum, by_value=fields.Date(format="%d/%m/%Y"))
         with pytest.raises(ValidationError, match="Not a valid date."):
             field.deserialize("30/02/2004")
+
+    def test_enum_by_value_allow_none_default(self):
+        field = fields.Enum(UltimatumEnum, by_value=True)
+        assert field.deserialize(None) is None
 
     def test_deserialization_function_must_be_callable(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #2985

> If `by_value` is enabled on an enum with a `None` value `allow_none` defaults to `True`.