### PR TITLE
Return default from get_value for out-of-range int keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Features:
 - If `by_value` is enabled on an enum with a `None` value `allow_none` now defaults to `True`.
   Thanks :user:`GeraldineGalindo` for the suggestion (:issue:`2985`).
 
+Bug fixes:
+
+- `marshmallow.utils.get_value` returns the ``default`` instead of raising a
+  ``TypeError`` when given an out-of-range or missing integer key (:issue:`2893`).
+
 4.3.0 (2026-04-03)
 ------------------
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -119,6 +119,14 @@ def _get_value_for_keys(obj, keys, default):
 
 
 def _get_value_for_key(obj, key, default):
+    if not isinstance(key, str):
+        # ``getattr`` only accepts string attribute names, so a non-string key
+        # (e.g. an int index) can never fall back to attribute access.
+        try:
+            return obj[key]
+        except (KeyError, IndexError, TypeError, AttributeError):
+            return default
+
     if not hasattr(obj, "__getitem__"):
         return getattr(obj, key, default)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,16 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+# regression test for https://github.com/marshmallow-code/marshmallow/issues/2893
+def test_get_value_with_out_of_range_int_key_returns_default():
+    # An out-of-range int index (or missing int dict key) must fall back to the
+    # default instead of raising TypeError from an attempted getattr.
+    lst = [0, 1, 2, 3, 4, 5]
+    assert utils.get_value(lst, 999, default=3) == 3
+    assert utils.get_value({1: "a", 2: "b", 3: "c"}, 4, default="z") == "z"
+    assert utils.get_value([[PointClass(24, 42)]], 3, default=None) is None
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893

### Root cause
`utils.get_value` delegates to `_get_value_for_key`, which on any exception from `obj[key]` falls back to `getattr(obj, key, default)`. `getattr` requires a *string* attribute name, so when `key` is an integer (an out-of-range list index, or a missing integer dict key) the fallback itself raises:

```
TypeError: getattr(): attribute name must be string
```

instead of returning the caller-supplied `default`. This contradicts the documented behaviour and the way string keys already degrade to `default`.

### Fix
Handle non-string keys explicitly in `_get_value_for_key`: attempt the item lookup and, on failure, return `default` directly — skipping the attribute-access step that can never succeed for a non-string key. String keys retain their existing `__getitem__` -> `getattr` fallback.

```python
from marshmallow import utils
utils.get_value([0, 1, 2, 3, 4, 5], 999, default=3)        # -> 3
utils.get_value({1: 'a', 2: 'b', 3: 'c'}, 4, default='z')  # -> 'z'
```

### Tests
Added a regression test `test_get_value_with_out_of_range_int_key_returns_default` in `tests/test_utils.py`.

Full suite: `1184 passed, 1 failed` — the single failure is the pre-existing, Windows-only `test_from_timestamp_with_overflow_value` (issue #2999), unrelated to this change.