### PR TITLE
Hardcode missing as get_value default

### DIFF
--- a/src/marshmallow/fields.py
+++ b/src/marshmallow/fields.py
@@ -259,10 +259,7 @@ class Field(typing.Generic[_InternalT]):
         self,
         obj: typing.Any,
         attr: str,
-        accessor: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-        ) = None,
-        default: typing.Any = missing_,
+        accessor: (typing.Callable[[typing.Any, str], typing.Any] | None) = None,
     ) -> _InternalT:
         """Return the value for a given key from an object.
 
@@ -273,7 +270,7 @@ class Field(typing.Generic[_InternalT]):
         """
         accessor_func = accessor or utils.get_value
         check_key = attr if self.attribute is None else self.attribute
-        return accessor_func(obj, check_key, default)
+        return accessor_func(obj, check_key)
 
     def _validate(self, value: typing.Any) -> None:
         """Perform validation on ``value``. Raise a :exc:`ValidationError` if validation
@@ -315,9 +312,7 @@ class Field(typing.Generic[_InternalT]):
         self,
         attr: str,
         obj: typing.Any,
-        accessor: (
-            typing.Callable[[typing.Any, str, typing.Any], typing.Any] | None
-        ) = None,
+        accessor: (typing.Callable[[typing.Any, str], typing.Any] | None) = None,
         **kwargs,
     ):
         """Pulls the value for the given key from the object, applies the

--- a/src/marshmallow/schema.py
+++ b/src/marshmallow/schema.py
@@ -497,13 +497,13 @@ class Schema(metaclass=SchemaMeta):
             Receives `many` and `partial` (on deserialization) as keyword arguments.
         """
 
-    def get_attribute(self, obj: typing.Any, attr: str, default: typing.Any):
+    def get_attribute(self, obj: typing.Any, attr: str):
         """Defines how to pull values from an object to serialize.
 
         .. versionchanged:: 3.0.0a1
             Changed position of ``obj`` and ``attr``.
         """
-        return get_value(obj, attr, default)
+        return get_value(obj, attr)
 
     ##### Serialization/Deserialization API #####
 

--- a/src/marshmallow/utils.py
+++ b/src/marshmallow/utils.py
@@ -94,7 +94,7 @@ def pluck(dictlist: list[dict[str, typing.Any]], key: str):
 # Various utilities for pulling keyed values from objects
 
 
-def get_value(obj, key: str, default=missing):
+def get_value(obj, key: str):
     """Helper for pulling a keyed value off various types of objects. Fields use
     this method by default to access attributes of the source object. For object `x`
     and attribute `i`, this method first tries to access `x[i]`, and then falls back to
@@ -107,20 +107,20 @@ def get_value(obj, key: str, default=missing):
     """
     if "." in key:
         for k in key.split("."):
-            obj = _get_value_for_key(obj, k, default)
+            obj = _get_value_for_key(obj, k)
     else:
-        obj = _get_value_for_key(obj, key, default)
+        obj = _get_value_for_key(obj, key)
     return obj
 
 
-def _get_value_for_key(obj, key, default):
+def _get_value_for_key(obj, key):
     if not hasattr(obj, "__getitem__"):
-        return getattr(obj, key, default)
+        return getattr(obj, key, missing)
 
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, key, default)
+        return getattr(obj, key, missing)
 
 
 def set_value(dct: dict[str, typing.Any], key: str, value: typing.Any):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2274,8 +2274,8 @@ class TestFieldInheritance:
         assert SerializerD._declared_fields == expected
 
 
-def get_from_dict(schema, obj, key, default=None):
-    return obj.get("_" + key, default)
+def get_from_dict(schema, obj, key):
+    return obj.get("_" + key)
 
 
 class TestGetAttribute:
@@ -2284,8 +2284,8 @@ class TestGetAttribute:
             name = fields.Str()
             email = fields.Email()
 
-            def get_attribute(self, obj, attr, default):
-                return get_from_dict(self, obj, attr, default)
+            def get_attribute(self, obj, attr):
+                return get_from_dict(self, obj, attr)
 
         user_dict = {"_name": "joe", "_email": "joe@shmoe.com"}
         schema = UserDictSchema()
@@ -2302,8 +2302,8 @@ class TestGetAttribute:
             name = fields.Str()
             email = fields.Email()
 
-            def get_attribute(self, obj, attr, default):
-                return get_from_dict(self, obj, attr, default)
+            def get_attribute(self, obj, attr):
+                return get_from_dict(self, obj, attr)
 
         user_dicts = [
             {"_name": "joe", "_email": "joe@shmoe.com"},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,12 +39,12 @@ def test_get_value_from_object(obj):
     assert utils.get_value(obj, "y") == 42
 
 
-def test_get_value_from_namedtuple_with_default():
+def test_get_value_from_namedtuple():
     p = PointNT(x=42, y=None)
-    # Default is only returned if key is not found
-    assert utils.get_value(p, "z", default=123) == 123
-    # since 'y' is an attribute, None is returned instead of the default
-    assert utils.get_value(p, "y", default=123) is None
+    # missing is only returned if key is not found
+    assert utils.get_value(p, "z") == utils.missing
+    # since 'y' is an attribute, None is returned instead of missing
+    assert utils.get_value(p, "y") is None
 
 
 class Triangle:


### PR DESCRIPTION
The `default` parameter is never used, so there is no need propagating `missing` all along the call chain.

One test affected but I don't think the point of the test was to test a custom default value so I changed it to `missing`.