### PR TITLE
fix(utils): allow negative POSIX timestamps in from_timestamp()

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -41,8 +41,6 @@ def from_timestamp(value: typing.Any) -> dt.datetime:
     if value is True or value is False:
         raise ValueError("Not a valid POSIX timestamp")
     value = float(value)
-    if value < 0:
-        raise ValueError("Not a valid POSIX timestamp")
 
     # Load a timestamp with utc as timezone to prevent using system timezone.
     # Then set timezone to None, to let the Field handle adding timezone info.

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -569,8 +569,14 @@ class TestFieldDeserialization:
                 dt.datetime(2013, 11, 10, 0, 23, 45, 123456),
             ),
             ("timestamp", 1, dt.datetime(1970, 1, 1, 0, 0, 1)),
+            # Negative timestamps (pre-1970-01-01 dates) are valid POSIX
+            # timestamps and must be accepted; see
+            # test_timestamp_field_deserialization_round_trip_negative below.
+            ("timestamp", -1, dt.datetime(1969, 12, 31, 23, 59, 59)),
+            ("timestamp", -86400, dt.datetime(1969, 12, 31, 0, 0, 0)),
             ("timestamp_ms", 1384043025000, dt.datetime(2013, 11, 10, 0, 23, 45)),
             ("timestamp_ms", 1000, dt.datetime(1970, 1, 1, 0, 0, 1)),
+            ("timestamp_ms", -1000, dt.datetime(1969, 12, 31, 23, 59, 59)),
         ],
     )
     def test_timestamp_field_deserialization(self, fmt, value, expected):
@@ -590,6 +596,30 @@ class TestFieldDeserialization:
         expected_aware = expected.replace(tzinfo=central)
         assert field.deserialize(value) == expected_aware
 
+    # Regression test: serializing a datetime before 1970-01-01 with
+    # format="timestamp"/"timestamp_ms" legitimately produces a negative
+    # float (datetime.timestamp() handles pre-epoch dates fine), so
+    # from_timestamp() rejecting negative values broke the serialize/
+    # deserialize round trip for any date before the Unix epoch. This does
+    # not use mocks: it serializes a real pre-1970 datetime and asserts that
+    # deserializing the result reproduces the original value exactly.
+    @pytest.mark.parametrize("fmt", ["timestamp", "timestamp_ms"])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            dt.datetime(1969, 12, 31, 23, 59, 59, tzinfo=dt.timezone.utc),
+            dt.datetime(1950, 5, 3, 12, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(1900, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
+        ],
+    )
+    def test_timestamp_field_deserialization_round_trip_negative(self, fmt, value):
+        field = fields.DateTime(format=fmt)
+        serialized = field.serialize("value", {"value": value})
+        assert serialized < 0
+
+        roundtripped = field.deserialize(serialized)
+        assert roundtripped == value.replace(tzinfo=None)
+
     @pytest.mark.parametrize("fmt", ["timestamp", "timestamp_ms"])
     @pytest.mark.parametrize("in_value", [True, False])
     def test_boolean_timestamp_field_deserialization(self, fmt, in_value):
@@ -600,7 +630,7 @@ class TestFieldDeserialization:
     @pytest.mark.parametrize("fmt", ["timestamp", "timestamp_ms"])
     @pytest.mark.parametrize(
         "in_value",
-        ["", "!@#", -1],
+        ["", "!@#"],
     )
     def test_invalid_timestamp_field_deserialization(self, fmt, in_value):
         field = fields.DateTime(format=fmt)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,6 +108,11 @@ def test_is_collection():
     [
         (1676386740, dt.datetime(2023, 2, 14, 14, 59, 00)),
         (1676386740.58, dt.datetime(2023, 2, 14, 14, 59, 00, 580000)),
+        # Negative timestamps (dates before 1970-01-01) are valid POSIX
+        # timestamps and must round-trip correctly; see
+        # test_from_timestamp_with_negative_value below for the regression.
+        (-10, dt.datetime(1969, 12, 31, 23, 59, 50)),
+        (0, dt.datetime(1970, 1, 1, 0, 0, 0)),
     ],
 )
 def test_from_timestamp(value, expected):
@@ -117,9 +122,16 @@ def test_from_timestamp(value, expected):
 
 
 def test_from_timestamp_with_negative_value():
+    """Regression test: negative POSIX timestamps (dates before 1970-01-01)
+    are valid and must be accepted. Serializing an aware pre-1970 datetime
+    with `fields.DateTime(format="timestamp")` legitimately produces a
+    negative float (via `datetime.timestamp()`), so rejecting negative
+    values here breaks the serialize/deserialize round trip for any date
+    before the Unix epoch.
+    """
     value = -10
-    with pytest.raises(ValueError, match=r"Not a valid POSIX timestamp"):
-        utils.from_timestamp(value)
+    result = utils.from_timestamp(value)
+    assert result == dt.datetime(1969, 12, 31, 23, 59, 50)
 
 
 def test_from_timestamp_with_overflow_value():


### PR DESCRIPTION
## Summary

Fixes #3019.

`from_timestamp()` currently rejects negative POSIX timestamps even though negative timestamps are valid and are produced by `fields.DateTime(format="timestamp")` when serializing datetimes before the Unix epoch.

This breaks serialization/deserialization round-tripping for valid pre-1970 datetimes.

## Reproduction

```python
from datetime import datetime, timezone

from marshmallow import fields

field = fields.DateTime(format="timestamp")
value = datetime(1950, 5, 3, tzinfo=timezone.utc)

serialized = field.serialize("date", {"date": value})
# -620568000.0

field.deserialize(serialized)
# ValidationError: Not a valid datetime.
```

The same field can therefore produce a value that it cannot deserialize.

## Root cause

`from_timestamp()` explicitly rejected values below zero before calling `datetime.fromtimestamp()`.

Python's timestamp conversion already supports negative POSIX timestamps, so this explicit restriction was unnecessarily preventing valid dates from being deserialized.

## Fix

Remove the explicit negative-value rejection and rely on the existing timestamp conversion and `OSError` / `OverflowError` handling for genuine conversion failures.

Regression coverage was added for negative timestamps, including timestamp and timestamp-millisecond formats.

## Validation

- Regression tests pass.
- Full test suite: 1197 passed.
- Ruff formatting passes.
- Ruff lint passes.
- Mypy passes.
- No unrelated changes are included.

Fixes #3019