### PR TITLE
Return default from get_value for non-string keys (#2893)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Bug fixes:
+
+- ``utils.get_value`` now returns the ``default`` for a non-string key such as
+  an out-of-range integer index, instead of raising a ``TypeError`` from
+  ``getattr`` (:issue:`2893`).
+
 4.3.0 (2026-04-03)
 ------------------
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,12 +120,21 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
-        return getattr(obj, key, default)
+        return _getattr_or_default(obj, key, default)
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        return _getattr_or_default(obj, key, default)
+
+
+def _getattr_or_default(obj, key, default):
+    # getattr only accepts a string attribute name, so a non-string key (e.g. an
+    # out-of-range int index) can never be an attribute: fall back to the default
+    # instead of letting getattr raise a TypeError.
+    if not isinstance(key, str):
+        return default
+    return getattr(obj, key, default)
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,16 @@ def test_get_value_from_namedtuple_with_default():
     assert utils.get_value(p, "y", default=123) is None
 
 
+def test_get_value_with_out_of_range_int_key_returns_default():
+    # A non-string key (e.g. an out-of-range int index) must fall back to the
+    # default instead of raising a TypeError from getattr (gh-2893).
+    assert utils.get_value([0, 1, 2], 999, default=3) == 3
+    assert utils.get_value({1: "a", 2: "b"}, 4, default="z") == "z"
+    assert utils.get_value([[1, 2]], 3, default=None) is None
+    # a valid int index still returns the element
+    assert utils.get_value([10, 20, 30], 1, default=None) == 20
+
+
 class Triangle:
     def __init__(self, p1, p2, p3):
         self.p1 = p1


### PR DESCRIPTION
## Summary

Fixes #2893. `utils.get_value` falls back to `getattr(obj, key, default)` whenever the container lookup fails, but `getattr` requires a **string** attribute name. So an out-of-range integer index (or any non-string key) raises `TypeError: attribute name must be string` instead of returning the default:

```python
utils.get_value([0, 1, 2], 999, default=3)          # TypeError (expected: 3)
utils.get_value({1: "a", 2: "b"}, 4, default="z")    # TypeError (expected: "z")
```

## Fix

Only call `getattr` when the key is a string; a non-string key can't be an attribute name, so return the `default`.

## Tests

- Added `test_get_value_with_out_of_range_int_key_returns_default`; it fails on `dev` (`TypeError`) and passes here.
- The full test suite passes (1179); `ruff` clean; changelog updated.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
