### PR TITLE
Reflect field load-only and dump-only flags on schema

### DIFF
--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -428,8 +428,16 @@ class Schema(metaclass=SchemaMeta):
         self.exclude: set[typing.Any] | typing.MutableSet[typing.Any] = set(
             self.opts.exclude
         ) | set(exclude)
-        self.load_only = set(load_only) or set(self.opts.load_only)
-        self.dump_only = set(dump_only) or set(self.opts.dump_only)
+        self.load_only = (set(load_only) or set(self.opts.load_only)) | {
+            name
+            for name, field_obj in self.declared_fields.items()
+            if field_obj.load_only
+        }
+        self.dump_only = (set(dump_only) or set(self.opts.dump_only)) | {
+            name
+            for name, field_obj in self.declared_fields.items()
+            if field_obj.dump_only
+        }
         self.partial = partial
         self.unknown: types.UnknownOption = (
             self.opts.unknown if unknown is None else unknown

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1297,6 +1297,17 @@ def test_attribute_collision(attribute):
             MySchema()
 
 
+def test_load_only_and_dump_only_include_declared_field_options():
+    class MySchema(Schema):
+        read_only = fields.String(dump_only=True)
+        write_only = fields.String(load_only=True)
+
+    schema = MySchema()
+
+    assert schema.dump_only == {"read_only"}
+    assert schema.load_only == {"write_only"}
+
+
 class TestDeeplyNestedLoadOnly:
     @pytest.fixture
     def schema(self):


### PR DESCRIPTION
Fixes #1857

## Summary
- include field-level load_only declarations in Schema.load_only
- include field-level dump_only declarations in Schema.dump_only
- add regression coverage for both symmetric options

## Testing
- uv run pytest
- uv run pytest tests/test_schema.py
- uv run pre-commit run --files src/marshmallow/schema.py tests/test_schema.py