### PR TITLE
Raise ValidationError (not ValueError) for NaN in TimeDelta

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1581,7 +1581,10 @@ class TimeDelta(Field[dt.timedelta]):
 
         try:
             return dt.timedelta(**kwargs)
-        except OverflowError as error:
+        except (OverflowError, ValueError) as error:
+            # OverflowError: value out of timedelta's range (e.g. infinity).
+            # ValueError: value is NaN (float("nan") passes the float() guard
+            # above but timedelta() rejects it).
             raise self.make_error("invalid") from error
 
 

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -1583,8 +1583,7 @@ class TimeDelta(Field[dt.timedelta]):
             return dt.timedelta(**kwargs)
         except (OverflowError, ValueError) as error:
             # OverflowError: value out of timedelta's range (e.g. infinity).
-            # ValueError: value is NaN (float("nan") passes the float() guard
-            # above but timedelta() rejects it).
+            # ValueError: value is NaN.
             raise self.make_error("invalid") from error
 
 

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -862,7 +862,9 @@ class TestFieldDeserialization:
         unit_value = dt.timedelta(weeks=1).total_seconds()
         assert math.isclose(result.total_seconds() / unit_value, total_weeks_value)
 
-    @pytest.mark.parametrize("in_value", ["", "badvalue", [], 9999999999])
+    @pytest.mark.parametrize(
+        "in_value", ["", "badvalue", [], 9999999999, "nan", "inf", "-inf"]
+    )
     def test_invalid_timedelta_field_deserialization(self, in_value):
         field = fields.TimeDelta(fields.TimeDelta.DAYS)
         with pytest.raises(ValidationError) as excinfo:


### PR DESCRIPTION
### Problem

A `TimeDelta` field raises a bare `ValueError` (instead of `ValidationError`) when it receives `NaN`, so loading untrusted input can crash with an exception that isn't part of marshmallow's public error contract:

```python
from marshmallow import Schema, fields

class S(Schema):
    duration = fields.TimeDelta()

S().load({"duration": "nan"})
# ValueError: cannot convert float NaN to integer   <- leaks; expected ValidationError
```

`"inf"` / `"-inf"` already behave correctly (they raise `ValidationError`), which makes the `NaN` case an inconsistency rather than intended behaviour.

### Cause

`TimeDelta._deserialize` only catches `OverflowError` around `dt.timedelta(**kwargs)`:

```python
try:
    return dt.timedelta(**kwargs)
except OverflowError as error:
    raise self.make_error("invalid") from error
```

`float("nan")` passes the earlier `float(value)` guard, but `dt.timedelta(nan)` raises `ValueError` — not `OverflowError` — so it escapes uncaught. (`inf`/`-inf` work because `timedelta` raises `OverflowError` for those.)

### Fix

Catch `ValueError` alongside `OverflowError`, so `NaN` produces the field's standard `"Not a valid period of time."` error like every other invalid input:

```python
except (OverflowError, ValueError) as error:
    raise self.make_error("invalid") from error
```

Extended the existing parametrized `test_invalid_timedelta_field_deserialization` with `"nan"`, `"inf"`, `"-inf"`. Full test suite passes locally.

---
*Disclosure: I used an LLM to help find and draft this fix; I've reviewed every line, reproduced the bug, and run the suite myself.*
