### PR TITLE
fix(tests): handle OSError exception message in test_from_timestamp_with_overflow_value

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,7 +124,10 @@ def test_from_timestamp_with_negative_value():
 
 def test_from_timestamp_with_overflow_value():
     value = 9223372036854775
-    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999|Error converting value|Timestamp is too large"):
+    with pytest.raises(
+        ValueError,
+        match=r"out of range|year must be in 1\.\.9999|Error converting value|Timestamp is too large",
+    ):
         utils.from_timestamp(value)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -124,7 +124,7 @@ def test_from_timestamp_with_negative_value():
 
 def test_from_timestamp_with_overflow_value():
     value = 9223372036854775
-    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
+    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999|Error converting value|Timestamp is too large"):
         utils.from_timestamp(value)
 
 


### PR DESCRIPTION
Updates the exception matching regex in `test_from_timestamp_with_overflow_value` to handle platform-specific OSError messages ("Error converting value to datetime" / "Timestamp is too large") raised by OS C library timestamp conversions on Windows/Python 3.14.