### PR TITLE
fix: deep-copy nested field error_messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 (unreleased)
 ------------
 
+Bug fixes:
+
+- Nested ``dict``/``list`` values in field ``error_messages`` are deep-copied so
+  mutating one field instance no longer rewrites siblings or class defaults
+  (:issue:`3005`).
+
 Features:
 
 - If `by_value` is enabled on an enum with a `None` value `allow_none` now defaults to `True`.

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -231,11 +231,13 @@ class Field(typing.Generic[_InternalT]):
 
         metadata = metadata or {}
         self.metadata = metadata
-        # Collect default error message from self and parent classes
+        # Collect default error message from self and parent classes.
+        # Deep-copy so nested dict/list message values are per-instance
+        # (shallow update shared nested containers across fields; issue #3005).
         messages: types.ErrorMessages = {}
         for cls in reversed(self.__class__.__mro__):
-            messages.update(getattr(cls, "default_error_messages", {}))
-        messages.update(error_messages or {})
+            messages.update(copy.deepcopy(getattr(cls, "default_error_messages", {})))
+        messages.update(copy.deepcopy(error_messages or {}))
         self.error_messages = messages
 
         self.parent: Field | Schema | None = None

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -282,6 +282,43 @@ class TestErrorMessages:
         assert "doesntexist" in excinfo.value.args[0]
         assert "MyField" in excinfo.value.args[0]
 
+    def test_nested_error_messages_are_not_shared_across_instances(self):
+        class NestedMsgField(fields.Field):
+            default_error_messages = {
+                "invalid": {"lo": "too low", "hi": "too high"},
+                "steps": ["a", "b"],
+            }
+
+        f1 = NestedMsgField()
+        f2 = NestedMsgField()
+        invalid1 = f1.error_messages["invalid"]
+        steps1 = f1.error_messages["steps"]
+        assert isinstance(invalid1, dict)
+        assert isinstance(steps1, list)
+        invalid1["lo"] = "CHANGED BY f1"
+        steps1.append("INJECTED")
+
+        invalid2 = f2.error_messages["invalid"]
+        assert isinstance(invalid2, dict)
+        assert invalid2["lo"] == "too low"
+        assert NestedMsgField.default_error_messages["steps"] == ["a", "b"]
+        new_invalid = NestedMsgField().error_messages["invalid"]
+        assert isinstance(new_invalid, dict)
+        assert new_invalid["lo"] == "too low"
+        assert f1.error_messages["invalid"] is not f2.error_messages["invalid"]
+
+    def test_error_messages_kwarg_dict_is_deep_copied(self):
+        shared: dict = {"invalid": {"lo": "too low"}}
+        f1: fields.Field = fields.Field(error_messages=shared)
+        f2: fields.Field = fields.Field(error_messages=shared)
+        invalid1 = f1.error_messages["invalid"]
+        assert isinstance(invalid1, dict)
+        invalid1["lo"] = "CHANGED"
+        invalid2 = f2.error_messages["invalid"]
+        assert isinstance(invalid2, dict)
+        assert invalid2["lo"] == "too low"
+        assert shared["invalid"]["lo"] == "too low"
+
 
 class TestNestedField:
     @pytest.mark.parametrize("param", ("only", "exclude"))


### PR DESCRIPTION
Since nested dict/list values are allowed in `error_messages`, a shallow `dict.update` in `Field.__init__` leaves those nested containers shared across every field instance and the class defaults. Mutating one instance rewrites siblings and future instances.

Deep-copy class defaults and the `error_messages` kwargs so nested message values are per-instance.

Fixes #3005
