### PR TITLE
Fix #2999: Add Windows error message to timestamp test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,7 +124,10 @@ def test_from_timestamp_with_negative_value():
 
 def test_from_timestamp_with_overflow_value():
     value = 9223372036854775
-    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
+    with pytest.raises(
+        ValueError,
+        match=r"out of range|year must be in 1\.\.9999|Error converting value to datetime",
+    ):
         utils.from_timestamp(value)
 
 


### PR DESCRIPTION
Fixes #2999

### Description
This PR updates the regex in `test_from_timestamp_with_overflow_value` to account for the generic fallback message (`"Error converting value to datetime"`) that occurs on Windows systems. 

Previously, the test strictly expected Linux/macOS specific error messages, which caused the test suite to fail locally on Windows environments.