### PR TITLE
fix(schema): validate dotted nested options on non-nested and non-existent fields (#2180)

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -970,14 +970,31 @@ class Schema(metaclass=SchemaMeta):
             nested_options[parent].append(nested_names)
         # Apply the nested field options.
         for key, options in iter(nested_options.items()):
+            if key not in self.declared_fields:
+                raise ValueError(f"Invalid fields for {self}: {{'{key}'}}.")
+            field_obj = self.declared_fields[key]
+            inner_obj = field_obj
+            while hasattr(inner_obj, "inner"):
+                inner_obj = inner_obj.inner
+            if not (
+                hasattr(type(inner_obj), "schema")
+                or hasattr(type(inner_obj), "nested")
+                or hasattr(type(inner_obj), "only")
+                or hasattr(type(inner_obj), "exclude")
+                or "only" in inner_obj.__dict__
+                or "exclude" in inner_obj.__dict__
+            ):
+                raise ValueError(
+                    f"Cannot apply nested option '{option_name}' to non-nested field '{key}'."
+                )
             new_options = self.set_class(options)
-            original_options = getattr(self.declared_fields[key], option_name, ())
+            original_options = getattr(field_obj, option_name, ())
             if original_options:
                 if set_operation == "union":
                     new_options |= self.set_class(original_options)
                 if set_operation == "intersection":
                     new_options &= self.set_class(original_options)
-            setattr(self.declared_fields[key], option_name, new_options)
+            setattr(field_obj, option_name, new_options)
 
     def _init_fields(self) -> None:
         """Update self.fields, self.load_fields, and self.dump_fields based on schema options.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2549,3 +2549,26 @@ def test_set_dict_class(dict_cls):
     result = MySchema().dump({"foo": "bar"})
     assert result == {"foo": "bar"}
     assert isinstance(result, dict_cls)
+
+
+def test_nested_options_on_non_nested_or_non_existent_fields():
+    class SimpleSchema(Schema):
+        foo = fields.String()
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot apply nested option 'only' to non-nested field 'foo'.",
+    ):
+        SimpleSchema(only=["foo.bar"])
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot apply nested option 'exclude' to non-nested field 'foo'.",
+    ):
+        SimpleSchema(exclude=["foo.bar"])
+
+    with pytest.raises(ValueError, match="Invalid fields for"):
+        SimpleSchema(only=["nonexistent.bar"])
+
+    with pytest.raises(ValueError, match="Invalid fields for"):
+        SimpleSchema(exclude=["nonexistent.bar"])


### PR DESCRIPTION
### Summary of Changes
Fixes #2180.

When `only` or `exclude` options contained dotted paths (e.g. `only=["foo.bar"]`), marshmallow previously:
1. Silently stripped the dotted segment when `foo` was a non-nested scalar field (e.g. `fields.Str()`), converting `only=["foo.bar"]` into `only=["foo"]` and dumping the entire scalar field without error or warning.
2. Crashed with an unhandled `KeyError` when `foo` was a non-existent field name.

### Solution
1. In `Schema.__apply_nested_option`, validate that dotted parent field names exist in `self.declared_fields`. If the parent field does not exist, raise a clean `ValueError(f"Invalid fields for {self}: {{'{key}'}}.")`.
2. Inspect the target field (unwrapping container fields like `List`) without invoking `@property` getters prematurely, ensuring the field supports nested options (`schema`, `only`, `exclude`, or `nested`). If the parent field is a non-nested scalar field (e.g. `fields.Str()`), raise a clean `ValueError(f"Cannot apply nested option '{option_name}' to non-nested field '{key}'.")`.
3. Added unit tests in `tests/test_schema.py` (`test_nested_options_on_non_nested_or_non_existent_fields`).

### Testing
- `ruff check` & `ruff format`: Passed cleanly.
- `pytest`: 1,188 passed.
