### PR TITLE
Return default for out-of-range int index in get_value (#2893)

### DIFF
--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -120,11 +120,17 @@ def _get_value_for_keys(obj, keys, default):
 
 def _get_value_for_key(obj, key, default):
     if not hasattr(obj, "__getitem__"):
+        # ``getattr`` requires a string attribute name; a non-string key (e.g. an
+        # int index) cannot name an attribute, so fall back to ``default``.
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
+        if not isinstance(key, str):
+            return default
         return getattr(obj, key, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,17 @@ def test_get_value_for_nested_object():
     assert utils.get_value(tri, "p3.x") == 5
 
 
+# regression test for https://github.com/marshmallow-code/marshmallow/issues/2893
+def test_get_value_with_out_of_range_int_index_returns_default():
+    # An out-of-range int index must return the default instead of raising
+    # TypeError from the getattr() fallback (which rejects non-string keys).
+    assert utils.get_value([0, 1, 2, 3, 4, 5], 999, default=3) == 3
+    assert utils.get_value({1: "a", 2: "b", 3: "c"}, 4, default="z") == "z"
+    assert utils.get_value([[PointClass(24, 42)]], 3, default=None) is None
+    # A valid int index still works.
+    assert utils.get_value([10, 20, 30], 1) == 20
+
+
 # regression test for https://github.com/marshmallow-code/marshmallow/issues/62
 def test_get_value_from_dict():
     d = dict(items=["foo", "bar"], keys=["baz", "quux"])


### PR DESCRIPTION
Fixes #2893.

## The bug

`utils.get_value` falls back to `getattr(obj, key, default)` when `obj[key]` raises. But `getattr` requires a string attribute name, so a non-string key — e.g. an out-of-range `int` index — raises `TypeError: attribute name must be string` instead of returning the `default`:

```python
from marshmallow import utils

utils.get_value([0, 1, 2], 999, default=3)   # TypeError  (expected: 3)
utils.get_value({1: "a"}, 4, default="z")    # TypeError  (expected: "z")
```

This is inconsistent with the string-key path and with the documented `default` behavior.

## The fix

Guard the `getattr` fallback so a non-string key returns `default` directly (a non-string can never name an attribute). Valid indexing and string-key attribute fallback are unchanged. Added a regression test covering lists, int-keyed dicts, and lists of objects.

The full suite passes locally. (One pre-existing, Windows-only `test_from_timestamp_with_overflow_value` failure reproduces on a clean checkout too and is unrelated to this change.)

Happy to add a `CHANGELOG.rst` entry in whatever version/format you prefer.

---

*Disclosure: this change was prepared with AI assistance; I reviewed it and verified the tests before submitting.*
