### PR TITLE
Make the timestamp overflow test independent of the platform

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,8 +123,14 @@ def test_from_timestamp_with_negative_value():
 
 
 def test_from_timestamp_with_overflow_value():
+    # The value is unrepresentable everywhere, but which error the platform
+    # raises differs, so matching one platform's wording is not portable:
+    # Linux raises ValueError("year ... is out of range"), which from_timestamp
+    # lets through unchanged, while Windows raises OSError(EINVAL), which it
+    # re-raises as ValueError("Error converting value to datetime"). Assert the
+    # contract they share instead.
     value = 9223372036854775
-    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
+    with pytest.raises(ValueError):
         utils.from_timestamp(value)
 
 


### PR DESCRIPTION
## Summary

Fixes #2999. `test_from_timestamp_with_overflow_value` fails on every Windows job (py310–py314) because it matches the exception text one platform happens to produce.

I reproduced it natively on Windows 11 — it's the only failure in the file:

```
>       with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
E       AssertionError: Regex pattern did not match.
E         Expected regex: 'out of range|year must be in 1\.\.9999'
E         Actual message: 'Error converting value to datetime'
```

## Why the message differs

`datetime.fromtimestamp` reports an unrepresentable timestamp differently per platform, and `from_timestamp` only wraps two of the three cases:

| platform | `fromtimestamp` raises | `from_timestamp` result |
| --- | --- | --- |
| Linux | `ValueError("year ... is out of range")` | **passes through unchanged** (not caught) |
| Windows | `OSError(EINVAL)` | caught → `ValueError("Error converting value to datetime")` |
| (either) | `OverflowError` | caught → `ValueError("Timestamp is too large")` |

Confirmed on Windows:

```
platform raises: OSError -> [Errno 22] Invalid argument
from_timestamp raises: ValueError -> Error converting value to datetime
```

So the test was really asserting CPython's Linux wording, which leaks through only because `ValueError` isn't in the `except` clauses.

## Why this is a test-only fix

I checked whether users see the difference, and they don't — `_TemporalField._deserialize` catches `ValueError` and reports the same thing either way:

```
9223372036854775       -> ValidationError ['Not a valid datetime.']
'nonsense'             -> ValidationError ['Not a valid datetime.']
```

Both platforms raise `ValueError` and both produce `Not a valid datetime.`, so only the internal wording differs. The test now asserts that shared contract, with a comment recording why the wording varies so nobody re-tightens it to one platform's text.

I deliberately did **not** change `from_timestamp` to normalise the three messages. That would alter public error text (`utils.from_timestamp` is importable) to fix a test, with no user-visible benefit. Happy to do it if you'd rather the function speak with one voice — it'd be a small follow-up.

## Verification

- `pytest tests/test_utils.py` → **20 passed** on Windows (was 1 failed, 19 passed)
- `pytest tests/` → **1178 passed**, no other Windows failures
- `ruff check src tests` → all checks passed; `ruff format --check` → 33 files already formatted
