### PR TITLE
Accept the Windows-specific error message in the overflow timestamp test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,7 +114,15 @@ def test_from_timestamp_with_negative_value():
 
 def test_from_timestamp_with_overflow_value():
     value = 9223372036854775
-    with pytest.raises(ValueError, match=r"out of range|year must be in 1\.\.9999"):
+    # datetime.fromtimestamp() reports this overflow differently depending on
+    # the platform: CPython on Linux/macOS raises a bare ValueError with a
+    # message about the resulting year, while Windows raises an OSError,
+    # which from_timestamp() itself catches and re-raises with its own
+    # message.
+    with pytest.raises(
+        ValueError,
+        match=r"out of range|year must be in 1\.\.9999|Error converting value to datetime",
+    ):
         utils.from_timestamp(value)
 
 


### PR DESCRIPTION
Fixes #2999

test_from_timestamp_with_overflow_value only checked for the error message datetime.fromtimestamp() produces on Linux and macOS for this particular overflow value, a plain ValueError about the year being out of range. On Windows, the same call raises OSError instead, which from_timestamp() already catches and re-raises as ValueError("Error converting value to datetime"), a perfectly valid outcome that the test's regex just never accounted for. That's exactly the failure shown in the linked issue's Windows CI log.

Broadened the match to also accept that message. Confirmed the existing behavior on my own machine still passes as before (this platform hits the ValueError branch, not OSError), and separately simulated the OSError branch by monkeypatching datetime.fromtimestamp to confirm the new alternative in the regex matches the literal message from_timestamp() produces there, since I don't have a Windows machine to reproduce the CI failure directly.

Full test suite (1190 tests) passes, ruff check and ruff format both clean at the pinned v0.16.1.