### PR TITLE
Fix URL validator rejecting a fragment after an empty path

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -188,3 +188,4 @@ Contributors (chronological)
 - `@rstar327 <https://github.com/rstar327>`_
 - Kadir Can Ozden  `@bysiber  <https://github.com/bysiber>`_
 - Dhruvil Darji  `@dhruvildarji  <https://github.com/dhruvildarji>`_
+- Haïm Dimer `@hdimer  <https://github.com/hdimer>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Features:
 Bug fixes:
 
 - `marshmallow.validate.URL` accepts a fragment that follows an empty path,
-  e.g. ``https://example.com#frag`` (:pr:`3016`).
+  e.g. ``https://example.com#frag`` (:pr:`3016`). Thanks :user:`hdimer` for the PR.
 
 4.3.0 (2026-04-03)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Features:
 - If `by_value` is enabled on an enum with a `None` value `allow_none` now defaults to `True`.
   Thanks :user:`GeraldineGalindo` for the suggestion (:issue:`2985`).
 
+Bug fixes:
+
+- `marshmallow.validate.URL` accepts a fragment that follows an empty path,
+  e.g. ``https://example.com#frag`` (:pr:`3016`).
+
 4.3.0 (2026-04-03)
 ------------------
 

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -157,7 +157,8 @@ class URL(Validator):
                     r"(?::\d+)?",
                 )
             )
-            relative_part = r"(?:/?|[/?]\S+)\Z"
+            # `#` may lead a fragment right after the host, e.g. `https://example.com#frag`.
+            relative_part = r"(?:/?|[/?#]\S+)\Z"
 
             if relative:
                 if absolute:

--- a/src/marshmallow/validate.py
+++ b/src/marshmallow/validate.py
@@ -157,7 +157,6 @@ class URL(Validator):
                     r"(?::\d+)?",
                 )
             )
-            # `#` may lead a fragment right after the host, e.g. `https://example.com#frag`.
             relative_part = r"(?:/?|[/?#]\S+)\Z"
 
             if relative:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -32,6 +32,8 @@ from marshmallow import ValidationError, validate
         "http://:pass@example.com",
         "http://@example.com",
         "http://AZaz09-._~%2A!$&'()*+,;=:@example.com",
+        "http://example.org#fragment",
+        "http://user@example.com#fragment",
     ],
 )
 def test_url_absolute_valid(valid_url):
@@ -88,6 +90,7 @@ def test_url_absolute_invalid(invalid_url):
         "/foo/bar",
         "/foo?bar",
         "/foo?bar#baz",
+        "#frag",
     ],
 )
 def test_url_relative_valid(valid_url):
@@ -124,6 +127,7 @@ def test_url_relative_invalid(invalid_url):
         "/foo?bar",
         "?bar",
         "/foo?bar#baz",
+        "#frag",
     ],
 )
 def test_url_relative_only_valid(valid_url):


### PR DESCRIPTION
`validate.URL` rejects an absolute URL whose fragment follows an empty path with no query:

```python
from marshmallow import validate
validate.URL()("https://example.com#frag")   # ValidationError: Not a valid URL.
```

Adding a path or a query makes it pass (`https://example.com/#frag`, `https://example.com?a=1#frag`), so only the bare-host + fragment case is affected. Per RFC 3986 a fragment may follow an empty path, and anchor links to a domain root (`https://example.com#section`) are common and valid.

The tail regex after the host allowed `/`, `/…` or `?…`, but a `#fragment` could only appear inside the path/query part. This adds `#` to the set of characters that may introduce the URL tail. As a consequence a bare `#frag` is now also accepted in relative mode, which matches the existing handling of a bare `?query` and is an RFC 3986 same-document reference.

### Testing

Added cases to the existing parametrized URL tests in `tests/test_validate.py` (absolute `#fragment` / `user@host#fragment`, and a bare `#frag` in both relative lists). Full test suite passes (`1188 passed`); `ruff check`/`ruff format` clean.

---
Used AI assistance on this; I reviewed and tested the change myself.