### PR TITLE
Fix typo: "arithmetics" -> "arithmetic" in TimeDelta field

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1505,7 +1505,7 @@ class TimeDelta(Field[dt.timedelta]):
     Float Caveats
     -------------
     Precision loss may occur when serializing a highly precise :class:`datetime.timedelta`
-    object using a big ``precision`` unit due to floating point arithmetics.
+    object using a big ``precision`` unit due to floating point arithmetic.
 
     When necessary, the :class:`datetime.timedelta` constructor rounds `float` inputs
     to whole microseconds during initialization of the object. As a result, deserializing
@@ -1564,7 +1564,7 @@ class TimeDelta(Field[dt.timedelta]):
         if value is None:
             return None
 
-        # limit float arithmetics to a single division to minimize precision loss
+        # limit float arithmetic to a single division to minimize precision loss
         microseconds: int = utils.timedelta_to_microseconds(value)
         microseconds_per_unit: int = self._unit_to_microseconds_mapping[self.precision]
         return microseconds / microseconds_per_unit


### PR DESCRIPTION
## Summary

Fix a grammatical typo in `src/marshmallow/fields.py` — the word "arithmetics" is not standard English; the correct term is "arithmetic" (uncountable noun).

Two occurrences fixed:
- Line 1508: in the `TimeDelta` class docstring ("Float Caveats" section)
- Line 1567: in the `_serialize` method inline comment

## Changes

```diff
-    object using a big ``precision`` unit due to floating point arithmetics.
+    object using a big ``precision`` unit due to floating point arithmetic.

-        # limit float arithmetics to a single division to minimize precision loss
+        # limit float arithmetic to a single division to minimize precision loss
```

Found with `codespell`.