### PR TITLE
Return default from get_value for missing non-string keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,12 @@ Features:
 - If `by_value` is enabled on an enum with a `None` value `allow_none` now defaults to `True`.
   Thanks :user:`GeraldineGalindo` for the suggestion (:issue:`2985`).
 
+Bug fixes:
+
+- ``get_value`` now returns the ``default`` for a missing non-string key (such as
+  an out-of-range list index or an absent integer dict key) instead of raising
+  ``TypeError`` from the ``getattr`` fallback (:issue:`2893`).
+
 4.3.0 (2026-04-03)
 ------------------
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -119,6 +119,14 @@ def _get_value_for_keys(obj, keys, default):
 
 
 def _get_value_for_key(obj, key, default):
+    # getattr() requires a string attribute name, so a non-string key can only
+    # be resolved through item access -- never fall back to getattr for it.
+    if not isinstance(key, str):
+        try:
+            return obj[key]
+        except (KeyError, IndexError, TypeError, AttributeError):
+            return default
+
     if not hasattr(obj, "__getitem__"):
         return getattr(obj, key, default)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,17 @@ def test_get_value_for_nested_object():
     assert utils.get_value(tri, "p3.x") == 5
 
 
+def test_get_value_out_of_range_int_key_returns_default():
+    # Regression test for #2893: a non-string key that misses (out-of-range
+    # list index / absent int dict key) must return the default, not raise
+    # ``TypeError`` from the getattr() fallback.
+    assert utils.get_value([0, 1, 2], 999, default=3) == 3
+    assert utils.get_value({1: "a"}, 4, default="z") == "z"
+    # a present integer key still resolves normally
+    assert utils.get_value([0, 1, 2], 1) == 1
+    assert utils.get_value({1: "a"}, 1) == "a"
+
+
 # regression test for https://github.com/marshmallow-code/marshmallow/issues/62
 def test_get_value_from_dict():
     d = dict(items=["foo", "bar"], keys=["baz", "quux"])


### PR DESCRIPTION
Fixes #2893.

`utils.get_value` fell back to `getattr()` when item access failed, but `getattr()` rejects non-string attribute names — so an out-of-range list index or an absent integer dict key raised `TypeError` instead of returning the default:

```python
>>> from marshmallow import utils
>>> utils.get_value([0, 1, 2], 999, default=3)
TypeError: attribute name must be string, not 'int'
>>> utils.get_value({1: "a"}, 4, default="z")
TypeError: attribute name must be string, not 'int'
```

A non-string key can only be resolved through item access, never attribute access, so this resolves non-string keys via item lookup only and returns the `default` when it misses. Present integer keys still work as before. Added a regression test and a changelog entry.
