### PR TITLE
Simplify `get_value` to match actual usage

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -94,7 +94,7 @@ def pluck(dictlist: list[dict[str, typing.Any]], key: str):
 # Various utilities for pulling keyed values from objects
 
 
-def get_value(obj, key: int | str, default=missing):
+def get_value(obj, key: str, default=missing):
     """Helper for pulling a keyed value off various types of objects. Fields use
     this method by default to access attributes of the source object. For object `x`
     and attribute `i`, this method first tries to access `x[i]`, and then falls back to
@@ -105,17 +105,12 @@ def get_value(obj, key: int | str, default=missing):
         `get_value` will never check the value `x.i`. Consider overriding
         `marshmallow.fields.Field.get_value` in this case.
     """
-    if not isinstance(key, int) and "." in key:
-        return _get_value_for_keys(obj, key.split("."), default)
-    return _get_value_for_key(obj, key, default)
-
-
-def _get_value_for_keys(obj, keys, default):
-    if len(keys) == 1:
-        return _get_value_for_key(obj, keys[0], default)
-    return _get_value_for_keys(
-        _get_value_for_key(obj, keys[0], default), keys[1:], default
-    )
+    if "." in key:
+        for k in key.split("."):
+            obj = _get_value_for_key(obj, k, default)
+    else:
+        obj = _get_value_for_key(obj, key, default)
+    return obj
 
 
 def _get_value_for_key(obj, key, default):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,16 +69,6 @@ def test_get_value_from_dict():
     assert utils.get_value(d, "keys") == ["baz", "quux"]
 
 
-def test_get_value():
-    lst = [1, 2, 3]
-    assert utils.get_value(lst, 1) == 2
-
-    class MyInt(int):
-        pass
-
-    assert utils.get_value(lst, MyInt(1)) == 2
-
-
 def test_set_value():
     d: dict[str, int | dict] = {}
     utils.set_value(d, "foo", 42)


### PR DESCRIPTION
The `str | int` typehint and accompanying test were incorrect, because the only two calls to `get_value` in marshmallow have type hints that require the `attr` key to be a string.

Closes #2893

## Benchmark

Looping instead of recursion reduces dump time ~3%. Unconditionally splitting would further reduce the line count, but the unnecessary list allocation has a significant performance penalty.

| python version | dev (usec/dump) | this (usec/dump) | 
|-----|-----|------|
| 3.14  | 8.9    | 8.6 (-3.4%) | 
| 3.13 | 11.8   | 11.4 (-3.4%) | 
| 3.12 | 14.5   | 14.5 (-0.0%) | 
| 3.10 | 16.5   | 15.9 (-3.6%) | 