### PR TITLE
Fix dot notation handling for Nested fields given schema instances

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -190,3 +190,4 @@ Contributors (chronological)
 - Dhruvil Darji  `@dhruvildarji  <https://github.com/dhruvildarji>`_
 - Haïm Dimer `@hdimer  <https://github.com/hdimer>`_
 - `@vidigoat <https://github.com/vidigoat>`_
+- Abhijeet Kumar Sah `@abhijeet117 <https://github.com/abhijeet117>`_

--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -581,15 +581,35 @@ class Nested(Field):
                 self._schema = copy.copy(nested)
                 # Respect only and exclude and many passed from parent and re-initialize fields
                 set_class = typing.cast("type[set]", self._schema.set_class)
-                if self.only is not None:
-                    if self._schema.only is not None:
-                        original = self._schema.only
-                    else:  # only=None -> all fields
-                        original = self._schema.fields.keys()
-                    self._schema.only = set_class(self.only) & set_class(original)
-                if self.exclude:
-                    original = self._schema.exclude
-                    self._schema.exclude = set_class(self.exclude) | set_class(original)
+                if self.only is not None or self.exclude:
+                    if any("." in name for name in self.only or ()) or any(
+                        "." in name for name in self.exclude
+                    ):
+                        # Detach the declared fields from the original schema,
+                        # so that resolving child options does not mutate it.
+                        self._schema.declared_fields = {
+                            name: copy.copy(field)
+                            for name, field in self._schema.declared_fields.items()
+                        }
+                    instance_only = self._schema.only
+                    instance_exclude = self._schema.exclude
+                    # Resolve dot-qualified options against the copied schema,
+                    # like Schema.__init__ does with its arguments.
+                    self._schema.only = (
+                        set_class(self.only) if self.only is not None else None
+                    )
+                    self._schema.exclude = set_class(self.exclude)
+                    self._schema._normalize_nested_options()
+                    if self.only is not None:
+                        if instance_only is not None:
+                            original = instance_only
+                        else:  # only=None -> all fields
+                            original = self._schema.fields.keys()
+                        self._schema.only = set_class(
+                            self._schema.only or ()
+                        ) & set_class(original)
+                    if self.exclude:
+                        self._schema.exclude |= set_class(instance_exclude)
                 if self.many is not None:
                     self._schema.many = self.many
                 self._schema._init_fields()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1090,6 +1090,78 @@ def test_nested_instance_exclude():
     assert schema.dump(full_album) == album
 
 
+# https://github.com/marshmallow-code/marshmallow/issues/2165
+def test_nested_instance_only_dot_notation():
+    class GrandChildSchema(Schema):
+        foo = fields.Raw()
+        bar = fields.Raw()
+
+    class ChildSchema(Schema):
+        blubb = fields.Nested(GrandChildSchema)
+
+    class ParentSchema(Schema):
+        bla = fields.Raw()
+        bli = fields.Raw()
+        blubb = fields.Nested(lambda: ChildSchema())
+
+    sch = ParentSchema(only=("bla", "blubb.blubb.foo"))
+    data = dict(bla=1, bli=2, blubb=dict(blubb=dict(foo=42, bar=24)))
+    result = sch.dump(data)
+    assert "bla" in result
+    assert "bli" not in result
+    child = result["blubb"]
+    assert "foo" in child["blubb"]
+    assert "bar" not in child["blubb"]
+
+
+# https://github.com/marshmallow-code/marshmallow/issues/2165
+def test_nested_instance_only_param():
+    class GrandChildSchema(Schema):
+        foo = fields.Raw()
+        bar = fields.Raw()
+
+    class ChildSchema(Schema):
+        blubb = fields.Nested(GrandChildSchema)
+
+    class ParentSchema(Schema):
+        bla = fields.Raw()
+        bli = fields.Raw()
+        blubb = fields.Nested(lambda: ChildSchema(), only=("blubb.foo",))
+
+    sch = ParentSchema()
+    data = dict(bla=1, bli=2, blubb=dict(blubb=dict(foo=42, bar=24)))
+    result = sch.dump(data)
+    assert "bla" in result
+    assert "bli" in result
+    child = result["blubb"]
+    assert "foo" in child["blubb"]
+    assert "bar" not in child["blubb"]
+
+
+# https://github.com/marshmallow-code/marshmallow/issues/2165
+def test_nested_instance_exclude_param():
+    class GrandChildSchema(Schema):
+        foo = fields.Raw()
+        bar = fields.Raw()
+
+    class ChildSchema(Schema):
+        blubb = fields.Nested(GrandChildSchema)
+
+    class ParentSchema(Schema):
+        bla = fields.Raw()
+        bli = fields.Raw()
+        blubb = fields.Nested(lambda: ChildSchema(), exclude=("blubb.bar",))
+
+    sch = ParentSchema()
+    data = dict(bla=1, bli=2, blubb=dict(blubb=dict(foo=42, bar=24)))
+    result = sch.dump(data)
+    assert "bla" in result
+    assert "bli" in result
+    child = result["blubb"]
+    assert "foo" in child["blubb"]
+    assert "bar" not in child["blubb"]
+
+
 def test_meta_nested_exclude():
     class ChildSchema(Schema):
         foo = fields.Raw()


### PR DESCRIPTION
## Summary

`fields.Nested` given a callable returning a `Schema` instance bypassed the dot-aware resolution that `Schema.__init__` applies to its arguments, so dot-qualified `only`/`exclude` entries (e.g. `b.a2`) were intersected against top-level field names and silently produced empty selections. The instance branch of `Nested.schema` now resolves options through `_normalize_nested_options` before merging them with the instance constraints, matching the class path.

## Testing

Reproduced with the issue snippet: `DSchema(only=("d.c.b.a2",)).dump(...)` returned `{'d': {'c': {}}}` instead of the selected subfield; it now dumps correctly. Added regression tests covering ancestor dot notation and dotted `only`/`exclude` passed to instance-backed `Nested`; all three fail without the fix and pass with it. Full pytest run, plus `ruff check`, `ruff format --check`, and `mypy`, pass locally.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
