### PR TITLE
fix: get_value returns default for out-of-range/missing int keys

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,12 +120,12 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
-        return getattr(obj, key, default)
+        return getattr(obj, key, default) if isinstance(key, str) else default
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        return getattr(obj, key, default) if isinstance(key, str) else default
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,18 @@ def test_get_value():
     assert utils.get_value(lst, MyInt(1)) == 2
 
 
+# regression test for https://github.com/marshmallow-code/marshmallow/issues/2893
+def test_get_value_with_out_of_range_int_key_returns_default():
+    lst = [0, 1, 2, 3, 4, 5]
+    assert utils.get_value(lst, 999, default=3) == 3
+
+    dictionary = {1: "a", 2: "b", 3: "c"}
+    assert utils.get_value(dictionary, 4, default="z") == "z"
+
+    list_obj = [[PointClass(24, 42), {"x": 24, "y": 42}]]
+    assert utils.get_value(list_obj, 3, default=None) is None
+
+
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
Fixes #2893.

`utils.get_value()` raised `TypeError: attribute name must be string` instead of returning the caller-supplied `default` when passed an out-of-range or missing int key.

This happened because `_get_value_for_key()` falls back to `getattr(obj, key, default)` after `obj[key]` fails. However, `getattr()` requires a string attribute name, so when `key` is an `int`, that fallback raises `TypeError` instead of returning `default`.

Fix: only attempt the `getattr()` fallback when `key` is a `str`; for other key types, return `default` directly.

Added a regression test covering the reproduction cases from the issue.

The full test suite passes with no regressions.