### PR TITLE
fix: prevent TypeError in get_value and set_value when using integer keys

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,11 +120,17 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
+        # getattr only accepts strings. If key is an int, return default immediately.
+        if isinstance(key, int):
+            return default
         return getattr(obj, key, default)
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        # Same check here.
+        if isinstance(key, int):
+            return default
         return getattr(obj, key, default)
 
 
@@ -139,7 +145,8 @@ def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):
         >>> d
         {'foo': {'bar': 42}}
     """
-    if "." in key:
+    # Only check for dots if the key is actually a string!
+    if isinstance(key, str) and "." in key:
         head, rest = key.split(".", 1)
         target = dct.setdefault(head, {})
         if not isinstance(target, dict):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -759,6 +759,7 @@ class TestFieldPreAndPostLoad:
 class IntAttributeSchema(Schema):
     name = fields.String(required=True, attribute=1)
 
+
 def test_set_value_int_key_schema_load():
     """Schema.load() with an integer attribute key should produce {1: value},
     not raise TypeError from set_value."""

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -753,3 +753,14 @@ class TestFieldPreAndPostLoad:
             match="The 'post_load' parameter must be a callable or an iterable of callables.",
         ):
             fields.Int(post_load="not_callable")  # type: ignore[arg-type]
+
+
+# Integer key handling during schema load
+class IntAttributeSchema(Schema):
+    name = fields.String(required=True, attribute=1)
+
+def test_set_value_int_key_schema_load():
+    """Schema.load() with an integer attribute key should produce {1: value},
+    not raise TypeError from set_value."""
+    result = IntAttributeSchema().load({"name": "hello"})
+    assert result == {1: "hello"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,3 +158,48 @@ def test_function_field_using_type_annotation():
     data = {"friends": "Clark;Alfred;Robin"}
     result = MySchema().load(data)
     assert result == {"friends": ["Clark", "Alfred", "Robin"]}
+
+
+# Integer key handling in get_value and set_value
+def test_get_value_int_key_plain_object_returns_default():
+    """get_value with an int key on an object that has no __getitem__
+    should return default, not raise TypeError."""
+    class DummyObject:
+        pass
+
+    result = utils.get_value(DummyObject(), 1, default="fallback")
+    assert result == "fallback"
+
+
+def test_get_value_int_key_dict_missing_returns_default():
+    """get_value with an int key on a dict where the key is absent
+    should return default, not raise TypeError."""
+    result = utils.get_value({"name": "Praveen"}, 1, default="fallback")
+    assert result == "fallback"
+
+
+def test_get_value_int_key_dict_present_returns_value():
+    """get_value with an int key on a dict where the key exists
+    should return the correct value."""
+    result = utils.get_value({1: "found"}, 1, default="fallback")
+    assert result == "found"
+
+
+def test_get_value_int_key_list_valid_index():
+    """get_value with an int key on a list should return the element."""
+    result = utils.get_value(["a", "b", "c"], 1, default="fallback")
+    assert result == "b"
+
+
+def test_get_value_int_key_list_out_of_range_returns_default():
+    """get_value with an out-of-range int key on a list should return default."""
+    result = utils.get_value(["a", "b"], 99, default="fallback")
+    assert result == "fallback"
+
+
+def test_set_value_int_key_direct():
+    """utils.set_value with an integer key should store it directly,
+    not crash trying to do '.' in key on an int."""
+    d = {}
+    utils.set_value(d, 1, "value")
+    assert d == {1: "value"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,6 +164,7 @@ def test_function_field_using_type_annotation():
 def test_get_value_int_key_plain_object_returns_default():
     """get_value with an int key on an object that has no __getitem__
     should return default, not raise TypeError."""
+
     class DummyObject:
         pass
 


### PR DESCRIPTION
This PR fixes a bug where `utils.get_value` and `utils.set_value` crash with a `TypeError` when an integer is used as a dictionary key or field attribute. 

Previously, `_get_value_for_key` would attempt to pass an integer to `getattr`, and `set_value` would attempt to call `.` checks on the integer. This adds strict string checks to prevent the crash and safely resolve integer lookups.

**Changes:**
- Add `isinstance(key, int)` guards in `utils._get_value_for_key`.
- Add `isinstance(key, str)` guard before attempting dotted splits in `utils.set_value`.
- Add test coverage in `test_utils.py`.