### PR TITLE
Return default from get_value for out-of-range int index

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -125,6 +125,8 @@ def _get_value_for_key(obj, key, default):
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,11 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+def test_get_value_out_of_range_int_index():
+    assert utils.get_value([0, 1, 2, 3], 999, default=42) == 42
+    assert utils.get_value({1: "a", 2: "b"}, 4, default="z") == "z"
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893

`get_value(obj, key, default)` is documented to fall back to `default` when a key is missing, and it does for string and dict keys. But an out-of-range integer index against a sequence raises `TypeError: attribute name must be string, not 'int'` instead of returning the default:

```python
>>> from marshmallow import utils
>>> utils.get_value([0, 1, 2, 3], 999, default=42)
TypeError: attribute name must be string, not 'int'
```

`_get_value_for_key` catches the `IndexError` from `obj[key]` and falls back to `getattr(obj, key, default)`, but when `key` is an int, `getattr` itself raises `TypeError` because attribute names must be strings. A non-string key can never be an attribute name, so this guards that path to return `default` directly instead of calling `getattr`.

Added a regression test covering the out-of-range int index and a missing int dict key; the int case raises `TypeError` on `dev` and passes with the change.
