### PR TITLE
tests: fix tautological assertion in test_containsonly_custom_message

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -919,18 +919,14 @@ def test_containsonly_custom_message():
     containsonly = validate.ContainsOnly(
         [1, 2, 3], error="{input} is not one of {choices}"
     )
-    expected = "4, 5 is not one of 1, 2, 3"
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="4, 5 is not one of 1, 2, 3"):
         containsonly([4, 5])
-    assert expected in str(expected)
 
     containsonly = validate.ContainsOnly(
         [1, 2, 3], ["one", "two", "three"], error="{input} is not one of {labels}"
     )
-    expected = "4, 5 is not one of one, two, three"
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="4, 5 is not one of one, two, three"):
         containsonly([4, 5])
-    assert expected in str(expected)
 
 
 def test_containsonly_repr():


### PR DESCRIPTION
### Summary
- In `tests/test_validate.py::test_containsonly_custom_message`, replace tautological `assert expected in str(expected)` with `pytest.raises(ValidationError, match=...)` to actually verify the exception message against the expected string.